### PR TITLE
{int16x8,int8x16}.select -> bitselect + add select

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -3044,13 +3044,38 @@ if (typeof SIMD.int16x8.select === "undefined") {
   /**
     * @param {int16x8} t Selector mask. An instance of int16x8
     * @param {int16x8} trueValue Pick lane from here if corresponding
-    * selector lane is 0xFFFF
+    * selector lane is true
     * @param {int16x8} falseValue Pick lane from here if corresponding
-    * selector lane is 0x0
+    * selector lane is false
     * @return {int16x8} Mix of lanes from trueValue or falseValue as
     * indicated
     */
   SIMD.int16x8.select = function(t, trueValue, falseValue) {
+    t = SIMD.int16x8.check(t);
+    trueValue = SIMD.int16x8.check(trueValue);
+    falseValue = SIMD.int16x8.check(falseValue);
+    return SIMD.int16x8(_SIMD_PRIVATE.tobool(t.s0) ? trueValue.s0 : falseValue.s0,
+                        _SIMD_PRIVATE.tobool(t.s1) ? trueValue.s1 : falseValue.s1,
+                        _SIMD_PRIVATE.tobool(t.s2) ? trueValue.s2 : falseValue.s2,
+                        _SIMD_PRIVATE.tobool(t.s3) ? trueValue.s3 : falseValue.s3,
+                        _SIMD_PRIVATE.tobool(t.s4) ? trueValue.s4 : falseValue.s4,
+                        _SIMD_PRIVATE.tobool(t.s5) ? trueValue.s5 : falseValue.s5,
+                        _SIMD_PRIVATE.tobool(t.s6) ? trueValue.s6 : falseValue.s6,
+                        _SIMD_PRIVATE.tobool(t.s7) ? trueValue.s7 : falseValue.s7);
+  }
+}
+
+if (typeof SIMD.int16x8.bitselect === "undefined") {
+  /**
+    * @param {int16x8} t Selector mask. An instance of int16x8
+    * @param {int16x8} trueValue Pick lane from here if corresponding
+    * selector bit is 1
+    * @param {int16x8} falseValue Pick lane from here if corresponding
+    * selector bit is 0
+    * @return {int16x8} Mix of lanes from trueValue or falseValue as
+    * indicated
+    */
+  SIMD.int16x8.bitselect = function(t, trueValue, falseValue) {
     t = SIMD.int16x8.check(t);
     trueValue = SIMD.int16x8.check(trueValue);
     falseValue = SIMD.int16x8.check(falseValue);
@@ -3379,13 +3404,46 @@ if (typeof SIMD.int8x16.select === "undefined") {
   /**
     * @param {int8x16} t Selector mask. An instance of int8x16
     * @param {int8x16} trueValue Pick lane from here if corresponding
-    * selector lane is 0xFF
+    * selector lane is true
     * @param {int8x16} falseValue Pick lane from here if corresponding
-    * selector lane is 0x0
+    * selector lane is false
     * @return {int8x16} Mix of lanes from trueValue or falseValue as
     * indicated
     */
   SIMD.int8x16.select = function(t, trueValue, falseValue) {
+    t = SIMD.int8x16.check(t);
+    trueValue = SIMD.int8x16.check(trueValue);
+    falseValue = SIMD.int8x16.check(falseValue);
+    return SIMD.int8x16(_SIMD_PRIVATE.tobool(t.s0) ? trueValue.s0 : falseValue.s0,
+                        _SIMD_PRIVATE.tobool(t.s1) ? trueValue.s1 : falseValue.s1,
+                        _SIMD_PRIVATE.tobool(t.s2) ? trueValue.s2 : falseValue.s2,
+                        _SIMD_PRIVATE.tobool(t.s3) ? trueValue.s3 : falseValue.s3,
+                        _SIMD_PRIVATE.tobool(t.s4) ? trueValue.s4 : falseValue.s4,
+                        _SIMD_PRIVATE.tobool(t.s5) ? trueValue.s5 : falseValue.s5,
+                        _SIMD_PRIVATE.tobool(t.s6) ? trueValue.s6 : falseValue.s6,
+                        _SIMD_PRIVATE.tobool(t.s7) ? trueValue.s7 : falseValue.s7,
+                        _SIMD_PRIVATE.tobool(t.s8) ? trueValue.s8 : falseValue.s8,
+                        _SIMD_PRIVATE.tobool(t.s9) ? trueValue.s9 : falseValue.s9,
+                        _SIMD_PRIVATE.tobool(t.s10) ? trueValue.s10 : falseValue.s10,
+                        _SIMD_PRIVATE.tobool(t.s11) ? trueValue.s11 : falseValue.s11,
+                        _SIMD_PRIVATE.tobool(t.s12) ? trueValue.s12 : falseValue.s12,
+                        _SIMD_PRIVATE.tobool(t.s13) ? trueValue.s13 : falseValue.s13,
+                        _SIMD_PRIVATE.tobool(t.s14) ? trueValue.s14 : falseValue.s14,
+                        _SIMD_PRIVATE.tobool(t.s15) ? trueValue.s15 : falseValue.s15);
+  }
+}
+
+if (typeof SIMD.int8x16.bitselect === "undefined") {
+  /**
+    * @param {int8x16} t Selector mask. An instance of int8x16
+    * @param {int8x16} trueValue Pick lane from here if corresponding
+    * selector bit is 1
+    * @param {int8x16} falseValue Pick lane from here if corresponding
+    * selector bit is 0
+    * @return {int8x16} Mix of lanes from trueValue or falseValue as
+    * indicated
+    */
+  SIMD.int8x16.bitselect = function(t, trueValue, falseValue) {
     t = SIMD.int8x16.check(t);
     trueValue = SIMD.int8x16.check(trueValue);
     falseValue = SIMD.int8x16.check(falseValue);

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -3212,6 +3212,21 @@ test('int16x8 select', function() {
   equal(16, s.s7);
 });
 
+test('int16x8 bitselect', function() {
+  var m = SIMD.int16x8(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x55555555);
+  var t = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var f = SIMD.int16x8(9, 10, 11, 12, 13, 14, 15, 16);
+  var s = SIMD.int16x8.bitselect(m, t, f);
+  equal(1, s.s0);
+  equal(2, s.s1);
+  equal(3, s.s2);
+  equal(4, s.s3);
+  equal(5, s.s4);
+  equal(6, s.s5);
+  equal(15, s.s6);
+  equal(0, s.s7);
+});
+
 test('int8x16 and', function() {
   var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 170, 170, 170, 170, 0xAA, 0xAA, 0xAA, 0xAA);
   var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
@@ -3745,6 +3760,30 @@ test('int8x16 select', function() {
   equal(30, s.s13);
   equal(31, s.s14);
   equal(32, s.s15);
+});
+
+test('int8x16 bitselect', function() {
+  var m = SIMD.int8x16(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x11111111,
+                       0x22222222, 0x33333333, 0x44444444, 0x55555555, 0x66666666, 0x77777777, 0x88888888, 0x99999999);
+  var t = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var f = SIMD.int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+  var s = SIMD.int8x16.bitselect(m, t, f);
+  equal(17, s.s0);
+  equal(2, s.s1);
+  equal(19, s.s2);
+  equal(4, s.s3);
+  equal(21, s.s4);
+  equal(6, s.s5);
+  equal(23, s.s6);
+  equal(8, s.s7);
+  equal(25, s.s8);
+  equal(10, s.s9);
+  equal(27, s.s10);
+  equal(12, s.s11);
+  equal(29, s.s12);
+  equal(14, s.s13);
+  equal(31, s.s14);
+  equal(48, s.s15);
 });
 
 test('int8x16 fromFloat32x4Bits constructor', function() {


### PR DESCRIPTION
It looked like the int16x8.select and int8x16.select methods implemented a
bitselect. This commit renames those select methods to bitselect and
implements an actual select.