### PR TITLE
Utils

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1296,46 +1296,6 @@ if (typeof SIMD.float32x4.div === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.clamp === "undefined") {
-  /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} lowerLimit An instance of float32x4.
-    * @param {float32x4} upperLimit An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with t's values clamped
-    * between lowerLimit and upperLimit.
-    */
-  SIMD.float32x4.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float32x4.check(t);
-    lowerLimit = SIMD.float32x4.check(lowerLimit);
-    upperLimit = SIMD.float32x4.check(upperLimit);
-    var cx = SIMD.float32x4.extractLane(t, 0) <
-        SIMD.float32x4.extractLane(lowerLimit, 0) ?
-            SIMD.float32x4.extractLane(lowerLimit, 0) :
-                SIMD.float32x4.extractLane(t, 0);
-    var cy = SIMD.float32x4.extractLane(t, 1) <
-        SIMD.float32x4.extractLane(lowerLimit, 1) ?
-            SIMD.float32x4.extractLane(lowerLimit, 1) :
-                SIMD.float32x4.extractLane(t, 1);
-    var cz = SIMD.float32x4.extractLane(t, 2) <
-        SIMD.float32x4.extractLane(lowerLimit, 2) ?
-            SIMD.float32x4.extractLane(lowerLimit, 2) :
-                SIMD.float32x4.extractLane(t, 2);
-    var cw = SIMD.float32x4.extractLane(t, 3) <
-        SIMD.float32x4.extractLane(lowerLimit, 3) ?
-            SIMD.float32x4.extractLane(lowerLimit, 3) :
-                SIMD.float32x4.extractLane(t, 3);
-    cx = cx > SIMD.float32x4.extractLane(upperLimit, 0) ?
-        SIMD.float32x4.extractLane(upperLimit, 0) : cx;
-    cy = cy > SIMD.float32x4.extractLane(upperLimit, 1) ?
-        SIMD.float32x4.extractLane(upperLimit, 1) : cy;
-    cz = cz > SIMD.float32x4.extractLane(upperLimit, 2) ?
-        SIMD.float32x4.extractLane(upperLimit, 2) : cz;
-    cw = cw > SIMD.float32x4.extractLane(upperLimit, 3) ?
-        SIMD.float32x4.extractLane(upperLimit, 3) : cw;
-    return SIMD.float32x4(cx, cy, cz, cw);
-  }
-}
-
 if (typeof SIMD.float32x4.min === "undefined") {
   /**
     * @param {float32x4} t An instance of float32x4.
@@ -2076,34 +2036,6 @@ if (typeof SIMD.float64x2.div === "undefined") {
     return SIMD.float64x2(
         SIMD.float64x2.extractLane(a, 0) / SIMD.float64x2.extractLane(b, 0),
         SIMD.float64x2.extractLane(a, 1) / SIMD.float64x2.extractLane(b, 1));
-  }
-}
-
-if (typeof SIMD.float64x2.clamp === "undefined") {
-  /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} lowerLimit An instance of float64x2.
-    * @param {float64x2} upperLimit An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with t's values clamped
-    * between lowerLimit and upperLimit.
-    */
-  SIMD.float64x2.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float64x2.check(t);
-    lowerLimit = SIMD.float64x2.check(lowerLimit);
-    upperLimit = SIMD.float64x2.check(upperLimit);
-    var cx = SIMD.float64x2.extractLane(t, 0) <
-        SIMD.float64x2.extractLane(lowerLimit, 0) ?
-            SIMD.float64x2.extractLane(lowerLimit, 0) :
-                SIMD.float64x2.extractLane(t, 0);
-    var cy = SIMD.float64x2.extractLane(t, 1) <
-        SIMD.float64x2.extractLane(lowerLimit, 1) ?
-            SIMD.float64x2.extractLane(lowerLimit, 1) :
-                SIMD.float64x2.extractLane(t, 1);
-    cx = cx > SIMD.float64x2.extractLane(upperLimit, 0) ?
-        SIMD.float64x2.extractLane(upperLimit, 0) : cx;
-    cy = cy > SIMD.float64x2.extractLane(upperLimit, 1) ?
-        SIMD.float64x2.extractLane(upperLimit, 1) : cy;
-    return SIMD.float64x2(cx, cy);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -316,17 +316,6 @@ test('float32x4 div', function() {
   equal(SIMD.float32x4.extractLane(i, 3), Infinity);
 });
 
-test('float32x4 clamp', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.clamp(a, lower, upper);
-  equal(2.0, SIMD.float32x4.extractLane(c, 0));
-  equal(5.0, SIMD.float32x4.extractLane(c, 1));
-  equal(50.0, SIMD.float32x4.extractLane(c, 2));
-  equal(0.5, SIMD.float32x4.extractLane(c, 3));
-});
-
 test('float32x4 min', function() {
   var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
   var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
@@ -1419,29 +1408,6 @@ test('float64x2 div', function() {
   equal(SIMD.float64x2.extractLane(i0, 1), -Infinity);
   equal(SIMD.float64x2.extractLane(i1, 0), -Infinity);
   equal(SIMD.float64x2.extractLane(i1, 1), Infinity);
-});
-
-test('float64x2 clamp', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var b = SIMD.float64x2(2.125, 3.0);
-  var lower = SIMD.float64x2(2.0, 1.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.clamp(a, lower, upper);
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(5.0, SIMD.float64x2.extractLane(c, 1));
-  c = SIMD.float64x2.clamp(b, lower, upper);
-  equal(2.125, SIMD.float64x2.extractLane(c, 0));
-  equal(3.0, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(-3.4e200, 3.4e250);
-  b = SIMD.float64x2(3.4e100, 3.4e200);
-  lower = SIMD.float64x2(3.4e50, 3.4e100);
-  upper = SIMD.float64x2(3.4e150, 3.4e300);
-  c = SIMD.float64x2.clamp(a, lower, upper);
-  equal(3.4e50, SIMD.float64x2.extractLane(c, 0));
-  equal(3.4e250, SIMD.float64x2.extractLane(c, 1));
-  c = SIMD.float64x2.clamp(b, lower, upper);
-  equal(3.4e100, SIMD.float64x2.extractLane(c, 0));
-  equal(3.4e200, SIMD.float64x2.extractLane(c, 1));
 });
 
 test('float64x2 min', function() {

--- a/src/index.html
+++ b/src/index.html
@@ -11,5 +11,7 @@
   <script src="external/qunit.js"></script>
   <script src="ecmascript_simd.js"></script>
   <script src="ecmascript_simd_tests.js"></script>
+  <script src="utils.js"></script>
+  <script src="utils_tests.js"></script>
 </body>
 </html>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,64 @@
+/*
+  vim: set ts=8 sts=2 et sw=2 tw=79:
+  Copyright (C) 2013
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+(function (global) {
+
+global.SIMDUtils = {};
+
+if (typeof module !== "undefined") {
+    module.exports = global.SIMDUtils;
+}
+
+var utils = global.SIMDUtils;
+
+utils.int32x4 = {};
+
+utils.int32x4.zero = SIMD.int32x4(0, 0, 0, 0);
+
+utils.float32x4 = {};
+
+utils.float32x4.zero = SIMD.float32x4(0, 0, 0, 0);
+
+utils.float32x4.clamp = function(v, min, max) {
+    v = SIMD.float32x4.check(v);
+    min = SIMD.float32x4.check(min);
+    max = SIMD.float32x4.check(max);
+    var t1 = SIMD.float32x4.lessThanOrEqual(v, min);
+    var t2 = SIMD.float32x4.select(t1, min, v);
+    var t3 = SIMD.float32x4.greaterThanOrEqual(t2, max);
+    return SIMD.float32x4.select(t3, max, t2);
+}
+
+utils.float64x2 = {};
+
+utils.float64x2.zero = SIMD.float64x2(0, 0);
+
+utils.float64x2.clamp = function(v, min, max) {
+    v = SIMD.float64x2.check(v);
+    min = SIMD.float64x2.check(min);
+    max = SIMD.float64x2.check(max);
+    var t1 = SIMD.float64x2.lessThanOrEqual(v, min);
+    var t2 = SIMD.float64x2.select(t1, min, v);
+    var t3 = SIMD.float64x2.greaterThanOrEqual(t2, max);
+    return SIMD.float64x2.select(t3, max, t2);
+}
+
+})(typeof window !== "undefined" ? window : this);

--- a/src/utils_tests.js
+++ b/src/utils_tests.js
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2015
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+test('utils.float32x4.clamp', function() {
+    var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
+    var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
+    var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
+    var c = SIMDUtils.float32x4.clamp(a, lower, upper);
+    equal(2.0, SIMD.float32x4.extractLane(c, 0));
+    equal(5.0, SIMD.float32x4.extractLane(c, 1));
+    equal(50.0, SIMD.float32x4.extractLane(c, 2));
+    equal(0.5, SIMD.float32x4.extractLane(c, 3));
+});
+
+test('utils.float64x2.clamp', function() {
+  var a = SIMD.float64x2(-20.0, 10.0);
+  var b = SIMD.float64x2(2.125, 3.0);
+  var lower = SIMD.float64x2(2.0, 1.0);
+  var upper = SIMD.float64x2(2.5, 5.0);
+  var c = SIMDUtils.float64x2.clamp(a, lower, upper);
+  equal(2.0, SIMD.float64x2.extractLane(c, 0));
+  equal(5.0, SIMD.float64x2.extractLane(c, 1));
+  c = SIMDUtils.float64x2.clamp(b, lower, upper);
+  equal(2.125, SIMD.float64x2.extractLane(c, 0));
+  equal(3.0, SIMD.float64x2.extractLane(c, 1));
+  a = SIMD.float64x2(-3.4e200, 3.4e250);
+  b = SIMD.float64x2(3.4e100, 3.4e200);
+  lower = SIMD.float64x2(3.4e50, 3.4e100);
+  upper = SIMD.float64x2(3.4e150, 3.4e300);
+  c = SIMDUtils.float64x2.clamp(a, lower, upper);
+  equal(3.4e50, SIMD.float64x2.extractLane(c, 0));
+  equal(3.4e250, SIMD.float64x2.extractLane(c, 1));
+  c = SIMDUtils.float64x2.clamp(b, lower, upper);
+  equal(3.4e100, SIMD.float64x2.extractLane(c, 0));
+  equal(3.4e200, SIMD.float64x2.extractLane(c, 1));
+});


### PR DESCRIPTION
As a long overdue, here is the start of a utility library using SIMD.js, as an example of what can be done with SIMD.js. It contains the previously deleted "zero" attribute, and the "clamp" method deleted in my previous pull request. As a matter of fact, this pull request depends on the merge of the clamp removal PR.

There are different possible approaches for this utilities library: the one presented in this patch (use a global object, SIMDUtil, on which we implant the new methods, to prevent possible future namespace issues), or adding methods to the global SIMD object itself (which would have the previously mentioned issue), or having pure functions that take the SIMD object and other arguments (e.g. `function float32x4Clamp(SIMD, v, min, max)` or simply `function float32x4Clamp(v, min, max)`) -- but this last one lacks symmetry with the SIMD global object, in my opinion. Of course, as this is just a start, everybody can add useful utility functions later or change the ones already present in this file.

@sunfishcode, @johnmccutchan, @PeterJensen, what do you think?