### PR TITLE
Make float64x2 select work with float64x2 comparison values.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -2173,8 +2173,10 @@ if (typeof SIMD.float64x2.select === "undefined") {
     t = SIMD.int32x4.check(t);
     trueValue = SIMD.float64x2.check(trueValue);
     falseValue = SIMD.float64x2.check(falseValue);
+    // We use t.z for the second element because t is an int32x4, because
+    // int64x2 isn't available.
     return SIMD.float64x2(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
-                          _SIMD_PRIVATE.tobool(t.y) ? trueValue.y : falseValue.y);
+                          _SIMD_PRIVATE.tobool(t.z) ? trueValue.y : falseValue.y);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -1702,7 +1702,7 @@ test('float64x2 comparisons', function() {
 });
 
 test('float64x2 select', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0x55555555);
+  var m = SIMD.int32x4(0xaaaaaaaa, 0, 0x55555555, 0);
   var t = SIMD.float64x2(1.0, 2.0);
   var f = SIMD.float64x2(3.0, 4.0);
   var s = SIMD.float64x2.select(m, t, f);


### PR DESCRIPTION
float64x2 comparisons and float64x2 select use int32x4 to hold boolean
values, but they differed on how to map the int32x4 lanes to the
float64x2 lanes. This patch makes select use lanes x and z in the
int32x4 value, to match the comparisons.