### PR TITLE
Make test output a little more meaningful

### DIFF
--- a/src/shell_test_runner.js
+++ b/src/shell_test_runner.js
@@ -2,15 +2,19 @@
 
 load("ecmascript_simd.js");
 
-var currentName = '';
-var anyFailures = false;
+// clearer marking
+var currentName = '<global>';
+var numFails = 0;
 
-function fail(str)
-{
+function printIndented(str) {
+  console.log(str.split('\n').map(function (s) { return '  ' + s }).join('\n'));
+}
+
+function fail(str) {
   var e = Error(str);
   console.log(e.toString());
-  console.log(e.stack);
-  anyFailures = true;
+  printIndented(e.stack);
+  numFails++;
 }
 
 function test(name, func) {
@@ -23,15 +27,13 @@ function test(name, func) {
 }
 
 function equal(a, b) {
-  if (a == b)
-    return;
-  fail('equal(' + a + ', ' + b + ') failed in ' + currentName);
+  if (a != b)
+    fail('equal(' + a + ', ' + b + ') failed in ' + currentName);
 }
 
 function notEqual(a, b) {
-  if (a != b)
-    return;
-  fail('notEqual(' + a + ', ' + b + ') failed in ' + currentName);
+  if (a == b)
+    fail('notEqual(' + a + ', ' + b + ') failed in ' + currentName);
 }
 
 function throws(func) {
@@ -52,5 +54,7 @@ function ok(x) {
 
 load("ecmascript_simd_tests.js");
 
-if (anyFailures)
-    quit(1);
+if (numFails > 0) {
+  print('total number of fails and exceptions: ' + numFails);
+  quit(1);
+}

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,6 @@
+// To specifically test the p(r)olyfill.
+
+if (typeof SIMD != 'undefined')
+  SIMD = void 0;
+
+load('./shell_test_runner.js');


### PR DESCRIPTION
Pretty simple. This indents the error outputs, and prints the total number of failing tests at the end.