### PR TITLE
Print a prettier stack trace when a test fails with an exception.

### DIFF
--- a/src/shell_test_runner.js
+++ b/src/shell_test_runner.js
@@ -22,7 +22,9 @@ function test(name, func) {
   try {
     func();
   } catch (e) {
-    fail('exception thrown from ' + currentName);
+    console.log('exception thrown from ' + currentName + ': ' + e.toString());
+    printIndented(e.stack);
+    numFails++;
   }
 }
 


### PR DESCRIPTION
Instead of constructing a new Error after the failure, print the stack
of the exception that was originally thrown so that the point of the
throw is presented.