### PR TITLE
Implement float-to-integer conversion error handling

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -91,6 +91,12 @@ _SIMD_PRIVATE.frombool = function(x) {
   return !x - 1;
 }
 
+_SIMD_PRIVATE.int32FromFloat = function(x) {
+  if (x >= -0x80000000 && x <= 0x7fffffff)
+      return x|0;
+  throw new RangeError("Conversion from floating-point to integer failed");
+}
+
 // Save/Restore utilities for implementing bitwise conversions.
 
 _SIMD_PRIVATE.saveFloat64x2 = function(x) {
@@ -564,7 +570,10 @@ if (typeof SIMD.int32x4.fromFloat32x4 === "undefined") {
     */
   SIMD.int32x4.fromFloat32x4 = function(t) {
     t = SIMD.float32x4.check(t);
-    return SIMD.int32x4(t.x, t.y, t.z, t.w);
+    return SIMD.int32x4(_SIMD_PRIVATE.int32FromFloat(t.x),
+                        _SIMD_PRIVATE.int32FromFloat(t.y),
+                        _SIMD_PRIVATE.int32FromFloat(t.z),
+                        _SIMD_PRIVATE.int32FromFloat(t.w));
   }
 }
 
@@ -575,7 +584,10 @@ if (typeof SIMD.int32x4.fromFloat64x2 === "undefined") {
     */
   SIMD.int32x4.fromFloat64x2 = function(t) {
     t = SIMD.float64x2.check(t);
-    return SIMD.int32x4(t.x, t.y, 0, 0);
+    return SIMD.int32x4(_SIMD_PRIVATE.int32FromFloat(t.x),
+                        _SIMD_PRIVATE.int32FromFloat(t.y),
+                        0,
+                        0);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -1931,6 +1931,28 @@ test('int32x4 fromFloat32x4 constructor', function() {
   equal(0, n.y);
   equal(-1, n.z);
   equal(-3, n.w);
+
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0x7fffffff, 0, 0, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, -0x80000081, 0, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, 2147483648, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, 0, -2147483904));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(Infinity, 0, 0, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, -Infinity, 0, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, NaN, 0));
+  });
 });
 
 test('int32x4 fromFloat64x2 constructor', function() {
@@ -1961,6 +1983,22 @@ test('int32x4 fromFloat64x2 constructor', function() {
   equal(-3, n.y);
   equal(0, n.z);
   equal(0, n.w);
+
+  throws(function() {
+    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0x80000000, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0, -0x80000001));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(Infinity, 0));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0, -Infinity));
+  });
+  throws(function() {
+    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(NaN, 0));
+  });
 });
 
 test('int32x4 fromFloat32x4Bits constructor', function() {


### PR DESCRIPTION
Issue #99 is about what to do when float-to-integer conversion fails.

Making float32-to-int32 conversion return 0x7fffffff on error was appealing since 0x7fffffff is never a value produced by a successful conversion, however this isn't true of float64-to-int32 conversion, where there is no such value. Instead, this patch proposes throwing an exception on conversion error.