### PR TITLE
Fix the "simd128 types check" test to avoid using == on SIMD values

### DIFF
--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -32,28 +32,32 @@ test('float32x4 constructor', function() {
 });
 
 test('simd128 types check', function() {
+  function equalX4(a, b) {
+      return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+  }
+
   var x = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  equal(SIMD.float32x4.check(x), x);
+  equalX4(SIMD.float32x4.check(x), x);
   throws(function() {SIMD.float32x4.check(1)});
   throws(function() {SIMD.float32x4.check('hi')});
 
   var y = SIMD.int32x4(1, 2, 3, 4);
-  equal(SIMD.int32x4.check(y), y);
+  equalX4(SIMD.int32x4.check(y), y);
   throws(function() {SIMD.int32x4.check(1)});
   throws(function() {SIMD.int32x4.check('hi')});
 
   var z = SIMD.float64x2(1.0, 2.0);
-  equal(SIMD.float64x2.check(z), z);
+  equalX4(SIMD.float64x2.check(z), z);
   throws(function() {SIMD.float64x2.check(1)});
   throws(function() {SIMD.float64x2.check('hi')});
 
   var u = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  equal(SIMD.int16x8.check(u), u);
+  equalX4(SIMD.int16x8.check(u), u);
   throws(function() {SIMD.int16x8.check(1)});
   throws(function() {SIMD.int16x8.check('hi')});
 
   var v = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  equal(SIMD.int8x16.check(v), v);
+  equalX4(SIMD.int8x16.check(v), v);
   throws(function() {SIMD.int8x16.check(1)});
   throws(function() {SIMD.int8x16.check('hi')});
 });


### PR DESCRIPTION
This makes the test independent of whether SIMD values are objects or
how the == operator works on them.