### PR TITLE
Int64x2

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -555,6 +555,17 @@ if (typeof SIMD.int32x4.extractLane === "undefined") {
   }
 }
 
+if (typeof SIMD.int32x4.extractLaneAsBool === "undefined") {
+  /**
+    * @param {int32x4} t An instance of int32x4.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {Boolean} The value in lane i of t as a boolean.
+    */
+  SIMD.int32x4.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.int32x4.extractLane(t, i));
+  }
+}
+
 if (typeof SIMD.int32x4.replaceLane === "undefined") {
   /**
     * @param {int32x4} t An instance of int32x4.
@@ -582,10 +593,10 @@ if (typeof SIMD.int32x4.allTrue === "undefined") {
     if (!(v instanceof SIMD.int32x4)) {
       throw new TypeError("argument is not a int32x4.");
     }
-    return toBool(SIMD.int32x4.extractLane(v, 0)) &&
-        toBool(SIMD.int32x4.extractLane(v, 1)) &&
-        toBool(SIMD.int32x4.extractLane(v, 2)) &&
-        toBool(SIMD.int32x4.extractLane(v, 3));
+    return SIMD.int32x4.extractLaneAsBool(v, 0) &&
+        SIMD.int32x4.extractLaneAsBool(v, 1) &&
+        SIMD.int32x4.extractLaneAsBool(v, 2) &&
+        SIMD.int32x4.extractLaneAsBool(v, 3);
   }
 }
 
@@ -599,10 +610,10 @@ if (typeof SIMD.int32x4.anyTrue === "undefined") {
     if (!(v instanceof SIMD.int32x4)) {
       throw new TypeError("argument is not a int32x4.");
     }
-    return toBool(SIMD.int32x4.extractLane(v, 0)) ||
-        toBool(SIMD.int32x4.extractLane(v, 1)) ||
-        toBool(SIMD.int32x4.extractLane(v, 2)) ||
-        toBool(SIMD.int32x4.extractLane(v, 3));
+    return SIMD.int32x4.extractLaneAsBool(v, 0) ||
+        SIMD.int32x4.extractLaneAsBool(v, 1) ||
+        SIMD.int32x4.extractLaneAsBool(v, 2) ||
+        SIMD.int32x4.extractLaneAsBool(v, 3);
   }
 }
 
@@ -773,6 +784,17 @@ if (typeof SIMD.int16x8.extractLane === "undefined") {
   }
 }
 
+if (typeof SIMD.int16x8.extractLaneAsBool === "undefined") {
+  /**
+    * @param {int16x8} t An instance of int16x8.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {Boolean} The value in lane i of t as a boolean.
+    */
+  SIMD.int16x8.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.int16x8.extractLane(t, i));
+  }
+}
+
 if (typeof SIMD.int16x8.replaceLane === "undefined") {
   /**
     * @param {int16x8} t An instance of int16x8.
@@ -800,14 +822,14 @@ if (typeof SIMD.int16x8.allTrue === "undefined") {
     if (!(v instanceof SIMD.int16x8)) {
       throw new TypeError("argument is not a int16x8.");
     }
-    return toBool(SIMD.int16x8.extractLane(v, 0)) &&
-           toBool(SIMD.int16x8.extractLane(v, 1)) &&
-           toBool(SIMD.int16x8.extractLane(v, 2)) &&
-           toBool(SIMD.int16x8.extractLane(v, 3)) &&
-           toBool(SIMD.int16x8.extractLane(v, 4)) &&
-           toBool(SIMD.int16x8.extractLane(v, 5)) &&
-           toBool(SIMD.int16x8.extractLane(v, 6)) &&
-           toBool(SIMD.int16x8.extractLane(v, 7));
+    return SIMD.int16x8.extractLaneAsBool(v, 0) &&
+           SIMD.int16x8.extractLaneAsBool(v, 1) &&
+           SIMD.int16x8.extractLaneAsBool(v, 2) &&
+           SIMD.int16x8.extractLaneAsBool(v, 3) &&
+           SIMD.int16x8.extractLaneAsBool(v, 4) &&
+           SIMD.int16x8.extractLaneAsBool(v, 5) &&
+           SIMD.int16x8.extractLaneAsBool(v, 6) &&
+           SIMD.int16x8.extractLaneAsBool(v, 7);
   }
 }
 
@@ -821,14 +843,14 @@ if (typeof SIMD.int16x8.anyTrue === "undefined") {
     if (!(v instanceof SIMD.int16x8)) {
       throw new TypeError("argument is not a int16x8.");
     }
-    return toBool(SIMD.int16x8.extractLane(v, 0)) ||
-           toBool(SIMD.int16x8.extractLane(v, 1)) ||
-           toBool(SIMD.int16x8.extractLane(v, 2)) ||
-           toBool(SIMD.int16x8.extractLane(v, 3)) ||
-           toBool(SIMD.int16x8.extractLane(v, 4)) ||
-           toBool(SIMD.int16x8.extractLane(v, 5)) ||
-           toBool(SIMD.int16x8.extractLane(v, 6)) ||
-           toBool(SIMD.int16x8.extractLane(v, 7));
+    return SIMD.int16x8.extractLaneAsBool(v, 0) ||
+           SIMD.int16x8.extractLaneAsBool(v, 1) ||
+           SIMD.int16x8.extractLaneAsBool(v, 2) ||
+           SIMD.int16x8.extractLaneAsBool(v, 3) ||
+           SIMD.int16x8.extractLaneAsBool(v, 4) ||
+           SIMD.int16x8.extractLaneAsBool(v, 5) ||
+           SIMD.int16x8.extractLaneAsBool(v, 6) ||
+           SIMD.int16x8.extractLaneAsBool(v, 7);
   }
 }
 
@@ -861,14 +883,14 @@ if (typeof SIMD.int16x8.bool === "undefined") {
     * @constructor
     */
   SIMD.int16x8.bool = function(s0, s1, s2, s3, s4, s5, s6, s7) {
-    return SIMD.int16x8(s0 ? -1 : 0x0,
-                        s1 ? -1 : 0x0,
-                        s2 ? -1 : 0x0,
-                        s3 ? -1 : 0x0,
-                        s4 ? -1 : 0x0,
-                        s5 ? -1 : 0x0,
-                        s6 ? -1 : 0x0,
-                        s7 ? -1 : 0x0);
+    return SIMD.int16x8(fromBool(s0),
+                        fromBool(s1),
+                        fromBool(s2),
+                        fromBool(s3),
+                        fromBool(s4),
+                        fromBool(s5),
+                        fromBool(s6),
+                        fromBool(s7));
   }
 }
 
@@ -1005,6 +1027,17 @@ if (typeof SIMD.int8x16.extractLane === "undefined") {
   }
 }
 
+if (typeof SIMD.int8x16.extractLaneAsBool === "undefined") {
+  /**
+    * @param {int8x16} t An instance of int8x16.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {Boolean} The value in lane i of t as a boolean.
+    */
+  SIMD.int8x16.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.int8x16.extractLane(t, i));
+  }
+}
+
 if (typeof SIMD.int8x16.replaceLane === "undefined") {
   /**
     * @param {int8x16} t An instance of int8x16.
@@ -1032,22 +1065,22 @@ if (typeof SIMD.int8x16.allTrue === "undefined") {
     if (!(v instanceof SIMD.int8x16)) {
       throw new TypeError("argument is not a int8x16.");
     }
-    return toBool(SIMD.int8x16.extractLane(v, 0)) &&
-           toBool(SIMD.int8x16.extractLane(v, 1)) &&
-           toBool(SIMD.int8x16.extractLane(v, 2)) &&
-           toBool(SIMD.int8x16.extractLane(v, 3)) &&
-           toBool(SIMD.int8x16.extractLane(v, 4)) &&
-           toBool(SIMD.int8x16.extractLane(v, 5)) &&
-           toBool(SIMD.int8x16.extractLane(v, 6)) &&
-           toBool(SIMD.int8x16.extractLane(v, 7)) &&
-           toBool(SIMD.int8x16.extractLane(v, 8)) &&
-           toBool(SIMD.int8x16.extractLane(v, 9)) &&
-           toBool(SIMD.int8x16.extractLane(v, 10)) &&
-           toBool(SIMD.int8x16.extractLane(v, 11)) &&
-           toBool(SIMD.int8x16.extractLane(v, 12)) &&
-           toBool(SIMD.int8x16.extractLane(v, 13)) &&
-           toBool(SIMD.int8x16.extractLane(v, 14)) &&
-           toBool(SIMD.int8x16.extractLane(v, 15));
+    return SIMD.int8x16.extractLaneAsBool(v, 0) &&
+           SIMD.int8x16.extractLaneAsBool(v, 1) &&
+           SIMD.int8x16.extractLaneAsBool(v, 2) &&
+           SIMD.int8x16.extractLaneAsBool(v, 3) &&
+           SIMD.int8x16.extractLaneAsBool(v, 4) &&
+           SIMD.int8x16.extractLaneAsBool(v, 5) &&
+           SIMD.int8x16.extractLaneAsBool(v, 6) &&
+           SIMD.int8x16.extractLaneAsBool(v, 7) &&
+           SIMD.int8x16.extractLaneAsBool(v, 8) &&
+           SIMD.int8x16.extractLaneAsBool(v, 9) &&
+           SIMD.int8x16.extractLaneAsBool(v, 10) &&
+           SIMD.int8x16.extractLaneAsBool(v, 11) &&
+           SIMD.int8x16.extractLaneAsBool(v, 12) &&
+           SIMD.int8x16.extractLaneAsBool(v, 13) &&
+           SIMD.int8x16.extractLaneAsBool(v, 14) &&
+           SIMD.int8x16.extractLaneAsBool(v, 15);
   }
 }
 
@@ -1061,22 +1094,22 @@ if (typeof SIMD.int8x16.anyTrue === "undefined") {
     if (!(v instanceof SIMD.int8x16)) {
       throw new TypeError("argument is not a int8x16.");
     }
-    return toBool(SIMD.int8x16.extractLane(v, 0)) ||
-           toBool(SIMD.int8x16.extractLane(v, 1)) ||
-           toBool(SIMD.int8x16.extractLane(v, 2)) ||
-           toBool(SIMD.int8x16.extractLane(v, 3)) ||
-           toBool(SIMD.int8x16.extractLane(v, 4)) ||
-           toBool(SIMD.int8x16.extractLane(v, 5)) ||
-           toBool(SIMD.int8x16.extractLane(v, 6)) ||
-           toBool(SIMD.int8x16.extractLane(v, 7)) ||
-           toBool(SIMD.int8x16.extractLane(v, 8)) ||
-           toBool(SIMD.int8x16.extractLane(v, 9)) ||
-           toBool(SIMD.int8x16.extractLane(v, 10)) ||
-           toBool(SIMD.int8x16.extractLane(v, 11)) ||
-           toBool(SIMD.int8x16.extractLane(v, 12)) ||
-           toBool(SIMD.int8x16.extractLane(v, 13)) ||
-           toBool(SIMD.int8x16.extractLane(v, 14)) ||
-           toBool(SIMD.int8x16.extractLane(v, 15));
+    return SIMD.int8x16.extractLaneAsBool(v, 0) ||
+           SIMD.int8x16.extractLaneAsBool(v, 1) ||
+           SIMD.int8x16.extractLaneAsBool(v, 2) ||
+           SIMD.int8x16.extractLaneAsBool(v, 3) ||
+           SIMD.int8x16.extractLaneAsBool(v, 4) ||
+           SIMD.int8x16.extractLaneAsBool(v, 5) ||
+           SIMD.int8x16.extractLaneAsBool(v, 6) ||
+           SIMD.int8x16.extractLaneAsBool(v, 7) ||
+           SIMD.int8x16.extractLaneAsBool(v, 8) ||
+           SIMD.int8x16.extractLaneAsBool(v, 9) ||
+           SIMD.int8x16.extractLaneAsBool(v, 10) ||
+           SIMD.int8x16.extractLaneAsBool(v, 11) ||
+           SIMD.int8x16.extractLaneAsBool(v, 12) ||
+           SIMD.int8x16.extractLaneAsBool(v, 13) ||
+           SIMD.int8x16.extractLaneAsBool(v, 14) ||
+           SIMD.int8x16.extractLaneAsBool(v, 15);
   }
 }
 
@@ -1119,22 +1152,22 @@ if (typeof SIMD.int8x16.bool === "undefined") {
     */
   SIMD.int8x16.bool = function(s0, s1, s2, s3, s4, s5, s6, s7,
                                s8, s9, s10, s11, s12, s13, s14, s15) {
-    return SIMD.int8x16(s0 ? -1 : 0x0,
-                        s1 ? -1 : 0x0,
-                        s2 ? -1 : 0x0,
-                        s3 ? -1 : 0x0,
-                        s4 ? -1 : 0x0,
-                        s5 ? -1 : 0x0,
-                        s6 ? -1 : 0x0,
-                        s7 ? -1 : 0x0,
-                        s8 ? -1 : 0x0,
-                        s9 ? -1 : 0x0,
-                        s10 ? -1 : 0x0,
-                        s11 ? -1 : 0x0,
-                        s12 ? -1 : 0x0,
-                        s13 ? -1 : 0x0,
-                        s14 ? -1 : 0x0,
-                        s15 ? -1 : 0x0);
+    return SIMD.int8x16(fromBool(s0),
+                        fromBool(s1),
+                        fromBool(s2),
+                        fromBool(s3),
+                        fromBool(s4),
+                        fromBool(s5),
+                        fromBool(s6),
+                        fromBool(s7),
+                        fromBool(s8),
+                        fromBool(s9),
+                        fromBool(s10),
+                        fromBool(s11),
+                        fromBool(s12),
+                        fromBool(s13),
+                        fromBool(s14),
+                        fromBool(s15));
   }
 }
 
@@ -1624,16 +1657,16 @@ if (typeof SIMD.float32x4.select === "undefined") {
     trueValue = SIMD.float32x4.check(trueValue);
     falseValue = SIMD.float32x4.check(falseValue);
     return SIMD.float32x4(
-        toBool(SIMD.int32x4.extractLane(t, 0)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 0) ?
             SIMD.float32x4.extractLane(trueValue, 0) :
                 SIMD.float32x4.extractLane(falseValue, 0),
-        toBool(SIMD.int32x4.extractLane(t, 1)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 1) ?
             SIMD.float32x4.extractLane(trueValue, 1) :
                 SIMD.float32x4.extractLane(falseValue, 1),
-        toBool(SIMD.int32x4.extractLane(t, 2)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 2) ?
             SIMD.float32x4.extractLane(trueValue, 2) :
                 SIMD.float32x4.extractLane(falseValue, 2),
-        toBool(SIMD.int32x4.extractLane(t, 3)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 3) ?
             SIMD.float32x4.extractLane(trueValue, 3) :
                 SIMD.float32x4.extractLane(falseValue, 3));
   }
@@ -2313,10 +2346,10 @@ if (typeof SIMD.float64x2.select === "undefined") {
     // We use t.z_ for the second element because t is an int32x4, because
     // int64x2 isn't available.
     return SIMD.float64x2(
-        toBool(SIMD.int32x4.extractLane(t, 0)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 0) ?
             SIMD.float64x2.extractLane(trueValue, 0) :
                 SIMD.float64x2.extractLane(falseValue, 0),
-        toBool(SIMD.int32x4.extractLane(t, 2)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 2) ?
             SIMD.float64x2.extractLane(trueValue, 1) :
                 SIMD.float64x2.extractLane(falseValue, 1));
   }
@@ -2657,16 +2690,16 @@ if (typeof SIMD.int32x4.select === "undefined") {
     trueValue = SIMD.int32x4.check(trueValue);
     falseValue = SIMD.int32x4.check(falseValue);
     return SIMD.int32x4(
-        toBool(SIMD.int32x4.extractLane(t, 0)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 0) ?
             SIMD.int32x4.extractLane(trueValue, 0) :
                 SIMD.int32x4.extractLane(falseValue, 0),
-        toBool(SIMD.int32x4.extractLane(t, 1)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 1) ?
             SIMD.int32x4.extractLane(trueValue, 1) :
                 SIMD.int32x4.extractLane(falseValue, 1),
-        toBool(SIMD.int32x4.extractLane(t, 2)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 2) ?
             SIMD.int32x4.extractLane(trueValue, 2) :
                 SIMD.int32x4.extractLane(falseValue, 2),
-        toBool(SIMD.int32x4.extractLane(t, 3)) ?
+        SIMD.int32x4.extractLaneAsBool(t, 3) ?
             SIMD.int32x4.extractLane(trueValue, 3) :
                 SIMD.int32x4.extractLane(falseValue, 3));
   }
@@ -3421,28 +3454,28 @@ if (typeof SIMD.int16x8.select === "undefined") {
     trueValue = SIMD.int16x8.check(trueValue);
     falseValue = SIMD.int16x8.check(falseValue);
     return SIMD.int16x8(
-        toBool(SIMD.int16x8.extractLane(t, 0)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 0) ?
             SIMD.int16x8.extractLane(trueValue, 0) :
                 SIMD.int16x8.extractLane(falseValue, 0),
-        toBool(SIMD.int16x8.extractLane(t, 1)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 1) ?
             SIMD.int16x8.extractLane(trueValue, 1) :
                 SIMD.int16x8.extractLane(falseValue, 1),
-        toBool(SIMD.int16x8.extractLane(t, 2)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 2) ?
             SIMD.int16x8.extractLane(trueValue, 2) :
                 SIMD.int16x8.extractLane(falseValue, 2),
-        toBool(SIMD.int16x8.extractLane(t, 3)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 3) ?
             SIMD.int16x8.extractLane(trueValue, 3) :
                 SIMD.int16x8.extractLane(falseValue, 3),
-        toBool(SIMD.int16x8.extractLane(t, 4)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 4) ?
             SIMD.int16x8.extractLane(trueValue, 4) :
                 SIMD.int16x8.extractLane(falseValue, 4),
-        toBool(SIMD.int16x8.extractLane(t, 5)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 5) ?
             SIMD.int16x8.extractLane(trueValue, 5) :
                 SIMD.int16x8.extractLane(falseValue, 5),
-        toBool(SIMD.int16x8.extractLane(t, 6)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 6) ?
             SIMD.int16x8.extractLane(trueValue, 6) :
                 SIMD.int16x8.extractLane(falseValue, 6),
-        toBool(SIMD.int16x8.extractLane(t, 7)) ?
+        SIMD.int16x8.extractLaneAsBool(t, 7) ?
             SIMD.int16x8.extractLane(trueValue, 7) :
                 SIMD.int16x8.extractLane(falseValue, 7));
   }
@@ -4265,52 +4298,52 @@ if (typeof SIMD.int8x16.select === "undefined") {
     trueValue = SIMD.int8x16.check(trueValue);
     falseValue = SIMD.int8x16.check(falseValue);
     return SIMD.int8x16(
-        toBool(SIMD.int8x16.extractLane(t, 0)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 0) ?
             SIMD.int8x16.extractLane(trueValue, 0) :
                 SIMD.int8x16.extractLane(falseValue, 0),
-        toBool(SIMD.int8x16.extractLane(t, 1)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 1) ?
             SIMD.int8x16.extractLane(trueValue, 1) :
                 SIMD.int8x16.extractLane(falseValue, 1),
-        toBool(SIMD.int8x16.extractLane(t, 2)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 2) ?
             SIMD.int8x16.extractLane(trueValue, 2) :
                 SIMD.int8x16.extractLane(falseValue, 2),
-        toBool(SIMD.int8x16.extractLane(t, 3)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 3) ?
             SIMD.int8x16.extractLane(trueValue, 3) :
                 SIMD.int8x16.extractLane(falseValue, 3),
-        toBool(SIMD.int8x16.extractLane(t, 4)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 4) ?
             SIMD.int8x16.extractLane(trueValue, 4) :
                 SIMD.int8x16.extractLane(falseValue, 4),
-        toBool(SIMD.int8x16.extractLane(t, 5)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 5) ?
             SIMD.int8x16.extractLane(trueValue, 5) :
                 SIMD.int8x16.extractLane(falseValue, 5),
-        toBool(SIMD.int8x16.extractLane(t, 6)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 6) ?
             SIMD.int8x16.extractLane(trueValue, 6) :
                 SIMD.int8x16.extractLane(falseValue, 6),
-        toBool(SIMD.int8x16.extractLane(t, 7)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 7) ?
             SIMD.int8x16.extractLane(trueValue, 7) :
                 SIMD.int8x16.extractLane(falseValue, 7),
-        toBool(SIMD.int8x16.extractLane(t, 8)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 8) ?
             SIMD.int8x16.extractLane(trueValue, 8) :
                 SIMD.int8x16.extractLane(falseValue, 8),
-        toBool(SIMD.int8x16.extractLane(t, 9)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 9) ?
             SIMD.int8x16.extractLane(trueValue, 9) :
                 SIMD.int8x16.extractLane(falseValue, 9),
-        toBool(SIMD.int8x16.extractLane(t, 10)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 10) ?
             SIMD.int8x16.extractLane(trueValue, 10) :
                 SIMD.int8x16.extractLane(falseValue, 10),
-        toBool(SIMD.int8x16.extractLane(t, 11)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 11) ?
             SIMD.int8x16.extractLane(trueValue, 11) :
                 SIMD.int8x16.extractLane(falseValue, 11),
-        toBool(SIMD.int8x16.extractLane(t, 12)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 12) ?
             SIMD.int8x16.extractLane(trueValue, 12) :
                 SIMD.int8x16.extractLane(falseValue, 12),
-        toBool(SIMD.int8x16.extractLane(t, 13)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 13) ?
             SIMD.int8x16.extractLane(trueValue, 13) :
                 SIMD.int8x16.extractLane(falseValue, 13),
-        toBool(SIMD.int8x16.extractLane(t, 14)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 14) ?
             SIMD.int8x16.extractLane(trueValue, 14) :
                 SIMD.int8x16.extractLane(falseValue, 14),
-        toBool(SIMD.int8x16.extractLane(t, 15)) ?
+        SIMD.int8x16.extractLaneAsBool(t, 15) ?
             SIMD.int8x16.extractLane(trueValue, 15) :
                 SIMD.int8x16.extractLane(falseValue, 15));
   }

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -2364,7 +2364,7 @@ if (typeof SIMD.float64x2.lessThan === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t < other.
     */
   SIMD.float64x2.lessThan = function(t, other) {
@@ -2374,7 +2374,7 @@ if (typeof SIMD.float64x2.lessThan === "undefined") {
         SIMD.float64x2.extractLane(t, 0) < SIMD.float64x2.extractLane(other, 0);
     var cy =
         SIMD.float64x2.extractLane(t, 1) < SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
@@ -2382,7 +2382,7 @@ if (typeof SIMD.float64x2.lessThanOrEqual === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t <= other.
     */
   SIMD.float64x2.lessThanOrEqual = function(t, other) {
@@ -2392,7 +2392,7 @@ if (typeof SIMD.float64x2.lessThanOrEqual === "undefined") {
         SIMD.float64x2.extractLane(other, 0);
     var cy = SIMD.float64x2.extractLane(t, 1) <=
         SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
@@ -2400,7 +2400,7 @@ if (typeof SIMD.float64x2.equal === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t == other.
     */
   SIMD.float64x2.equal = function(t, other) {
@@ -2410,7 +2410,7 @@ if (typeof SIMD.float64x2.equal === "undefined") {
         SIMD.float64x2.extractLane(other, 0);
     var cy = SIMD.float64x2.extractLane(t, 1) ==
         SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
@@ -2418,7 +2418,7 @@ if (typeof SIMD.float64x2.notEqual === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t != other.
     */
   SIMD.float64x2.notEqual = function(t, other) {
@@ -2428,7 +2428,7 @@ if (typeof SIMD.float64x2.notEqual === "undefined") {
         SIMD.float64x2.extractLane(other, 0);
     var cy = SIMD.float64x2.extractLane(t, 1) !=
         SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
@@ -2436,7 +2436,7 @@ if (typeof SIMD.float64x2.greaterThanOrEqual === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t >= other.
     */
   SIMD.float64x2.greaterThanOrEqual = function(t, other) {
@@ -2446,7 +2446,7 @@ if (typeof SIMD.float64x2.greaterThanOrEqual === "undefined") {
         SIMD.float64x2.extractLane(other, 0);
     var cy = SIMD.float64x2.extractLane(t, 1) >=
         SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
@@ -2454,7 +2454,7 @@ if (typeof SIMD.float64x2.greaterThan === "undefined") {
   /**
     * @param {float64x2} t An instance of float64x2.
     * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @return {int64x2} true or false in each lane depending on
     * the result of t > other.
     */
   SIMD.float64x2.greaterThan = function(t, other) {
@@ -2464,13 +2464,13 @@ if (typeof SIMD.float64x2.greaterThan === "undefined") {
         SIMD.float64x2.extractLane(t, 0) > SIMD.float64x2.extractLane(other, 0);
     var cy =
         SIMD.float64x2.extractLane(t, 1) > SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.int64x2.bool(cx, cy);
   }
 }
 
 if (typeof SIMD.float64x2.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
+    * @param {int64x2} t Selector mask. An instance of int64x2
     * @param {float64x2} trueValue Pick lane from here if corresponding
     * selector lane is true
     * @param {float64x2} falseValue Pick lane from here if corresponding
@@ -2479,16 +2479,14 @@ if (typeof SIMD.float64x2.select === "undefined") {
     * indicated
     */
   SIMD.float64x2.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
+    t = SIMD.int64x2.check(t);
     trueValue = SIMD.float64x2.check(trueValue);
     falseValue = SIMD.float64x2.check(falseValue);
-    // We use t.z_ for the second element because t is an int32x4, because
-    // int64x2 isn't available.
     return SIMD.float64x2(
-        SIMD.int32x4.extractLaneAsBool(t, 0) ?
+        SIMD.int64x2.extractLaneAsBool(t, 0) ?
             SIMD.float64x2.extractLane(trueValue, 0) :
                 SIMD.float64x2.extractLane(falseValue, 0),
-        SIMD.int32x4.extractLaneAsBool(t, 2) ?
+        SIMD.int64x2.extractLaneAsBool(t, 1) ?
             SIMD.float64x2.extractLane(trueValue, 1) :
                 SIMD.float64x2.extractLane(falseValue, 1));
   }
@@ -2496,7 +2494,7 @@ if (typeof SIMD.float64x2.select === "undefined") {
 
 if (typeof SIMD.float64x2.selectBits === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
+    * @param {int64x2} t Selector mask. An instance of int64x2
     * @param {float64x2} trueValue Pick bit from here if corresponding
     * selector bit is 1
     * @param {float64x2} falseValue Pick bit from here if corresponding
@@ -2505,14 +2503,14 @@ if (typeof SIMD.float64x2.selectBits === "undefined") {
     * indicated
     */
   SIMD.float64x2.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
+    t = SIMD.int64x2.check(t);
     trueValue = SIMD.float64x2.check(trueValue);
     falseValue = SIMD.float64x2.check(falseValue);
-    var tv = SIMD.int32x4.fromFloat64x2Bits(trueValue);
-    var fv = SIMD.int32x4.fromFloat64x2Bits(falseValue);
-    var tr = SIMD.int32x4.and(t, tv);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
-    return SIMD.float64x2.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+    var tv = SIMD.int64x2.fromFloat64x2Bits(trueValue);
+    var fv = SIMD.int64x2.fromFloat64x2Bits(falseValue);
+    var tr = SIMD.int64x2.and(t, tv);
+    var fr = SIMD.int64x2.and(SIMD.int64x2.not(t), fv);
+    return SIMD.float64x2.fromInt64x2Bits(SIMD.int64x2.or(tr, fr));
   }
 }
 

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -483,6 +483,16 @@ if (typeof SIMD.float64x2.fromFloat32x4Bits === "undefined") {
   }
 }
 
+if (typeof SIMD.float64x2.fromInt64x2Bits === "undefined") {
+  /**
+   * @param {int64x2} t An instance of int64x2.
+   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   */
+  SIMD.float64x2.fromInt64x2Bits = function(t) {
+    return SIMD.float64x2.fromInt32x4Bits(t.int32x4_);
+  }
+}
+
 if (typeof SIMD.float64x2.fromInt32x4Bits === "undefined") {
   /**
    * @param {int32x4} t An instance of int32x4.
@@ -697,6 +707,16 @@ if (typeof SIMD.int32x4.fromFloat32x4Bits === "undefined") {
   SIMD.int32x4.fromFloat32x4Bits = function(t) {
     saveFloat32x4(t);
     return restoreInt32x4();
+  }
+}
+
+if (typeof SIMD.int32x4.fromInt64x2Bits === "undefined") {
+  /**
+   * @param {int64x2} t An instance of int64x2.
+   * @return {int32x4} a bit-wise copy of t as an int32x4.
+   */
+  SIMD.int32x4.fromInt64x2Bits = function(t) {
+    return t.int32x4_;
   }
 }
 
@@ -1225,6 +1245,125 @@ if (typeof SIMD.int8x16.fromInt16x8Bits === "undefined") {
   SIMD.int8x16.fromInt16x8Bits = function(t) {
     saveInt16x8(t);
     return restoreInt8x16();
+  }
+}
+
+if (typeof SIMD.int64x2 === "undefined") {
+  /**
+    * Construct a new instance of int64x2 number.
+    * This function conceptually requires 64-bit integer arguments. Until JS
+    * has support for that, this function cannot be passed any arguments. To
+    * produce an int64x2 value, use int64x2.load, int64x2.bool, or a
+    * float64x2 comparison.
+    * @constructor
+    */
+  SIMD.int64x2 = function() {
+    if (!(this instanceof SIMD.int64x2)) {
+      return new SIMD.int64x2();
+    }
+    if (arguments.length != 0) {
+      throw new Error("int64x2 cannot currently be directly constructed");
+    }
+
+    this.int32x4_ = SIMD.int32x4.splat(0);
+  }
+}
+
+if (typeof SIMD.int64x2.extractLaneAsBool === "undefined") {
+  /**
+    * @param {int64x2} t An instance of int64x2.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {Boolean} The value in lane i of t as a boolean.
+    */
+  SIMD.int64x2.extractLaneAsBool = function(t, i) {
+    t = SIMD.int64x2.check(t);
+    return SIMD.int32x4.extractLaneAsBool(t.int32x4_, i << 1)
+  }
+}
+
+
+if (typeof SIMD.int64x2.allTrue === "undefined") {
+  /**
+    * Check if all 2 lanes hold a true value (bit 63 == 1)
+    * @param {int64x2} v An instance of int64x2.
+    * @return {Boolean} All 2 lanes hold a true value
+    */
+  SIMD.int64x2.allTrue = function(v) {
+    if (!(v instanceof SIMD.int64x2)) {
+      throw new TypeError("argument is not a int64x2.");
+    }
+    return SIMD.int64x2.extractLaneAsBool(v, 0) &&
+        SIMD.int64x2.extractLaneAsBool(v, 1);
+  }
+}
+
+if (typeof SIMD.int64x2.anyTrue === "undefined") {
+  /**
+    * Check if any of the 2 lanes hold a true value (bit 63 == 1)
+    * @param {int64x2} v An instance of int64x2.
+    * @return {Boolean} Any of the 2 lanes holds a true value
+    */
+  SIMD.int64x2.anyTrue = function(v) {
+    if (!(v instanceof SIMD.int64x2)) {
+      throw new TypeError("argument is not a int64x2.");
+    }
+    return SIMD.int64x2.extractLaneAsBool(v, 0) ||
+        SIMD.int64x2.extractLaneAsBool(v, 1);
+  }
+}
+
+if (typeof SIMD.int64x2.check === "undefined") {
+  /**
+    * Check whether the argument is a int64x2.
+    * @param {int64x2} v An instance of int64x2.
+    * @return {int64x2} The int64x2 instance.
+    */
+  SIMD.int64x2.check = function(v) {
+    if (!(v instanceof SIMD.int64x2)) {
+      throw new TypeError("argument is not a int64x2.");
+    }
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.bool === "undefined") {
+  /**
+    * Construct a new instance of int64x2 number with either true or false in
+    * each lane, depending on the truth values in x and y.
+    * @param {boolean} flag used for x lane.
+    * @param {boolean} flag used for y lane.
+    * @constructor
+    */
+  SIMD.int64x2.bool = function(x, y) {
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.bool(x, 0, y, 0);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.fromFloat64x2Bits === "undefined") {
+  /**
+   * @param {float64x2} t An instance of float64x2.
+   * @return {int64x2} a bit-wise copy of t as an int64x2.
+   */
+  SIMD.int64x2.fromFloat64x2Bits = function(t) {
+    saveFloat64x2(t);
+    var v = SIMD.int64x2();
+    v.int32x4_ = restoreInt32x4();
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.fromInt32x4Bits === "undefined") {
+  /**
+   * @param {int32x4} t An instance of int32x4.
+   * @return {int64x2} a bit-wise copy of t as an int64x2.
+   */
+  SIMD.int64x2.fromInt32x4Bits = function(t) {
+    t = SIMD.int32x4.check(t);
+    var v = SIMD.int64x2();
+    v.int32x4_ = t;
+    return v;
   }
 }
 
@@ -2481,6 +2620,148 @@ if (typeof SIMD.float64x2.store1 === "undefined") {
     var n = 8 / bpe;
     for (var i = 0; i < n; ++i)
       tarray[index + i] = array[i];
+  }
+}
+
+if (typeof SIMD.int64x2.and === "undefined") {
+  /**
+    * @param {int64x2} a An instance of int64x2.
+    * @param {int64x2} b An instance of int64x2.
+    * @return {int64x2} New instance of int64x2 with values of a & b.
+    */
+  SIMD.int64x2.and = function(a, b) {
+    a = SIMD.int64x2.check(a);
+    b = SIMD.int64x2.check(b);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.and(a.int32x4_, b.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.or === "undefined") {
+  /**
+    * @param {int64x2} a An instance of int64x2.
+    * @param {int64x2} b An instance of int64x2.
+    * @return {int64x2} New instance of int64x2 with values of a | b.
+    */
+  SIMD.int64x2.or = function(a, b) {
+    a = SIMD.int64x2.check(a);
+    b = SIMD.int64x2.check(b);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.or(a.int32x4_, b.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.xor === "undefined") {
+  /**
+    * @param {int64x2} a An instance of int64x2.
+    * @param {int64x2} b An instance of int64x2.
+    * @return {int64x2} New instance of int64x2 with values of a ^ b.
+    */
+  SIMD.int64x2.xor = function(a, b) {
+    a = SIMD.int64x2.check(a);
+    b = SIMD.int64x2.check(b);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.xor(a.int32x4_, b.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.not === "undefined") {
+  /**
+    * @param {int64x2} t An instance of int64x2.
+    * @return {int64x2} New instance of int64x2 with values of ~t
+    */
+  SIMD.int64x2.not = function(t) {
+    t = SIMD.int64x2.check(t);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.not(t.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.equal === "undefined") {
+  /**
+    * @param {int64x2} t An instance of int64x2.
+    * @param {int64x2} other An instance of int64x2.
+    * @return {int64x2} true or false in each lane depending on
+    * the result of t == other.
+    */
+  SIMD.int64x2.equal = function(t, other) {
+    t = SIMD.int64x2.check(t);
+    other = SIMD.int64x2.check(other);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.equal(t.int32x4_, other.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.notEqual === "undefined") {
+  /**
+    * @param {int64x2} t An instance of int64x2.
+    * @param {int64x2} other An instance of int64x2.
+    * @return {int64x2} true or false in each lane depending on
+    * the result of t != other.
+    */
+  SIMD.int64x2.notEqual = function(t, other) {
+    t = SIMD.int64x2.check(t);
+    other = SIMD.int64x2.check(other);
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.notEqual(t.int32x4_, other.int32x4_);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.load === "undefined") {
+  /**
+    * @param {Typed array} tarray An instance of a typed array.
+    * @param {Number} index An instance of Number.
+    * @return {int64x2} New instance of int64x2.
+    */
+  SIMD.int64x2.load = function(tarray, index) {
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.load(tarray, index);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.load1 === "undefined") {
+  /**
+    * @param {Typed array} tarray An instance of a typed array.
+    * @param {Number} index An instance of Number.
+    * @return {int64x2} New instance of int64x2.
+    */
+  SIMD.int64x2.load1 = function(tarray, index) {
+    var v = SIMD.int64x2();
+    v.int32x4_ = SIMD.int32x4.load2(tarray, index);
+    return v;
+  }
+}
+
+if (typeof SIMD.int64x2.store === "undefined") {
+  /**
+    * @param {Typed array} tarray An instance of a typed array.
+    * @param {Number} index An instance of Number.
+    * @param {int64x2} value An instance of int64x2.
+    * @return {void}
+    */
+  SIMD.int64x2.store = function(tarray, index, value) {
+    value = SIMD.int64x2.check(value);
+    return SIMD.int32x4.store(tarray, index, value.int32x4_);
+  }
+}
+
+if (typeof SIMD.int64x2.store1 === "undefined") {
+  /**
+    * @param {Typed array} tarray An instance of a typed array.
+    * @param {Number} index An instance of Number.
+    * @param {int64x2} value An instance of int64x2.
+    * @return {void}
+    */
+  SIMD.int64x2.store1 = function(tarray, index, value) {
+    value = SIMD.int64x2.check(value);
+    return SIMD.int32x4.store2(tarray, index, value.int32x4_);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -1705,120 +1705,97 @@ test('float64x2 comparisons', function() {
 
   var cmp;
   cmp = SIMD.float64x2.lessThan(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.lessThan(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.lessThanOrEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.lessThanOrEqual(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.equal(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.equal(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.notEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.notEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.greaterThanOrEqual(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.greaterThanOrEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.greaterThan(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.greaterThan(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   var o = SIMD.float64x2(0.0, -0.0);
   var p = SIMD.float64x2(-0.0, 0.0);
   var q = SIMD.float64x2(0.0, NaN);
   var r = SIMD.float64x2(NaN, 0.0);
   cmp = SIMD.float64x2.lessThan(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.lessThan(q, r);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.lessThanOrEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.lessThanOrEqual(q, r);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.equal(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.equal(q, r);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.notEqual(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.notEqual(q, r);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.greaterThanOrEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.greaterThanOrEqual(q, r);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 
   cmp = SIMD.float64x2.greaterThan(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
   cmp = SIMD.float64x2.greaterThan(q, r);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
 });
 
 test('float64x2 select', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0, 0x55555555, 0);
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa,
+                                                    0x55555555, 0x55555555));
   var t = SIMD.float64x2(1.0, 2.0);
   var f = SIMD.float64x2(3.0, 4.0);
   var s = SIMD.float64x2.select(m, t, f);
@@ -1827,12 +1804,13 @@ test('float64x2 select', function() {
 });
 
 test('float64x2 selectBits', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0x55555555);
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa,
+                                                    0x55555555, 0x55555555));
   var t = SIMD.float64x2(1.0, 2.0);
   var f = SIMD.float64x2(3.0, 4.0);
   var s = SIMD.float64x2.selectBits(m, t, f);
-  equal(7.475396213323176e-206, SIMD.float64x2.extractLane(s, 0));
-  equal(4.0, SIMD.float64x2.extractLane(s, 1));
+  equal(4.013165208090495e+205, SIMD.float64x2.extractLane(s, 0));
+  equal(2.0, SIMD.float64x2.extractLane(s, 1));
 });
 
 test('float64x2 load', function() {

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -1308,6 +1308,13 @@ test('float64x2 fromFloat32x4Bits constructor', function() {
   equal(2.0, SIMD.float64x2.extractLane(n, 1));
 });
 
+test('float64x2 fromInt64x2Bits constructor', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000));
+  var n = SIMD.float64x2.fromInt64x2Bits(m);
+  equal(1.0, SIMD.float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+});
+
 test('float64x2 fromInt32x4Bits constructor', function() {
   var m = SIMD.int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000);
   var n = SIMD.float64x2.fromInt32x4Bits(m);
@@ -2011,6 +2018,309 @@ test('float64x2 store1 exceptions', function () {
   });
 });
 
+test('int64x2 allTrue', function () {
+  var v0000 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v0001 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5));
+  var v0010 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  var v0100 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v1000 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v0011 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5));
+  var v0111 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
+  var v1111 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
+  equal(SIMD.int64x2.allTrue(v0000), false);
+  equal(SIMD.int64x2.allTrue(v0001), false);
+  equal(SIMD.int64x2.allTrue(v0010), false);
+  equal(SIMD.int64x2.allTrue(v0100), false);
+  equal(SIMD.int64x2.allTrue(v1000), false);
+  equal(SIMD.int64x2.allTrue(v0011), false);
+  equal(SIMD.int64x2.allTrue(v0111), false);
+  equal(SIMD.int64x2.allTrue(v1111), true);
+});
+
+test('int64x2 fromFloat64x2Bits constructor', function() {
+  var m = SIMD.float64x2(1.0, 2.0);
+  var n = SIMD.int64x2.fromFloat64x2Bits(m);
+  var v = SIMD.int32x4.fromInt64x2Bits(n);
+  equal(0x00000000, SIMD.int32x4.extractLane(v, 0));
+  equal(0x3FF00000, SIMD.int32x4.extractLane(v, 1));
+  equal(0x00000000, SIMD.int32x4.extractLane(v, 2));
+  equal(0x40000000, SIMD.int32x4.extractLane(v, 3));
+});
+
+test('int64x2 anyTrue', function () {
+  var v00 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v01 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  var v10 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v11 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  equal(SIMD.int64x2.anyTrue(v00), false);
+  equal(SIMD.int64x2.anyTrue(v01), true);
+  equal(SIMD.int64x2.anyTrue(v10), true);
+  equal(SIMD.int64x2.anyTrue(v11), true);
+});
+
+test('int64x2 and', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA));
+  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.int64x2.and(m,n);  // and
+  var p = SIMD.int32x4.fromInt64x2Bits(o);
+  equal(0x0, SIMD.int32x4.extractLane(p, 0));
+  equal(0x0, SIMD.int32x4.extractLane(p, 1));
+  equal(0x0, SIMD.int32x4.extractLane(p, 2));
+  equal(0x0, SIMD.int32x4.extractLane(p, 3));
+  equal(false, SIMD.int64x2.extractLaneAsBool(o, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(o, 1));
+});
+
+test('int64x2 or', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
+  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.int64x2.or(m,n);  // or
+  var p = SIMD.int32x4.fromInt64x2Bits(o);
+  equal(-1, SIMD.int32x4.extractLane(p, 0));
+  equal(-1, SIMD.int32x4.extractLane(p, 1));
+  equal(-1, SIMD.int32x4.extractLane(p, 2));
+  equal(-1, SIMD.int32x4.extractLane(p, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(o, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(o, 1));
+});
+
+test('int64x2 xor', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
+  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.int64x2.xor(m,n);  // xor
+  var p = SIMD.int32x4.fromInt64x2Bits(o);
+  equal(-1, SIMD.int32x4.extractLane(p, 0));
+  equal(-1, SIMD.int32x4.extractLane(p, 1));
+  equal(-1, SIMD.int32x4.extractLane(p, 2));
+  equal(-1, SIMD.int32x4.extractLane(p, 3));
+  equal(true, SIMD.int64x2.extractLaneAsBool(o, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(o, 1));
+});
+
+test('int64x2 comparisons', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(1000, 2000, 100, 100));
+  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(-2000, 2000, 100, 100));
+  var cmp;
+
+  cmp = SIMD.int64x2.equal(m, n);
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+
+  cmp = SIMD.int64x2.notEqual(m, n);
+  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+});
+
+test('int64x2 load', function() {
+  var a = new Int32Array(16);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 3; i++) {
+    var v = SIMD.int64x2.load(a, i);
+    var w = SIMD.int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.int32x4.extractLane(w, 1));
+    equal(i+2, SIMD.int32x4.extractLane(w, 2));
+    equal(i+3, SIMD.int32x4.extractLane(w, 3));
+  }
+});
+
+test('int64x2 unaligned load', function() {
+  var a = new Int32Array(16);
+  var ai = new Int8Array(a.buffer);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+
+  // Copy the bytes, offset by 1.
+  var b = new Int8Array(ai.length + 1);
+  for (var i = 0; i < ai.length; i++) {
+    b[i + 1] = ai[i];
+  }
+
+  // Load the values unaligned.
+  for (var i = 0; i < a.length - 3; i++) {
+    var v = SIMD.int64x2.load(b, i * 4 + 1);
+    var w = SIMD.int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.int32x4.extractLane(w, 1));
+    equal(i+2, SIMD.int32x4.extractLane(w, 2));
+    equal(i+3, SIMD.int32x4.extractLane(w, 3));
+  }
+});
+
+test('int64x2 load1', function() {
+  var a = new Int32Array(16);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+  for (var i = 0; i < a.length - 1; i++) {
+    var v = SIMD.int64x2.load1(a, i);
+    var w = SIMD.int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.int32x4.extractLane(w, 1));
+    isPositiveZero(SIMD.int32x4.extractLane(w, 2));
+    isPositiveZero(SIMD.int32x4.extractLane(w, 3));
+  }
+});
+
+test('int64x2 unaligned load1', function() {
+  var a = new Int32Array(16);
+  var ai = new Int8Array(a.buffer);
+  for (var i = 0; i < a.length; i++) {
+    a[i] = i;
+  }
+
+  // Copy the bytes, offset by 1.
+  var b = new Int8Array(ai.length + 1);
+  for (var i = 0; i < ai.length; i++) {
+    b[i + 1] = ai[i];
+  }
+
+  // Copy the values unaligned.
+  for (var i = 0; i < a.length - 1; i++) {
+    var v = SIMD.int64x2.load1(b, i * 4 + 1);
+    var w = SIMD.int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.int32x4.extractLane(w, 1));
+    isPositiveZero(SIMD.int32x4.extractLane(w, 2));
+    isPositiveZero(SIMD.int32x4.extractLane(w, 3));
+  }
+});
+
+test('int64x2 store', function() {
+  var a = new Int32Array(12);
+  SIMD.int64x2.store(a, 0, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3)));
+  SIMD.int64x2.store(a, 4, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, 6, 7)));
+  SIMD.int64x2.store(a, 8, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(8, 9, 10, 11)));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int64x2 unaligned store', function() {
+  var c = new Int8Array(48 + 1);
+  SIMD.int64x2.store(c, 0 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3)));
+  SIMD.int64x2.store(c, 16 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, 6, 7)));
+  SIMD.int64x2.store(c, 32 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(8, 9, 10, 11)));
+
+  // Copy the bytes, offset by 1.
+  var b = new Int8Array(c.length - 1);
+  for (var i = 1; i < c.length; i++) {
+      b[i - 1] = c[i];
+  }
+
+  var a = new Int32Array(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int64x2 store1', function() {
+  var a = new Int32Array(8);
+  SIMD.int64x2.store1(a, 0, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, -1, -1)));
+  SIMD.int64x2.store1(a, 2, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(2, 3, -1, -1)));
+  SIMD.int64x2.store1(a, 4, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, -1, -1)));
+  SIMD.int64x2.store1(a, 6, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(6, 7, -1, -1)));
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int64x2 unaligned store1', function() {
+  var c = new Int8Array(32 + 1);
+  SIMD.int64x2.store1(c, 0 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, -1, -1)));
+  SIMD.int64x2.store1(c, 8 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(2, 3, -1, -1)));
+  SIMD.int64x2.store1(c, 16 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, -1, -1)));
+  SIMD.int64x2.store1(c, 24 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(6, 7, -1, -1)));
+
+  // Copy the bytes, offset by 1.
+  var b = new Int8Array(c.length - 1);
+  for (var i = 1; i < c.length; i++) {
+      b[i - 1] = c[i];
+  }
+
+  var a = new Int32Array(b.buffer);
+  for (var i = 0; i < a.length; i++) {
+    equal(i, a[i]);
+  }
+});
+
+test('int64x2 load exceptions', function () {
+  var a = new Float64Array(8);
+  throws(function () {
+    var f = SIMD.int64x2.load(a, -1);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load(a, 7);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load(a.buffer, 1);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load(a, "a");
+  });
+});
+
+test('int64x2 load1 exceptions', function () {
+  var a = new Float64Array(8);
+  throws(function () {
+    var f = SIMD.int64x2.load1(a, -1);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load1(a, 8);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load1(a.buffer, 1);
+  });
+  throws(function () {
+    var f = SIMD.int64x2.load1(a, "a");
+  });
+});
+
+test('int64x2 store exceptions', function () {
+  var a = new Float64Array(8);
+  var f = SIMD.int64x2(1, 2);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int64x2.store(a, -1, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store(a, 7, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store(a.buffer, 1, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store(a, "a", f);
+  });
+  throws(function () {
+    SIMD.int64x2.store(a, 1, i);
+  });
+});
+
+test('int64x2 store1 exceptions', function () {
+  var a = new Float64Array(8);
+  var f = SIMD.int64x2(1, 2);
+  var i = SIMD.int32x4(1, 2, 3, 4);
+  throws(function () {
+    SIMD.int64x2.store1(a, -1, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store1(a, 8, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store1(a.buffer, 1, f);
+  });
+  throws(function () {
+    SIMD.int64x2.store1(a, "a", f);
+  });
+  throws(function () {
+    SIMD.int64x2.store1(a, 1, i);
+  });
+});
+
 test('int32x4 fromFloat32x4 constructor', function() {
   var m = SIMD.float32x4(1.0, 2.2, 3.6, 4.8);
   var n = SIMD.int32x4.fromFloat32x4(m);
@@ -2098,6 +2408,15 @@ test('int32x4 fromFloat64x2 constructor', function() {
   throws(function() {
     SIMD.int32x4.fromFloat64x2(SIMD.float64x2(NaN, 0));
   });
+});
+
+test('int32x4 fromInt64x2Bits constructor', function() {
+  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3));
+  var n = SIMD.int32x4.fromInt64x2Bits(m);
+  equal(0, SIMD.int32x4.extractLane(n, 0));
+  equal(1, SIMD.int32x4.extractLane(n, 1));
+  equal(2, SIMD.int32x4.extractLane(n, 2));
+  equal(3, SIMD.int32x4.extractLane(n, 3));
 });
 
 test('int32x4 fromFloat32x4Bits constructor', function() {


### PR DESCRIPTION
Following up on #152, adding an int64x2.

This patch series starts by introducing extractLaneAsBool functions for the integer SIMD types. These were discussed earlier and it seemed like there wasn't quite enough motivation for them, but now there's new motivation; int64x2 can't easily have an extractLane because there's no int64 scalar type, but it can have an extractLaneAsBool functions. And extractLaneAsBool is convenient for a few other things anyway.

Then, it adds int64x2, and updates float64x2 selects and comparisons to use it.