### PR TITLE
Remove an out-of-date comment.

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -34,10 +34,7 @@
 (function(global) {
 
 if (typeof global.SIMD === "undefined") {
-  // SIMD module. We don't use the var keyword here, so that we put the
-  // SIMD object in the global scope even if this polyfill code is included
-  // within some other scope. The theory is that we're anticipating a
-  // future where SIMD is predefined in the global scope.
+  // SIMD module.
   global.SIMD = {};
 }
 


### PR DESCRIPTION
From #144, this comment was written before 648ff9b8180d3186f96a0eff149b1cab7c6301ae, which put all the code in a closure. It would no longer make sense to use the var keyword there.