### PR TITLE
Remove clamp

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1097,30 +1097,6 @@ if (typeof SIMD.float32x4.div === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.clamp === "undefined") {
-  /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} lowerLimit An instance of float32x4.
-    * @param {float32x4} upperLimit An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with t's values clamped
-    * between lowerLimit and upperLimit.
-    */
-  SIMD.float32x4.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float32x4(t);
-    lowerLimit = SIMD.float32x4(lowerLimit);
-    upperLimit = SIMD.float32x4(upperLimit);
-    var cx = t.x < lowerLimit.x ? lowerLimit.x : t.x;
-    var cy = t.y < lowerLimit.y ? lowerLimit.y : t.y;
-    var cz = t.z < lowerLimit.z ? lowerLimit.z : t.z;
-    var cw = t.w < lowerLimit.w ? lowerLimit.w : t.w;
-    cx = cx > upperLimit.x ? upperLimit.x : cx;
-    cy = cy > upperLimit.y ? upperLimit.y : cy;
-    cz = cz > upperLimit.z ? upperLimit.z : cz;
-    cw = cw > upperLimit.w ? upperLimit.w : cw;
-    return SIMD.float32x4(cx, cy, cz, cw);
-  }
-}
-
 if (typeof SIMD.float32x4.min === "undefined") {
   /**
     * @param {float32x4} t An instance of float32x4.
@@ -1840,26 +1816,6 @@ if (typeof SIMD.float64x2.div === "undefined") {
     a = SIMD.float64x2(a);
     b = SIMD.float64x2(b);
     return SIMD.float64x2(a.x / b.x, a.y / b.y);
-  }
-}
-
-if (typeof SIMD.float64x2.clamp === "undefined") {
-  /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} lowerLimit An instance of float64x2.
-    * @param {float64x2} upperLimit An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with t's values clamped
-    * between lowerLimit and upperLimit.
-    */
-  SIMD.float64x2.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float64x2(t);
-    lowerLimit = SIMD.float64x2(lowerLimit);
-    upperLimit = SIMD.float64x2(upperLimit);
-    var cx = t.x < lowerLimit.x ? lowerLimit.x : t.x;
-    var cy = t.y < lowerLimit.y ? lowerLimit.y : t.y;
-    cx = cx > upperLimit.x ? upperLimit.x : cx;
-    cy = cy > upperLimit.y ? upperLimit.y : cy;
-    return SIMD.float64x2(cx, cy);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -287,17 +287,6 @@ test('float32x4 div', function() {
   equal(i.w, Infinity);
 });
 
-test('float32x4 clamp', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.clamp(a, lower, upper);
-  equal(2.0, c.x);
-  equal(5.0, c.y);
-  equal(50.0, c.z);
-  equal(0.5, c.w);
-});
-
 test('float32x4 min', function() {
   var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
   var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
@@ -1369,29 +1358,6 @@ test('float64x2 div', function() {
   equal(i0.y, -Infinity);
   equal(i1.x, -Infinity);
   equal(i1.y, Infinity);
-});
-
-test('float64x2 clamp', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var b = SIMD.float64x2(2.125, 3.0);
-  var lower = SIMD.float64x2(2.0, 1.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.clamp(a, lower, upper);
-  equal(2.0, c.x);
-  equal(5.0, c.y);
-  c = SIMD.float64x2.clamp(b, lower, upper);
-  equal(2.125, c.x);
-  equal(3.0, c.y);
-  a = SIMD.float64x2(-3.4e200, 3.4e250);
-  b = SIMD.float64x2(3.4e100, 3.4e200);
-  lower = SIMD.float64x2(3.4e50, 3.4e100);
-  upper = SIMD.float64x2(3.4e150, 3.4e300);
-  c = SIMD.float64x2.clamp(a, lower, upper);
-  equal(3.4e50, c.x);
-  equal(3.4e250, c.y);
-  c = SIMD.float64x2.clamp(b, lower, upper);
-  equal(3.4e100, c.x);
-  equal(3.4e200, c.y);
 });
 
 test('float64x2 min', function() {


### PR DESCRIPTION
I think there was consensus to remove clamp from float32x4 / float64x2, as it can be emulated with a min and a max.

```
// For float32x4
function clamp(v, low, high) {
 return SIMD.float32x4.max(SIMD.float32x4.min(v, high), low);
}
```

If that's still the case, could we just remove it from the spec / polyfill?