### PR TITLE
Int32x4 rotary shifts, Float FMAs

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -355,6 +355,13 @@ SIMD.float32x4.div = function(a, b) {
 }
 
 /**
+ * @return {float32x4} New instance of float32x4 with a * b + c
+ */
+SIMD.float32x4.mad = function(a, b, c) {
+  return SIMD.float32x4(a.x * b.x + c.x, a.y * b.y + c.y, a.z * b.z + c.z, a.w * b.w + c.w);
+}
+
+/**
   * @return {float32x4} New instance of float32x4 with t's values clamped
   * between lowerLimit and upperLimit.
   */
@@ -654,8 +661,6 @@ SIMD.float32x4.not = function(a) {
 * t.
 */
 SIMD.float64x2.abs = function(t) {
-  return SIMD.float64x2(Math.abs(t.x), Math.abs(t.y));
-}
 
 /**
   * @return {float64x2} New instance of float64x2 with negated values of
@@ -691,6 +696,13 @@ SIMD.float64x2.mul = function(a, b) {
   */
 SIMD.float64x2.div = function(a, b) {
   return SIMD.float64x2(a.x / b.x, a.y / b.y);
+}
+
+/**
+ * @return {float32x4} New instance of float32x4 with a * b + c
+ */
+SIMD.float64x2.mad = function(a, b, c) {
+  return SIMD.float64x2(a.x * b.x + c.x, a.y * b.y + c.y);
 }
 
 /**
@@ -1474,6 +1486,8 @@ Object.defineProperty(SIMD, 'XX',  { get: function() { return 0x0; } });
 Object.defineProperty(SIMD, 'XY',  { get: function() { return 0x2; } });
 Object.defineProperty(SIMD, 'YX',  { get: function() { return 0x1; } });
 Object.defineProperty(SIMD, 'YY',  { get: function() { return 0x3; } });
+
+Object.defineProperty(SIMD, 'HAS_FMA', { get: function() { return false; } });
 
 Object.defineProperty(SIMD.float32x4.prototype, 'x', {
   get: function() { return this.x_; }

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1150,6 +1150,32 @@ SIMD.int32x4.lessThan = function(t, other) {
 
 /**
   * @param {int32x4} a An instance of int32x4.
+  * @param {int} bits Bit count to rotate by.
+  * @return {int32x4} lanes in a rotated left by bits.
+  */
+SIMD.int32x4.rotateLeft = function(a, bits) {
+  var x = a.x << bits ^ a.x >> (32 - bits);
+  var y = a.y << bits ^ a.y >> (32 - bits);
+  var z = a.z << bits ^ a.z >> (32 - bits);
+  var w = a.w << bits ^ a.w >> (32 - bits);
+  return SIMD.int32x4(x, y, z, w);
+}
+
+/**
+  * @param {int32x4} a An instance of int32x4.
+  * @param {int} bits Bit count to rotate by.
+  * @return {int32x4} lanes in a rotated right by bits.
+  */
+SIMD.int32x4.rotateRight = function(a, bits) {
+  var x = a.x >> bits ^ a.x << (32 - bits);
+  var y = a.y >> bits ^ a.y << (32 - bits);
+  var z = a.z >> bits ^ a.z << (32 - bits);
+  var w = a.w >> bits ^ a.w << (32 - bits);
+  return SIMD.int32x4(x, y, z, w);
+}
+
+/**
+  * @param {int32x4} a An instance of int32x4.
   * @param {int} bits Bit count to shift by.
   * @return {int32x4} lanes in a shifted by bits.
   */


### PR DESCRIPTION
Int32x4 rotary shifts: Ubiquitous in crypto. Big performance gain on ISAs with vector rotary shift (e.g., XOP instruction). Easy to desugar to shift, shift, xor on platforms without.

Float32x4,64x4 FMAs: IEEE-754 FMAs are evaluated with infinite precision and then rounded. This provides  for some applications, high numerical accuracy improvements; can make the difference between float32x4 and float64x2. But need to know whether platform supports IEEE-754 FMAs (all ARM with VFP, very recent x64).

If these proposals are interesting, will contribute some sample code.