### PR TITLE
toString, toLocaleString and valueOf on float32x4 and int32x4

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -362,6 +362,38 @@ if (typeof SIMD.float32x4.fromInt8x16Bits === "undefined") {
   }
 }
 
+if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toString')) {
+  /**
+   * @return {String} a string representing the float32x4.
+   */
+  SIMD.float32x4.prototype.toString = function() {
+    return "float32x4(" +
+      this.x_ + ", " +
+      this.y_ + ", " +
+      this.z_ + ", " +
+      this.w_ + ")"
+  }
+}
+
+if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toLocaleString')) {
+  /**
+   * @return {String} a locale-sensitive string representing the float32x4.
+   */
+  SIMD.float32x4.prototype.toLocaleString = function() {
+    return "float32x4(" +
+      this.x_.toLocaleString() + ", " +
+      this.y_.toLocaleString() + ", " +
+      this.z_.toLocaleString() + ", " +
+      this.w_.toLocaleString() + ")"
+  }
+}
+
+if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'valueOf')) {
+  SIMD.float32x4.prototype.valueOf = function() {
+    throw new TypeError("float32x4 cannot be converted to a number");
+  }
+}
+
 if (typeof SIMD.float64x2 === "undefined") {
   /**
     * Construct a new instance of float64x2 number.
@@ -741,6 +773,38 @@ if (typeof SIMD.int32x4.fromInt8x16Bits === "undefined") {
   SIMD.int32x4.fromInt8x16Bits = function(t) {
     saveInt8x16(t);
     return restoreInt32x4();
+  }
+}
+
+if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toString')) {
+  /**
+   * @return {String} a string representing the float32x4.
+   */
+  SIMD.int32x4.prototype.toString = function() {
+    return "int32x4(" +
+      this.x_ + ", " +
+      this.y_ + ", " +
+      this.z_ + ", " +
+      this.w_ + ")";
+  }
+}
+
+if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toLocaleString')) {
+  /**
+   * @return {String} a locale-sensitive string representing the float32x4.
+   */
+  SIMD.int32x4.prototype.toLocaleString = function() {
+    return "int32x4(" +
+      this.x_.toLocaleString() + ", " +
+      this.y_.toLocaleString() + ", " +
+      this.z_.toLocaleString() + ", " +
+      this.w_.toLocaleString() + ")";
+  }
+}
+
+if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'valueOf')) {
+  SIMD.int32x4.prototype.valueOf = function() {
+    throw new TypeError("int32x4 cannot be converted to a number");
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -38,32 +38,72 @@ function toBool(x) {
   return x < 0;
 }
 
-test('odds and ends', function() {
-    // Not yet specified:
-    //   ==, ===, !=, !==, <=, >=
-    //   conversion to bool via !, ?, etc.:
-    isNaN(Number(SIMD.float32x4(0, 1, 2, 3)));
-    isNaN(+SIMD.float32x4(0, 1, 2, 3));
-    isNaN(-SIMD.float32x4(0, 1, 2, 3));
-    equal(~SIMD.float32x4(0, 1, 2, 3), -1);
-    isNaN(Math.fround(SIMD.float32x4(0, 1, 2, 3)));
-    equal(SIMD.float32x4(0, 1, 2, 3)|0, 0);
-    equal(SIMD.float32x4(0, 1, 2, 3)&0, 0);
-    equal(SIMD.float32x4(0, 1, 2, 3)^0, 0);
-    equal(SIMD.float32x4(0, 1, 2, 3)>>>0, 0);
-    equal(SIMD.float32x4(0, 1, 2, 3)>>0, 0);
-    equal(SIMD.float32x4(0, 1, 2, 3)<<0, 0);
-    equal(typeof (SIMD.float32x4(0, 1, 2, 3) + SIMD.float32x4(4, 5, 6, 7)), "string");
-    isNaN(SIMD.float32x4(0, 1, 2, 3) - SIMD.float32x4(4, 5, 6, 7));
-    isNaN(SIMD.float32x4(0, 1, 2, 3) * SIMD.float32x4(4, 5, 6, 7));
-    isNaN(SIMD.float32x4(0, 1, 2, 3) / SIMD.float32x4(4, 5, 6, 7));
-    isNaN(SIMD.float32x4(0, 1, 2, 3) % SIMD.float32x4(4, 5, 6, 7));
-    equal(SIMD.float32x4(0, 1, 2, 3) < SIMD.float32x4(4, 5, 6, 7), false);
-    equal(SIMD.float32x4(0, 1, 2, 3) > SIMD.float32x4(4, 5, 6, 7), false);
-    equal(typeof (SIMD.float32x4(0, 1, 2, 3).toString()), "string");
+test('float32x4 operators', function() {
+    // Not possible to implement properly in polyfill:
+    //   ==, ===, !=, !==
+    throws(function() {Number(SIMD.float32x4(0, 1, 2, 3))});
+    throws(function() {+SIMD.float32x4(0, 1, 2, 3)});
+    throws(function() {-SIMD.float32x4(0, 1, 2, 3)});
+    throws(function() {~SIMD.float32x4(0, 1, 2, 3), -1});
+    throws(function() {Math.fround(SIMD.float32x4(0, 1, 2, 3))});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)|0});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)&0});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)^0});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)>>>0});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)>>0});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3)<<0});
+    throws(function() {(SIMD.float32x4(0, 1, 2, 3) + SIMD.float32x4(4, 5, 6, 7))});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) - SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) * SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) / SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) % SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) < SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) > SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) <= SIMD.float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.float32x4(0, 1, 2, 3) >= SIMD.float32x4(4, 5, 6, 7)});
+    equal(SIMD.float32x4(0, 1, 2, 3).toString(), "float32x4(0, 1, 2, 3)");
+    equal(SIMD.float32x4(0, 1, 2, 3).toLocaleString(), "float32x4(0, 1, 2, 3)");
     throws(function() { SIMD.float32x4(0, 1, 2, 3)(); });
     equal(SIMD.float32x4(0, 1, 2, 3)[0], undefined);
     equal(SIMD.float32x4(0, 1, 2, 3).a, undefined);
+    equal(!SIMD.float32x4(0, 1, 2, 3), false);
+    equal(!SIMD.float32x4(0, 0, 0, 0), false);
+    equal(SIMD.float32x4(0, 1, 2, 3) ? 1 : 2, 1);
+    equal(SIMD.float32x4(0, 0, 0, 0) ? 1 : 2, 1);
+});
+
+test('int32x4 operators', function() {
+    // Not possible to implement properly in polyfill:
+    //   ==, ===, !=, !==
+    throws(function() {Number(SIMD.int32x4(0, 1, 2, 3))});
+    throws(function() {+SIMD.int32x4(0, 1, 2, 3)});
+    throws(function() {-SIMD.int32x4(0, 1, 2, 3)});
+    throws(function() {~SIMD.int32x4(0, 1, 2, 3), -1});
+    throws(function() {Math.fround(SIMD.int32x4(0, 1, 2, 3))});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)|0});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)&0});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)^0});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)>>>0});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)>>0});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3)<<0});
+    throws(function() {(SIMD.int32x4(0, 1, 2, 3) + SIMD.int32x4(4, 5, 6, 7))});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) - SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) * SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) / SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) % SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) < SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) > SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) <= SIMD.int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.int32x4(0, 1, 2, 3) >= SIMD.int32x4(4, 5, 6, 7)});
+    equal(SIMD.int32x4(0, 1, 2, 3).toString(), "int32x4(0, 1, 2, 3)");
+    equal(SIMD.int32x4(0, 1, 2, 3).toLocaleString(), "int32x4(0, 1, 2, 3)");
+    throws(function() { SIMD.int32x4(0, 1, 2, 3)(); });
+    equal(SIMD.int32x4(0, 1, 2, 3)[0], undefined);
+    equal(SIMD.int32x4(0, 1, 2, 3).a, undefined);
+    equal(!SIMD.int32x4(0, 1, 2, 3), false);
+    equal(!SIMD.int32x4(0, 0, 0, 0), false);
+    equal(SIMD.int32x4(0, 1, 2, 3) ? 1 : 2, 1);
+    equal(SIMD.int32x4(0, 0, 0, 0) ? 1 : 2, 1);
 });
 
 test('float32x4 constructor', function() {


### PR DESCRIPTION
This patch implements toString and toValueString on a couple SIMD
types with semantics that match the spec and the current Firefox
implementation. It also throws on calls to valueOf, which cause
an exception to be thrown on math operations, which should help
avoid programmer error and make normal usage more closely resemble
that of the SIMD spec (even if, in the SIMD spec, valueOf returns
the same primitive value).

A follow-on patch should extend these changes to other SIMD types.