### PR TITLE
Upper-case all SIMD type names, e.g., SIMD.float32x4 -> SIMD.Float32x4

### DIFF
--- a/src/benchmarks/aobench.js
+++ b/src/benchmarks/aobench.js
@@ -278,50 +278,50 @@
     orthoBasis(basis, isect.n);
 
     var occlusion = 0;
-    var occlusionx4 = SIMD.float32x4.splat(0.0);
+    var occlusionx4 = SIMD.Float32x4.splat(0.0);
 
     for (j = 0; j < ntheta; j++) {
       for (i = 0; i < nphi; i += 4) {
-        var theta = SIMD.float32x4.sqrt(SIMD.float32x4(rands1[j * ntheta + i], rands1[j * ntheta + i + 1], rands1[j * ntheta + i + 2], rands1[j * ntheta + i + 3]));
+        var theta = SIMD.Float32x4.sqrt(SIMD.Float32x4(rands1[j * ntheta + i], rands1[j * ntheta + i + 1], rands1[j * ntheta + i + 2], rands1[j * ntheta + i + 3]));
         var phi0 = 2 * Math.PI * rands2[j * ntheta + i];
         var phi1 = 2 * Math.PI * rands2[j * ntheta + i + 1];
         var phi2 = 2 * Math.PI * rands2[j * ntheta + i + 2];
         var phi3 = 2 * Math.PI * rands2[j * ntheta + i + 3];
-        var sinphi = SIMD.float32x4(Math.sin(phi0), Math.sin(phi1), Math.sin(phi2), Math.sin(phi3));
-        var cosphi = SIMD.float32x4(Math.cos(phi0), Math.cos(phi1), Math.cos(phi2), Math.cos(phi3));
+        var sinphi = SIMD.Float32x4(Math.sin(phi0), Math.sin(phi1), Math.sin(phi2), Math.sin(phi3));
+        var cosphi = SIMD.Float32x4(Math.cos(phi0), Math.cos(phi1), Math.cos(phi2), Math.cos(phi3));
 
-        var x = SIMD.float32x4.mul(cosphi, theta);
-        var y = SIMD.float32x4.mul(sinphi, theta);
-        var z = SIMD.float32x4.sqrt(SIMD.float32x4.sub(SIMD.float32x4.splat(1), SIMD.float32x4.mul(theta, theta)));
+        var x = SIMD.Float32x4.mul(cosphi, theta);
+        var y = SIMD.Float32x4.mul(sinphi, theta);
+        var z = SIMD.Float32x4.sqrt(SIMD.Float32x4.sub(SIMD.Float32x4.splat(1), SIMD.Float32x4.mul(theta, theta)));
 
-        var dirx = SIMD.float32x4.add(SIMD.float32x4.mul(x, SIMD.float32x4.splat(basis[0].x)),
-                            SIMD.float32x4.add(SIMD.float32x4.mul(y, SIMD.float32x4.splat(basis[1].x)),
-                                     SIMD.float32x4.mul(z, SIMD.float32x4.splat(basis[2].x))));
-        var diry = SIMD.float32x4.add(SIMD.float32x4.mul(x, SIMD.float32x4.splat(basis[0].y)),
-                            SIMD.float32x4.add(SIMD.float32x4.mul(y, SIMD.float32x4.splat(basis[1].y)),
-                                     SIMD.float32x4.mul(z, SIMD.float32x4.splat(basis[2].y))));
-        var dirz = SIMD.float32x4.add(SIMD.float32x4.mul(x, SIMD.float32x4.splat(basis[0].z)),
-                            SIMD.float32x4.add(SIMD.float32x4.mul(y, SIMD.float32x4.splat(basis[1].z)),
-                                     SIMD.float32x4.mul(z, SIMD.float32x4.splat(basis[2].z))));
+        var dirx = SIMD.Float32x4.add(SIMD.Float32x4.mul(x, SIMD.Float32x4.splat(basis[0].x)),
+                            SIMD.Float32x4.add(SIMD.Float32x4.mul(y, SIMD.Float32x4.splat(basis[1].x)),
+                                     SIMD.Float32x4.mul(z, SIMD.Float32x4.splat(basis[2].x))));
+        var diry = SIMD.Float32x4.add(SIMD.Float32x4.mul(x, SIMD.Float32x4.splat(basis[0].y)),
+                            SIMD.Float32x4.add(SIMD.Float32x4.mul(y, SIMD.Float32x4.splat(basis[1].y)),
+                                     SIMD.Float32x4.mul(z, SIMD.Float32x4.splat(basis[2].y))));
+        var dirz = SIMD.Float32x4.add(SIMD.Float32x4.mul(x, SIMD.Float32x4.splat(basis[0].z)),
+                            SIMD.Float32x4.add(SIMD.Float32x4.mul(y, SIMD.Float32x4.splat(basis[1].z)),
+                                     SIMD.Float32x4.mul(z, SIMD.Float32x4.splat(basis[2].z))));
 
-        var orgx = SIMD.float32x4.splat(p.x);
-        var orgy = SIMD.float32x4.splat(p.y);
-        var orgz = SIMD.float32x4.splat(p.z);
+        var orgx = SIMD.Float32x4.splat(p.x);
+        var orgy = SIMD.Float32x4.splat(p.y);
+        var orgz = SIMD.Float32x4.splat(p.z);
 
         var occIsectA = {
-          t: SIMD.float32x4.splat(1e17),
-          hit: SIMD.int32x4.splat(0)
+          t: SIMD.Float32x4.splat(1e17),
+          hit: SIMD.Int32x4.splat(0)
         };
         var occIsectB = {
           p: {
-            x: SIMD.float32x4.splat(0.0),
-            y: SIMD.float32x4.splat(0.0),
-            z: SIMD.float32x4.splat(0.0)
+            x: SIMD.Float32x4.splat(0.0),
+            y: SIMD.Float32x4.splat(0.0),
+            z: SIMD.Float32x4.splat(0.0)
           },
           n: {
-            x: SIMD.float32x4.splat(0.0),
-            y: SIMD.float32x4.splat(0.0),
-            z: SIMD.float32x4.splat(0.0)
+            x: SIMD.Float32x4.splat(0.0),
+            y: SIMD.Float32x4.splat(0.0),
+            z: SIMD.Float32x4.splat(0.0)
           }
         };
 
@@ -330,19 +330,19 @@
         ray_sphere_intersect_simd(occIsectA, occIsectB, dirx, diry, dirz, orgx, orgy, orgz, spheres[2]);
         ray_plane_intersect_simd (occIsectA, occIsectB, dirx, diry, dirz, orgx, orgy, orgz, plane);
 
-        occlusionx4 = SIMD.float32x4.add(
+        occlusionx4 = SIMD.Float32x4.add(
                         occlusionx4,
-                        SIMD.float32x4.fromInt32x4Bits(
-                          SIMD.int32x4.and(
-                            occIsectA.hit, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.splat(1)))));
+                        SIMD.Float32x4.fromInt32x4Bits(
+                          SIMD.Int32x4.and(
+                            occIsectA.hit, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.splat(1)))));
 
       }
     }
 
-    occlusion = SIMD.float32x4.extractLane(occlusionx4, 0) +
-        SIMD.float32x4.extractLane(occlusionx4, 1) +
-        SIMD.float32x4.extractLane(occlusionx4, 2) +
-        SIMD.float32x4.extractLane(occlusionx4, 3);
+    occlusion = SIMD.Float32x4.extractLane(occlusionx4, 0) +
+        SIMD.Float32x4.extractLane(occlusionx4, 1) +
+        SIMD.Float32x4.extractLane(occlusionx4, 2) +
+        SIMD.Float32x4.extractLane(occlusionx4, 3);
 
     occlusion = (ntheta * nphi - occlusion) / (ntheta * nphi);
 
@@ -355,106 +355,106 @@
 
   function ray_sphere_intersect_simd(isectA, isectB, dirx, diry, dirz, orgx, orgy, orgz, sphere) {
 
-    var rsx = SIMD.float32x4.sub(orgx, SIMD.float32x4.splat(sphere.center.x));
-    var rsy = SIMD.float32x4.sub(orgy, SIMD.float32x4.splat(sphere.center.y));
-    var rsz = SIMD.float32x4.sub(orgz, SIMD.float32x4.splat(sphere.center.z));
+    var rsx = SIMD.Float32x4.sub(orgx, SIMD.Float32x4.splat(sphere.center.x));
+    var rsy = SIMD.Float32x4.sub(orgy, SIMD.Float32x4.splat(sphere.center.y));
+    var rsz = SIMD.Float32x4.sub(orgz, SIMD.Float32x4.splat(sphere.center.z));
 
-    var B = SIMD.float32x4.add(SIMD.float32x4.mul(rsx, dirx),
-                     SIMD.float32x4.add(SIMD.float32x4.mul(rsy, diry), SIMD.float32x4.mul(rsz, dirz)));
-    var C = SIMD.float32x4.sub(SIMD.float32x4.add(SIMD.float32x4.mul(rsx, rsx),
-                              SIMD.float32x4.add(SIMD.float32x4.mul(rsy, rsy), SIMD.float32x4.mul(rsz, rsz))),
-                     SIMD.float32x4.splat(sphere.radius * sphere.radius));
-    var D = SIMD.float32x4.sub(SIMD.float32x4.mul(B, B), C);
+    var B = SIMD.Float32x4.add(SIMD.Float32x4.mul(rsx, dirx),
+                     SIMD.Float32x4.add(SIMD.Float32x4.mul(rsy, diry), SIMD.Float32x4.mul(rsz, dirz)));
+    var C = SIMD.Float32x4.sub(SIMD.Float32x4.add(SIMD.Float32x4.mul(rsx, rsx),
+                              SIMD.Float32x4.add(SIMD.Float32x4.mul(rsy, rsy), SIMD.Float32x4.mul(rsz, rsz))),
+                     SIMD.Float32x4.splat(sphere.radius * sphere.radius));
+    var D = SIMD.Float32x4.sub(SIMD.Float32x4.mul(B, B), C);
 
-    var cond1 = SIMD.float32x4.greaterThan(D, SIMD.float32x4.splat(0.0));
+    var cond1 = SIMD.Float32x4.greaterThan(D, SIMD.Float32x4.splat(0.0));
     if (cond1.signMask) {
-      var t2 = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(cond1, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.sub(SIMD.float32x4.neg(B), SIMD.float32x4.sqrt(D)))));
-      var cond2 = SIMD.int32x4.and(SIMD.float32x4.greaterThan(t2, SIMD.float32x4.splat(0.0)),
-                                   SIMD.float32x4.lessThan(t2, isectA.t));
+      var t2 = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(cond1, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.sub(SIMD.Float32x4.neg(B), SIMD.Float32x4.sqrt(D)))));
+      var cond2 = SIMD.Int32x4.and(SIMD.Float32x4.greaterThan(t2, SIMD.Float32x4.splat(0.0)),
+                                   SIMD.Float32x4.lessThan(t2, isectA.t));
       if (cond2.signMask) {
-        isectA.t = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(
-                       SIMD.int32x4.and(
+        isectA.t = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(
+                       SIMD.Int32x4.and(
                          cond2,
-                         SIMD.int32x4.fromFloat32x4Bits(t2)),
-                       SIMD.int32x4.and(
-                         SIMD.int32x4.not(cond2),
-                         SIMD.int32x4.fromFloat32x4Bits(isectA.t))));
-        isectA.hit = SIMD.int32x4.or(cond2, isectA.hit);
-        isectB.p.x = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(dirx, isectA.t)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.x))));
-        isectB.p.y = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(diry, isectA.t)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.y))));
-        isectB.p.z = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(dirz, isectA.t)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.z))));
+                         SIMD.Int32x4.fromFloat32x4Bits(t2)),
+                       SIMD.Int32x4.and(
+                         SIMD.Int32x4.not(cond2),
+                         SIMD.Int32x4.fromFloat32x4Bits(isectA.t))));
+        isectA.hit = SIMD.Int32x4.or(cond2, isectA.hit);
+        isectB.p.x = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(dirx, isectA.t)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.x))));
+        isectB.p.y = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(diry, isectA.t)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.y))));
+        isectB.p.z = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(dirz, isectA.t)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.z))));
 
-        isectB.n.x = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.sub(isectB.p.x, SIMD.float32x4.splat(sphere.center.x)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.x))));
-        isectB.n.y = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.sub(isectB.p.y, SIMD.float32x4.splat(sphere.center.y)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.y))));
-        isectB.n.z = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.sub(isectB.p.z, SIMD.float32x4.splat(sphere.center.z)))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.z))));
+        isectB.n.x = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.sub(isectB.p.x, SIMD.Float32x4.splat(sphere.center.x)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.x))));
+        isectB.n.y = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.sub(isectB.p.y, SIMD.Float32x4.splat(sphere.center.y)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.y))));
+        isectB.n.z = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.sub(isectB.p.z, SIMD.Float32x4.splat(sphere.center.z)))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.z))));
 
-        var lengths = SIMD.float32x4.sqrt(SIMD.float32x4.add(SIMD.float32x4.mul(isectB.n.x, isectB.n.x),
-                                          SIMD.float32x4.add(SIMD.float32x4.mul(isectB.n.y, isectB.n.y),
-                                                             SIMD.float32x4.mul(isectB.n.z, isectB.n.z))));
-        var cond3 = SIMD.float32x4.greaterThan(SIMD.float32x4.abs(lengths), SIMD.float32x4.splat(1e-17));
-        isectB.n.x = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond3, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.div(isectB.n.x, lengths))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond3), SIMD.int32x4.fromFloat32x4Bits(isectB.n.x))));
-        isectB.n.y = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond3, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.div(isectB.n.y, lengths))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond3), SIMD.int32x4.fromFloat32x4Bits(isectB.n.y))));
-        isectB.n.z = SIMD.float32x4.fromInt32x4Bits(
-                       SIMD.int32x4.or(SIMD.int32x4.and(cond3, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.div(isectB.n.z, lengths))),
-                       SIMD.int32x4.and(SIMD.int32x4.not(cond3), SIMD.int32x4.fromFloat32x4Bits(isectB.n.z))));
+        var lengths = SIMD.Float32x4.sqrt(SIMD.Float32x4.add(SIMD.Float32x4.mul(isectB.n.x, isectB.n.x),
+                                          SIMD.Float32x4.add(SIMD.Float32x4.mul(isectB.n.y, isectB.n.y),
+                                                             SIMD.Float32x4.mul(isectB.n.z, isectB.n.z))));
+        var cond3 = SIMD.Float32x4.greaterThan(SIMD.Float32x4.abs(lengths), SIMD.Float32x4.splat(1e-17));
+        isectB.n.x = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond3, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.div(isectB.n.x, lengths))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond3), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.x))));
+        isectB.n.y = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond3, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.div(isectB.n.y, lengths))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond3), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.y))));
+        isectB.n.z = SIMD.Float32x4.fromInt32x4Bits(
+                       SIMD.Int32x4.or(SIMD.Int32x4.and(cond3, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.div(isectB.n.z, lengths))),
+                       SIMD.Int32x4.and(SIMD.Int32x4.not(cond3), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.z))));
       }
     }
   }
 
   function ray_plane_intersect_simd(isectA, isectB, dirx, diry, dirz, orgx, orgy, orgz, plane) {
-    var d = SIMD.float32x4.neg(SIMD.float32x4.add(SIMD.float32x4.mul(SIMD.float32x4.splat(plane.p.x), SIMD.float32x4.splat(plane.n.x)),
-                               SIMD.float32x4.add(SIMD.float32x4.mul(SIMD.float32x4.splat(plane.p.y), SIMD.float32x4.splat(plane.n.y)),
-                                        SIMD.float32x4.mul(SIMD.float32x4.splat(plane.p.z), SIMD.float32x4.splat(plane.n.z)))));
-    var v = SIMD.float32x4.add(SIMD.float32x4.mul(dirx, SIMD.float32x4.splat(plane.n.x)),
-                     SIMD.float32x4.add(SIMD.float32x4.mul(diry, SIMD.float32x4.splat(plane.n.y)),
-                              SIMD.float32x4.mul(dirz, SIMD.float32x4.splat(plane.n.z))));
+    var d = SIMD.Float32x4.neg(SIMD.Float32x4.add(SIMD.Float32x4.mul(SIMD.Float32x4.splat(plane.p.x), SIMD.Float32x4.splat(plane.n.x)),
+                               SIMD.Float32x4.add(SIMD.Float32x4.mul(SIMD.Float32x4.splat(plane.p.y), SIMD.Float32x4.splat(plane.n.y)),
+                                        SIMD.Float32x4.mul(SIMD.Float32x4.splat(plane.p.z), SIMD.Float32x4.splat(plane.n.z)))));
+    var v = SIMD.Float32x4.add(SIMD.Float32x4.mul(dirx, SIMD.Float32x4.splat(plane.n.x)),
+                     SIMD.Float32x4.add(SIMD.Float32x4.mul(diry, SIMD.Float32x4.splat(plane.n.y)),
+                              SIMD.Float32x4.mul(dirz, SIMD.Float32x4.splat(plane.n.z))));
 
-    var cond1 = SIMD.float32x4.greaterThan(SIMD.float32x4.abs(v), SIMD.float32x4.splat(1e-17));
-    var dp = SIMD.float32x4.add(SIMD.float32x4.mul(orgx, SIMD.float32x4.splat(plane.n.x)),
-                      SIMD.float32x4.add(SIMD.float32x4.mul(orgy, SIMD.float32x4.splat(plane.n.y)),
-                               SIMD.float32x4.mul(orgz, SIMD.float32x4.splat(plane.n.z))));
-    var t2 = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(cond1, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.div(SIMD.float32x4.neg(SIMD.float32x4.add(dp, d)), v))));
-    var cond2 = SIMD.int32x4.and(SIMD.float32x4.greaterThan(t2, SIMD.float32x4.splat(0.0)), SIMD.float32x4.lessThan(t2, isectA.t));
+    var cond1 = SIMD.Float32x4.greaterThan(SIMD.Float32x4.abs(v), SIMD.Float32x4.splat(1e-17));
+    var dp = SIMD.Float32x4.add(SIMD.Float32x4.mul(orgx, SIMD.Float32x4.splat(plane.n.x)),
+                      SIMD.Float32x4.add(SIMD.Float32x4.mul(orgy, SIMD.Float32x4.splat(plane.n.y)),
+                               SIMD.Float32x4.mul(orgz, SIMD.Float32x4.splat(plane.n.z))));
+    var t2 = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(cond1, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.div(SIMD.Float32x4.neg(SIMD.Float32x4.add(dp, d)), v))));
+    var cond2 = SIMD.Int32x4.and(SIMD.Float32x4.greaterThan(t2, SIMD.Float32x4.splat(0.0)), SIMD.Float32x4.lessThan(t2, isectA.t));
     if (cond2.signMask) {
-      isectA.t = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(t2)),
-                                             SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectA.t))));
-      isectA.hit = SIMD.int32x4.or(cond2, isectA.hit);
-      isectB.p.x = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(dirx, isectA.t)))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.x))));
-      isectB.p.y = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(diry, isectA.t)))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.y))));
-      isectB.p.z = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.add(orgx, SIMD.float32x4.mul(dirz, isectA.t)))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.p.z))));
+      isectA.t = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(t2)),
+                                             SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectA.t))));
+      isectA.hit = SIMD.Int32x4.or(cond2, isectA.hit);
+      isectB.p.x = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(dirx, isectA.t)))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.x))));
+      isectB.p.y = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(diry, isectA.t)))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.y))));
+      isectB.p.z = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.add(orgx, SIMD.Float32x4.mul(dirz, isectA.t)))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.p.z))));
 
-      isectB.n.x = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(float32x4.splat(plane.n.x))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.x))));
-      isectB.n.y = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(float32x4.splat(plane.n.y))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.y))));
-      isectB.n.z = SIMD.float32x4.fromInt32x4Bits(
-                     SIMD.int32x4.or(SIMD.int32x4.and(cond2, SIMD.int32x4.fromFloat32x4Bits(float32x4.splat(plane.n.z))),
-                     SIMD.int32x4.and(SIMD.int32x4.not(cond2), SIMD.int32x4.fromFloat32x4Bits(isectB.n.z))));
+      isectB.n.x = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(Float32x4.splat(plane.n.x))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.x))));
+      isectB.n.y = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(Float32x4.splat(plane.n.y))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.y))));
+      isectB.n.z = SIMD.Float32x4.fromInt32x4Bits(
+                     SIMD.Int32x4.or(SIMD.Int32x4.and(cond2, SIMD.Int32x4.fromFloat32x4Bits(Float32x4.splat(plane.n.z))),
+                     SIMD.Int32x4.and(SIMD.Int32x4.not(cond2), SIMD.Int32x4.fromFloat32x4Bits(isectB.n.z))));
     }
   }
 

--- a/src/benchmarks/averageFloat32x4.js
+++ b/src/benchmarks/averageFloat32x4.js
@@ -52,15 +52,15 @@
   function simdAverage(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.float32x4.splat(0.0);
+      var sum4 = SIMD.Float32x4.splat(0.0);
       for (var j = 0; j < a_length; j += 4) {
-        sum4 = SIMD.float32x4.add(sum4, SIMD.float32x4.load(a, j));
+        sum4 = SIMD.Float32x4.add(sum4, SIMD.Float32x4.load(a, j));
       }
     }
-    return (SIMD.float32x4.extractLane(sum4, 0) +
-        SIMD.float32x4.extractLane(sum4, 1) +
-        SIMD.float32x4.extractLane(sum4, 2) +
-        SIMD.float32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Float32x4.extractLane(sum4, 0) +
+        SIMD.Float32x4.extractLane(sum4, 1) +
+        SIMD.Float32x4.extractLane(sum4, 2) +
+        SIMD.Float32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat32x4LoadFromInt8Array.js
+++ b/src/benchmarks/averageFloat32x4LoadFromInt8Array.js
@@ -52,15 +52,15 @@
 
   function simdAverage(n) {
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.float32x4.splat(0.0);
+      var sum4 = SIMD.Float32x4.splat(0.0);
       for (var j = 0; j < a.length / 4; ++j) {
-        sum4 = SIMD.float32x4.add(sum4, SIMD.float32x4.load(b, j << 4));
+        sum4 = SIMD.Float32x4.add(sum4, SIMD.Float32x4.load(b, j << 4));
       }
     }
-    return (SIMD.float32x4.extractLane(sum4, 0) +
-        SIMD.float32x4.extractLane(sum4, 1) +
-        SIMD.float32x4.extractLane(sum4, 2) +
-        SIMD.float32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Float32x4.extractLane(sum4, 0) +
+        SIMD.Float32x4.extractLane(sum4, 1) +
+        SIMD.Float32x4.extractLane(sum4, 2) +
+        SIMD.Float32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat32x4LoadX.js
+++ b/src/benchmarks/averageFloat32x4LoadX.js
@@ -55,15 +55,15 @@
   function simdAverageLoad(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.float32x4.splat(0.0);
+      var sum4 = SIMD.Float32x4.splat(0.0);
       for (var j = 0; j < a_length; ++j) {
-        sum4 = SIMD.float32x4.add(sum4, SIMD.float32x4.load1(a, j));
+        sum4 = SIMD.Float32x4.add(sum4, SIMD.Float32x4.load1(a, j));
       }
     }
-    return (SIMD.float32x4.extractLane(sum4, 0) +
-        SIMD.float32x4.extractLane(sum4, 1) +
-        SIMD.float32x4.extractLane(sum4, 2) +
-        SIMD.float32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Float32x4.extractLane(sum4, 0) +
+        SIMD.Float32x4.extractLane(sum4, 1) +
+        SIMD.Float32x4.extractLane(sum4, 2) +
+        SIMD.Float32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat32x4LoadXY.js
+++ b/src/benchmarks/averageFloat32x4LoadXY.js
@@ -55,16 +55,16 @@
   function simdAverageLoad(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.float32x4.splat(0.0);
+      var sum4 = SIMD.Float32x4.splat(0.0);
       for (var j = 0; j < a_length / 2; ++j) {
-        sum4 = SIMD.float32x4.add(sum4, SIMD.float32x4.load2(a, j << 1));
-        //SIMD.float32x4.store(a1, j << 2, sum4);
+        sum4 = SIMD.Float32x4.add(sum4, SIMD.Float32x4.load2(a, j << 1));
+        //SIMD.Float32x4.store(a1, j << 2, sum4);
       }
     }
-    return (SIMD.float32x4.extractLane(sum4, 0) +
-        SIMD.float32x4.extractLane(sum4, 1) +
-        SIMD.float32x4.extractLane(sum4, 2) +
-        SIMD.float32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Float32x4.extractLane(sum4, 0) +
+        SIMD.Float32x4.extractLane(sum4, 1) +
+        SIMD.Float32x4.extractLane(sum4, 2) +
+        SIMD.Float32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat32x4LoadXYZ.js
+++ b/src/benchmarks/averageFloat32x4LoadXYZ.js
@@ -55,16 +55,16 @@
   function simdAverageLoad(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.float32x4.splat(0.0);
+      var sum4 = SIMD.Float32x4.splat(0.0);
       for (var j = 0; j < a_length / 3 ; ++j) {
-        sum4 = SIMD.float32x4.add(sum4, SIMD.float32x4.load3(a, j * 3));
-        //SIMD.float32x4.store(a1, j << 2, sum4);
+        sum4 = SIMD.Float32x4.add(sum4, SIMD.Float32x4.load3(a, j * 3));
+        //SIMD.Float32x4.store(a1, j << 2, sum4);
       }
     }
-    return (SIMD.float32x4.extractLane(sum4, 0) +
-        SIMD.float32x4.extractLane(sum4, 1) +
-        SIMD.float32x4.extractLane(sum4, 2) +
-        SIMD.float32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Float32x4.extractLane(sum4, 0) +
+        SIMD.Float32x4.extractLane(sum4, 1) +
+        SIMD.Float32x4.extractLane(sum4, 2) +
+        SIMD.Float32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat64x2.js
+++ b/src/benchmarks/averageFloat64x2.js
@@ -53,13 +53,13 @@
   function simdAverage(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum2 = SIMD.float64x2.splat(0.0);
+      var sum2 = SIMD.Float64x2.splat(0.0);
       for (var j = 0; j < a_length; j += 2) {
-        sum2 = SIMD.float64x2.add(sum2, SIMD.float64x2.load(a, j));
+        sum2 = SIMD.Float64x2.add(sum2, SIMD.Float64x2.load(a, j));
       }
     }
-    return (SIMD.float64x2.extractLane(sum2, 0) +
-        SIMD.float64x2.extractLane(sum2, 1)) / a.length;
+    return (SIMD.Float64x2.extractLane(sum2, 0) +
+        SIMD.Float64x2.extractLane(sum2, 1)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageFloat64x2Load.js
+++ b/src/benchmarks/averageFloat64x2Load.js
@@ -52,13 +52,13 @@
 
   function simdAverage(n) {
     for (var i = 0; i < n; ++i) {
-      var sum2 = SIMD.float64x2.splat(0.0);
+      var sum2 = SIMD.Float64x2.splat(0.0);
       for (var j = 0; j < a.length / 2; ++j) {
-        sum2 = SIMD.float64x2.add(sum2, SIMD.float64x2.load(a, j << 1));
+        sum2 = SIMD.Float64x2.add(sum2, SIMD.Float64x2.load(a, j << 1));
       }
     }
-    return (SIMD.float64x2.extractLane(sum2, 0) +
-        SIMD.float64x2.extractLane(sum2, 1)) / a.length;
+    return (SIMD.Float64x2.extractLane(sum2, 0) +
+        SIMD.Float64x2.extractLane(sum2, 1)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/averageInt32x4Load.js
+++ b/src/benchmarks/averageInt32x4Load.js
@@ -55,15 +55,15 @@
   function simdAverageLoad(n) {
     var a_length = a.length;
     for (var i = 0; i < n; ++i) {
-      var sum4 = SIMD.int32x4.splat(0);
+      var sum4 = SIMD.Int32x4.splat(0);
       for (var j = 0; j < a_length / 4; ++j) {
-        sum4 = SIMD.int32x4.add(sum4, SIMD.int32x4.load(a, j << 2));
+        sum4 = SIMD.Int32x4.add(sum4, SIMD.Int32x4.load(a, j << 2));
       }
     }
-    return (SIMD.int32x4.extractLane(sum4, 0) +
-        SIMD.int32x4.extractLane(sum4, 1) +
-        SIMD.int32x4.extractLane(sum4, 2) +
-        SIMD.int32x4.extractLane(sum4, 3)) / a.length;
+    return (SIMD.Int32x4.extractLane(sum4, 0) +
+        SIMD.Int32x4.extractLane(sum4, 1) +
+        SIMD.Int32x4.extractLane(sum4, 2) +
+        SIMD.Int32x4.extractLane(sum4, 3)) / a.length;
   }
 
 } ());

--- a/src/benchmarks/inverse4x4.js
+++ b/src/benchmarks/inverse4x4.js
@@ -101,118 +101,118 @@
     var det;
 
     // Load the 4 rows
-    var src0 = SIMD.float32x4.load(src, 0);
-    var src1 = SIMD.float32x4.load(src, 4);
-    var src2 = SIMD.float32x4.load(src, 8);
-    var src3 = SIMD.float32x4.load(src, 16);
+    var src0 = SIMD.Float32x4.load(src, 0);
+    var src1 = SIMD.Float32x4.load(src, 4);
+    var src2 = SIMD.Float32x4.load(src, 8);
+    var src3 = SIMD.Float32x4.load(src, 16);
 
     // Transpose the source matrix.  Sort of.  Not a true transpose operation
 
-    tmp1 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-    row1 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-    row0 = SIMD.float32x4.shuffle(tmp1, row1, 0, 2, 4, 6);
-    row1 = SIMD.float32x4.shuffle(row1, tmp1, 1, 3, 5, 7);
+    tmp1 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+    row1 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+    row0 = SIMD.Float32x4.shuffle(tmp1, row1, 0, 2, 4, 6);
+    row1 = SIMD.Float32x4.shuffle(row1, tmp1, 1, 3, 5, 7);
 
-    tmp1 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-    row3 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-    row2 = SIMD.float32x4.shuffle(tmp1, row3, 0, 2, 4, 6);
-    row3 = SIMD.float32x4.shuffle(row3, tmp1, 1, 3, 5, 7);
+    tmp1 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+    row3 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+    row2 = SIMD.Float32x4.shuffle(tmp1, row3, 0, 2, 4, 6);
+    row3 = SIMD.Float32x4.shuffle(row3, tmp1, 1, 3, 5, 7);
 
     // This is a true transposition, but it will lead to an incorrect result
 
-    //tmp1 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-    //tmp2 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-    //row0  = SIMD.float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
-    //row1  = SIMD.float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
+    //tmp1 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+    //tmp2 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+    //row0  = SIMD.Float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
+    //row1  = SIMD.Float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
 
-    //tmp1 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-    //tmp2 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-    //row2  = SIMD.float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
-    //row3  = SIMD.float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
-
-    // ----
-    tmp1   = SIMD.float32x4.mul(row2, row3);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    minor0 = SIMD.float32x4.mul(row1, tmp1);
-    minor1 = SIMD.float32x4.mul(row0, tmp1);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor0 = SIMD.float32x4.sub(SIMD.float32x4.mul(row1, tmp1), minor0);
-    minor1 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor1);
-    minor1 = SIMD.float32x4.swizzle(minor1, 2, 3, 0, 1); // 0x4E = 01001110
+    //tmp1 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+    //tmp2 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+    //row2  = SIMD.Float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
+    //row3  = SIMD.Float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
 
     // ----
-    tmp1   = SIMD.float32x4.mul(row1, row2);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    minor0 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor0);
-    minor3 = SIMD.float32x4.mul(row0, tmp1);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor0 = SIMD.float32x4.sub(minor0, SIMD.float32x4.mul(row3, tmp1));
-    minor3 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor3);
-    minor3 = SIMD.float32x4.swizzle(minor3, 2, 3, 0, 1); // 0x4E = 01001110
+    tmp1   = SIMD.Float32x4.mul(row2, row3);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    minor0 = SIMD.Float32x4.mul(row1, tmp1);
+    minor1 = SIMD.Float32x4.mul(row0, tmp1);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor0 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row1, tmp1), minor0);
+    minor1 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor1);
+    minor1 = SIMD.Float32x4.swizzle(minor1, 2, 3, 0, 1); // 0x4E = 01001110
 
     // ----
-    tmp1   = SIMD.float32x4.mul(SIMD.float32x4.swizzle(row1, 2, 3, 0, 1), row3); // 0x4E = 01001110
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    row2   = SIMD.float32x4.swizzle(row2, 2, 3, 0, 1);  // 0x4E = 01001110
-    minor0 = SIMD.float32x4.add(SIMD.float32x4.mul(row2, tmp1), minor0);
-    minor2 = SIMD.float32x4.mul(row0, tmp1);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor0 = SIMD.float32x4.sub(minor0, SIMD.float32x4.mul(row2, tmp1));
-    minor2 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor2);
-    minor2 = SIMD.float32x4.swizzle(minor2, 2, 3, 0, 1); // 0x4E = 01001110
+    tmp1   = SIMD.Float32x4.mul(row1, row2);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor0);
+    minor3 = SIMD.Float32x4.mul(row0, tmp1);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row3, tmp1));
+    minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor3);
+    minor3 = SIMD.Float32x4.swizzle(minor3, 2, 3, 0, 1); // 0x4E = 01001110
 
     // ----
-    tmp1   = SIMD.float32x4.mul(row0, row1);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    minor2 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor2);
-    minor3 = SIMD.float32x4.sub(SIMD.float32x4.mul(row2, tmp1), minor3);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor2 = SIMD.float32x4.sub(SIMD.float32x4.mul(row3, tmp1), minor2);
-    minor3 = SIMD.float32x4.sub(minor3, SIMD.float32x4.mul(row2, tmp1));
+    tmp1   = SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(row1, 2, 3, 0, 1), row3); // 0x4E = 01001110
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    row2   = SIMD.Float32x4.swizzle(row2, 2, 3, 0, 1);  // 0x4E = 01001110
+    minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor0);
+    minor2 = SIMD.Float32x4.mul(row0, tmp1);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row2, tmp1));
+    minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor2);
+    minor2 = SIMD.Float32x4.swizzle(minor2, 2, 3, 0, 1); // 0x4E = 01001110
 
     // ----
-    tmp1   = SIMD.float32x4.mul(row0, row3);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    minor1 = SIMD.float32x4.sub(minor1, SIMD.float32x4.mul(row2, tmp1));
-    minor2 = SIMD.float32x4.add(SIMD.float32x4.mul(row1, tmp1), minor2);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor1 = SIMD.float32x4.add(SIMD.float32x4.mul(row2, tmp1), minor1);
-    minor2 = SIMD.float32x4.sub(minor2, SIMD.float32x4.mul(row1, tmp1));
+    tmp1   = SIMD.Float32x4.mul(row0, row1);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor2);
+    minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row2, tmp1), minor3);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row3, tmp1), minor2);
+    minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row2, tmp1));
 
     // ----
-    tmp1   = SIMD.float32x4.mul(row0, row2);
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-    minor1 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor1);
-    minor3 = SIMD.float32x4.sub(minor3, SIMD.float32x4.mul(row1, tmp1));
-    tmp1   = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-    minor1 = SIMD.float32x4.sub(minor1, SIMD.float32x4.mul(row3, tmp1));
-    minor3 = SIMD.float32x4.add(SIMD.float32x4.mul(row1, tmp1), minor3);
+    tmp1   = SIMD.Float32x4.mul(row0, row3);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row2, tmp1));
+    minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor2);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor1);
+    minor2 = SIMD.Float32x4.sub(minor2, SIMD.Float32x4.mul(row1, tmp1));
+
+    // ----
+    tmp1   = SIMD.Float32x4.mul(row0, row2);
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+    minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor1);
+    minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row1, tmp1));
+    tmp1   = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+    minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row3, tmp1));
+    minor3 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor3);
 
     // Compute determinant
-    det   = SIMD.float32x4.mul(row0, minor0);
-    det   = SIMD.float32x4.add(SIMD.float32x4.swizzle(det, 2, 3, 0, 1), det); // 0x4E = 01001110
-    det   = SIMD.float32x4.add(SIMD.float32x4.swizzle(det, 1, 0, 3, 2), det); // 0xB1 = 10110001
-    tmp1  = SIMD.float32x4.reciprocalApproximation(det);
-    det   = SIMD.float32x4.sub(SIMD.float32x4.add(tmp1, tmp1), SIMD.float32x4.mul(det, SIMD.float32x4.mul(tmp1, tmp1)));
-    det   = SIMD.float32x4.swizzle(det, 0, 0, 0, 0);
+    det   = SIMD.Float32x4.mul(row0, minor0);
+    det   = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 2, 3, 0, 1), det); // 0x4E = 01001110
+    det   = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 1, 0, 3, 2), det); // 0xB1 = 10110001
+    tmp1  = SIMD.Float32x4.reciprocalApproximation(det);
+    det   = SIMD.Float32x4.sub(SIMD.Float32x4.add(tmp1, tmp1), SIMD.Float32x4.mul(det, SIMD.Float32x4.mul(tmp1, tmp1)));
+    det   = SIMD.Float32x4.swizzle(det, 0, 0, 0, 0);
 
     // These shuffles aren't necessary if the faulty transposition is done
     // up at the top of this function.
-    //minor0 = SIMD.float32x4.swizzle(minor0, 2, 1, 0, 3);
-    //minor1 = SIMD.float32x4.swizzle(minor1, 2, 1, 0, 3);
-    //minor2 = SIMD.float32x4.swizzle(minor2, 2, 1, 0, 3);
-    //minor3 = SIMD.float32x4.swizzle(minor3, 2, 1, 0, 3);
+    //minor0 = SIMD.Float32x4.swizzle(minor0, 2, 1, 0, 3);
+    //minor1 = SIMD.Float32x4.swizzle(minor1, 2, 1, 0, 3);
+    //minor2 = SIMD.Float32x4.swizzle(minor2, 2, 1, 0, 3);
+    //minor3 = SIMD.Float32x4.swizzle(minor3, 2, 1, 0, 3);
 
     // Compute final values by multiplying with 1/det
-    minor0 = SIMD.float32x4.mul(det, minor0);
-    minor1 = SIMD.float32x4.mul(det, minor1);
-    minor2 = SIMD.float32x4.mul(det, minor2);
-    minor3 = SIMD.float32x4.mul(det, minor3);
+    minor0 = SIMD.Float32x4.mul(det, minor0);
+    minor1 = SIMD.Float32x4.mul(det, minor1);
+    minor2 = SIMD.Float32x4.mul(det, minor2);
+    minor3 = SIMD.Float32x4.mul(det, minor3);
 
-    SIMD.float32x4.store(dst, 0,  minor0);
-    SIMD.float32x4.store(dst, 4,  minor1);
-    SIMD.float32x4.store(dst, 8,  minor2);
-    SIMD.float32x4.store(dst, 12, minor3);
+    SIMD.Float32x4.store(dst, 0,  minor0);
+    SIMD.Float32x4.store(dst, 4,  minor1);
+    SIMD.Float32x4.store(dst, 8,  minor2);
+    SIMD.Float32x4.store(dst, 12, minor3);
   }
 
   function nonSimdMatrixInverse() {
@@ -310,118 +310,118 @@
       var det;
 
       // Load the 4 rows
-      var src0 = SIMD.float32x4.load(src, 0);
-      var src1 = SIMD.float32x4.load(src, 4);
-      var src2 = SIMD.float32x4.load(src, 8);
-      var src3 = SIMD.float32x4.load(src, 12);
+      var src0 = SIMD.Float32x4.load(src, 0);
+      var src1 = SIMD.Float32x4.load(src, 4);
+      var src2 = SIMD.Float32x4.load(src, 8);
+      var src3 = SIMD.Float32x4.load(src, 12);
 
       // Transpose the source matrix.  Sort of.  Not a true transpose operation
 
-      tmp1 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-      row1 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-      row0 = SIMD.float32x4.shuffle(tmp1, row1, 0, 2, 4, 6);
-      row1 = SIMD.float32x4.shuffle(row1, tmp1, 1, 3, 5, 7);
+      tmp1 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+      row1 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+      row0 = SIMD.Float32x4.shuffle(tmp1, row1, 0, 2, 4, 6);
+      row1 = SIMD.Float32x4.shuffle(row1, tmp1, 1, 3, 5, 7);
 
-      tmp1 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-      row3 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-      row2 = SIMD.float32x4.shuffle(tmp1, row3, 0, 2, 4, 6);
-      row3 = SIMD.float32x4.shuffle(row3, tmp1, 1, 3, 5, 7);
+      tmp1 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+      row3 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+      row2 = SIMD.Float32x4.shuffle(tmp1, row3, 0, 2, 4, 6);
+      row3 = SIMD.Float32x4.shuffle(row3, tmp1, 1, 3, 5, 7);
 
       // This is a true transposition, but it will lead to an incorrect result
 
-      //tmp1 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-      //tmp2 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-      //row0  = SIMD.float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
-      //row1  = SIMD.float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
+      //tmp1 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+      //tmp2 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+      //row0  = SIMD.Float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
+      //row1  = SIMD.Float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
 
-      //tmp1 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-      //tmp2 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-      //row2  = SIMD.float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
-      //row3  = SIMD.float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
-
-      // ----
-      tmp1 = SIMD.float32x4.mul(row2, row3);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      minor0 = SIMD.float32x4.mul(row1, tmp1);
-      minor1 = SIMD.float32x4.mul(row0, tmp1);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor0 = SIMD.float32x4.sub(SIMD.float32x4.mul(row1, tmp1), minor0);
-      minor1 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor1);
-      minor1 = SIMD.float32x4.swizzle(minor1, 2, 3, 0, 1); // 0x4E = 01001110
+      //tmp1 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+      //tmp2 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+      //row2  = SIMD.Float32x4.shuffle(tmp1, tmp2, 0, 2, 4, 6);
+      //row3  = SIMD.Float32x4.shuffle(tmp1, tmp2, 1, 3, 5, 7);
 
       // ----
-      tmp1 = SIMD.float32x4.mul(row1, row2);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      minor0 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor0);
-      minor3 = SIMD.float32x4.mul(row0, tmp1);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor0 = SIMD.float32x4.sub(minor0, SIMD.float32x4.mul(row3, tmp1));
-      minor3 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor3);
-      minor3 = SIMD.float32x4.swizzle(minor3, 2, 3, 0, 1); // 0x4E = 01001110
+      tmp1 = SIMD.Float32x4.mul(row2, row3);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      minor0 = SIMD.Float32x4.mul(row1, tmp1);
+      minor1 = SIMD.Float32x4.mul(row0, tmp1);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor0 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row1, tmp1), minor0);
+      minor1 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor1);
+      minor1 = SIMD.Float32x4.swizzle(minor1, 2, 3, 0, 1); // 0x4E = 01001110
 
       // ----
-      tmp1 = SIMD.float32x4.mul(SIMD.float32x4.swizzle(row1, 2, 3, 0, 1), row3); // 0x4E = 01001110
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      row2 = SIMD.float32x4.swizzle(row2, 2, 3, 0, 1);  // 0x4E = 01001110
-      minor0 = SIMD.float32x4.add(SIMD.float32x4.mul(row2, tmp1), minor0);
-      minor2 = SIMD.float32x4.mul(row0, tmp1);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor0 = SIMD.float32x4.sub(minor0, SIMD.float32x4.mul(row2, tmp1));
-      minor2 = SIMD.float32x4.sub(SIMD.float32x4.mul(row0, tmp1), minor2);
-      minor2 = SIMD.float32x4.swizzle(minor2, 2, 3, 0, 1); // 0x4E = 01001110
+      tmp1 = SIMD.Float32x4.mul(row1, row2);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor0);
+      minor3 = SIMD.Float32x4.mul(row0, tmp1);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row3, tmp1));
+      minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor3);
+      minor3 = SIMD.Float32x4.swizzle(minor3, 2, 3, 0, 1); // 0x4E = 01001110
 
       // ----
-      tmp1 = SIMD.float32x4.mul(row0, row1);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      minor2 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor2);
-      minor3 = SIMD.float32x4.sub(SIMD.float32x4.mul(row2, tmp1), minor3);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor2 = SIMD.float32x4.sub(SIMD.float32x4.mul(row3, tmp1), minor2);
-      minor3 = SIMD.float32x4.sub(minor3, SIMD.float32x4.mul(row2, tmp1));
+      tmp1 = SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(row1, 2, 3, 0, 1), row3); // 0x4E = 01001110
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      row2 = SIMD.Float32x4.swizzle(row2, 2, 3, 0, 1);  // 0x4E = 01001110
+      minor0 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor0);
+      minor2 = SIMD.Float32x4.mul(row0, tmp1);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor0 = SIMD.Float32x4.sub(minor0, SIMD.Float32x4.mul(row2, tmp1));
+      minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row0, tmp1), minor2);
+      minor2 = SIMD.Float32x4.swizzle(minor2, 2, 3, 0, 1); // 0x4E = 01001110
 
       // ----
-      tmp1 = SIMD.float32x4.mul(row0, row3);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      minor1 = SIMD.float32x4.sub(minor1, SIMD.float32x4.mul(row2, tmp1));
-      minor2 = SIMD.float32x4.add(SIMD.float32x4.mul(row1, tmp1), minor2);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor1 = SIMD.float32x4.add(SIMD.float32x4.mul(row2, tmp1), minor1);
-      minor2 = SIMD.float32x4.sub(minor2, SIMD.float32x4.mul(row1, tmp1));
+      tmp1 = SIMD.Float32x4.mul(row0, row1);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor2);
+      minor3 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row2, tmp1), minor3);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor2 = SIMD.Float32x4.sub(SIMD.Float32x4.mul(row3, tmp1), minor2);
+      minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row2, tmp1));
 
       // ----
-      tmp1 = SIMD.float32x4.mul(row0, row2);
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
-      minor1 = SIMD.float32x4.add(SIMD.float32x4.mul(row3, tmp1), minor1);
-      minor3 = SIMD.float32x4.sub(minor3, SIMD.float32x4.mul(row1, tmp1));
-      tmp1 = SIMD.float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
-      minor1 = SIMD.float32x4.sub(minor1, SIMD.float32x4.mul(row3, tmp1));
-      minor3 = SIMD.float32x4.add(SIMD.float32x4.mul(row1, tmp1), minor3);
+      tmp1 = SIMD.Float32x4.mul(row0, row3);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row2, tmp1));
+      minor2 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor2);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row2, tmp1), minor1);
+      minor2 = SIMD.Float32x4.sub(minor2, SIMD.Float32x4.mul(row1, tmp1));
+
+      // ----
+      tmp1 = SIMD.Float32x4.mul(row0, row2);
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 1, 0, 3, 2); // 0xB1 = 10110001
+      minor1 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row3, tmp1), minor1);
+      minor3 = SIMD.Float32x4.sub(minor3, SIMD.Float32x4.mul(row1, tmp1));
+      tmp1 = SIMD.Float32x4.swizzle(tmp1, 2, 3, 0, 1); // 0x4E = 01001110
+      minor1 = SIMD.Float32x4.sub(minor1, SIMD.Float32x4.mul(row3, tmp1));
+      minor3 = SIMD.Float32x4.add(SIMD.Float32x4.mul(row1, tmp1), minor3);
 
       // Compute determinant
-      det = SIMD.float32x4.mul(row0, minor0);
-      det = SIMD.float32x4.add(SIMD.float32x4.swizzle(det, 2, 3, 0, 1), det); // 0x4E = 01001110
-      det = SIMD.float32x4.add(SIMD.float32x4.swizzle(det, 1, 0, 3, 2), det); // 0xB1 = 10110001
-      tmp1 = SIMD.float32x4.reciprocalApproximation(det);
-      det = SIMD.float32x4.sub(SIMD.float32x4.add(tmp1, tmp1), SIMD.float32x4.mul(det, SIMD.float32x4.mul(tmp1, tmp1)));
-      det = SIMD.float32x4.swizzle(det, 0, 0, 0, 0);
+      det = SIMD.Float32x4.mul(row0, minor0);
+      det = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 2, 3, 0, 1), det); // 0x4E = 01001110
+      det = SIMD.Float32x4.add(SIMD.Float32x4.swizzle(det, 1, 0, 3, 2), det); // 0xB1 = 10110001
+      tmp1 = SIMD.Float32x4.reciprocalApproximation(det);
+      det = SIMD.Float32x4.sub(SIMD.Float32x4.add(tmp1, tmp1), SIMD.Float32x4.mul(det, SIMD.Float32x4.mul(tmp1, tmp1)));
+      det = SIMD.Float32x4.swizzle(det, 0, 0, 0, 0);
 
       // These shuffles aren't necessary if the faulty transposition is done
       // up at the top of this function.
-      //minor0 = SIMD.float32x4.swizzle(minor0, 2, 1, 0, 3);
-      //minor1 = SIMD.float32x4.swizzle(minor1, 2, 1, 0, 3);
-      //minor2 = SIMD.float32x4.swizzle(minor2, 2, 1, 0, 3);
-      //minor3 = SIMD.float32x4.swizzle(minor3, 2, 1, 0, 3);
+      //minor0 = SIMD.Float32x4.swizzle(minor0, 2, 1, 0, 3);
+      //minor1 = SIMD.Float32x4.swizzle(minor1, 2, 1, 0, 3);
+      //minor2 = SIMD.Float32x4.swizzle(minor2, 2, 1, 0, 3);
+      //minor3 = SIMD.Float32x4.swizzle(minor3, 2, 1, 0, 3);
 
       // Compute final values by multiplying with 1/det
-      minor0 = SIMD.float32x4.mul(det, minor0);
-      minor1 = SIMD.float32x4.mul(det, minor1);
-      minor2 = SIMD.float32x4.mul(det, minor2);
-      minor3 = SIMD.float32x4.mul(det, minor3);
+      minor0 = SIMD.Float32x4.mul(det, minor0);
+      minor1 = SIMD.Float32x4.mul(det, minor1);
+      minor2 = SIMD.Float32x4.mul(det, minor2);
+      minor3 = SIMD.Float32x4.mul(det, minor3);
 
-      SIMD.float32x4.store(dst, 0,  minor0);
-      SIMD.float32x4.store(dst, 4,  minor1);
-      SIMD.float32x4.store(dst, 8,  minor2);
-      SIMD.float32x4.store(dst, 12, minor3);
+      SIMD.Float32x4.store(dst, 0,  minor0);
+      SIMD.Float32x4.store(dst, 4,  minor1);
+      SIMD.Float32x4.store(dst, 8,  minor2);
+      SIMD.Float32x4.store(dst, 12, minor3);
     }
   }
 

--- a/src/benchmarks/mandelbrot.js
+++ b/src/benchmarks/mandelbrot.js
@@ -15,18 +15,18 @@
   // Hook up to the harness
   benchmarks.add (new Benchmark (kernelConfig));
 
-  function float32x4ToString (f4) {
-    return "[" + SIMD.float32x4.extractLane(f4, 0) + "," +
-        SIMD.float32x4.extractLane(f4, 1) + "," +
-        SIMD.float32x4.extractLane(f4, 2) + "," +
-        SIMD.float32x4.extractLane(f4, 3) + "]";
+  function Float32x4ToString (f4) {
+    return "[" + SIMD.Float32x4.extractLane(f4, 0) + "," +
+        SIMD.Float32x4.extractLane(f4, 1) + "," +
+        SIMD.Float32x4.extractLane(f4, 2) + "," +
+        SIMD.Float32x4.extractLane(f4, 3) + "]";
   }
 
-  function int32x4ToString (i4) {
-    return "[" + SIMD.int32x4.extractLane(i4, 0) + "," +
-        SIMD.int32x4.extractLane(i4, 1) + "," +
-        SIMD.int32x4.extractLane(i4, 2) + "," +
-        SIMD.int32x4.extractLane(i4, 3) + "]";
+  function Int32x4ToString (i4) {
+    return "[" + SIMD.Int32x4.extractLane(i4, 0) + "," +
+        SIMD.Int32x4.extractLane(i4, 1) + "," +
+        SIMD.Int32x4.extractLane(i4, 2) + "," +
+        SIMD.Int32x4.extractLane(i4, 3) + "]";
   }
 
   function mandelx1(c_re, c_im, max_iterations) {
@@ -50,26 +50,26 @@
   function mandelx4(c_re4, c_im4, max_iterations) {
     var z_re4  = c_re4;
     var z_im4  = c_im4;
-    var four4  = SIMD.float32x4.splat (4.0);
-    var two4   = SIMD.float32x4.splat (2.0);
-    var count4 = SIMD.int32x4.splat (0);
-    var one4   = SIMD.int32x4.splat (1);
+    var four4  = SIMD.Float32x4.splat (4.0);
+    var two4   = SIMD.Float32x4.splat (2.0);
+    var count4 = SIMD.Int32x4.splat (0);
+    var one4   = SIMD.Int32x4.splat (1);
 
     for (var i = 0; i < max_iterations; ++i) {
-      var z_re24 = SIMD.float32x4.mul (z_re4, z_re4);
-      var z_im24 = SIMD.float32x4.mul (z_im4, z_im4);
+      var z_re24 = SIMD.Float32x4.mul (z_re4, z_re4);
+      var z_im24 = SIMD.Float32x4.mul (z_im4, z_im4);
 
-      var mi4    = SIMD.float32x4.lessThanOrEqual (SIMD.float32x4.add (z_re24, z_im24), four4);
+      var mi4    = SIMD.Float32x4.lessThanOrEqual (SIMD.Float32x4.add (z_re24, z_im24), four4);
       // if all 4 values are greater than 4.0, there's no reason to continue
       if (mi4.signMask === 0x00) {
         break;
       }
 
-      var new_re4 = SIMD.float32x4.sub(z_re24, z_im24);
-      var new_im4 = SIMD.float32x4.mul(SIMD.float32x4.mul (two4, z_re4), z_im4);
-      z_re4       = SIMD.float32x4.add(c_re4, new_re4);
-      z_im4       = SIMD.float32x4.add(c_im4, new_im4);
-      count4      = SIMD.int32x4.add(count4, SIMD.int32x4.and (mi4, one4));
+      var new_re4 = SIMD.Float32x4.sub(z_re24, z_im24);
+      var new_im4 = SIMD.Float32x4.mul(SIMD.Float32x4.mul (two4, z_re4), z_im4);
+      z_re4       = SIMD.Float32x4.add(c_re4, new_re4);
+      z_im4       = SIMD.Float32x4.add(c_im4, new_im4);
+      count4      = SIMD.Int32x4.add(count4, SIMD.Int32x4.and (mi4, one4));
     }
     return count4;
   }
@@ -111,13 +111,13 @@
   // SIMD version of the kernel
   function simdMandelbrot (n) {
     var result = new Array (4);
-    var vec0  = SIMD.float32x4.splat (0.01);
+    var vec0  = SIMD.Float32x4.splat (0.01);
     for (var i = 0; i < n; ++i) {
       var r = mandelx4 (vec0, vec0, 100);
-      result [0] = SIMD.int32x4.extractLane(r, 0);
-      result [1] = SIMD.int32x4.extractLane(r, 1);
-      result [2] = SIMD.int32x4.extractLane(r, 2);
-      result [3] = SIMD.int32x4.extractLane(r, 3);
+      result [0] = SIMD.Int32x4.extractLane(r, 0);
+      result [1] = SIMD.Int32x4.extractLane(r, 1);
+      result [2] = SIMD.Int32x4.extractLane(r, 2);
+      result [3] = SIMD.Int32x4.extractLane(r, 3);
     }
     return result;
   }

--- a/src/benchmarks/matrix-multiplication.js
+++ b/src/benchmarks/matrix-multiplication.js
@@ -25,22 +25,22 @@
   var Outx = new Float32Array(16);
 
   function equals(A, b) {
-    return (A[0] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 0), 0)) &&
-           (A[1] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 0), 1)) &&
-           (A[2] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 0), 2)) &&
-           (A[3] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 0), 3)) &&
-           (A[4] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 4), 0)) &&
-           (A[5] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 4), 1)) &&
-           (A[6] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 4), 2)) &&
-           (A[7] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 4), 3)) &&
-           (A[8] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 8), 0)) &&
-           (A[9] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 8), 1)) &&
-           (A[10] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 8), 2)) &&
-           (A[11] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 8), 3)) &&
-           (A[12] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 12), 0)) &&
-           (A[13] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 12), 1)) &&
-           (A[14] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 12), 2)) &&
-           (A[15] == SIMD.float32x4.extractLane(SIMD.float32x4.load(b, 12), 3));
+    return (A[0] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 0), 0)) &&
+           (A[1] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 0), 1)) &&
+           (A[2] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 0), 2)) &&
+           (A[3] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 0), 3)) &&
+           (A[4] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 4), 0)) &&
+           (A[5] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 4), 1)) &&
+           (A[6] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 4), 2)) &&
+           (A[7] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 4), 3)) &&
+           (A[8] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 8), 0)) &&
+           (A[9] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 8), 1)) &&
+           (A[10] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 8), 2)) &&
+           (A[11] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 8), 3)) &&
+           (A[12] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 12), 0)) &&
+           (A[13] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 12), 1)) &&
+           (A[14] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 12), 2)) &&
+           (A[15] == SIMD.Float32x4.extractLane(SIMD.Float32x4.load(b, 12), 3));
   }
 
   function init() {
@@ -54,15 +54,15 @@
     T2[10] = 2.0;
     T2[15] = 2.0;
 
-    SIMD.float32x4.store(T1x, 0,  SIMD.float32x4(1.0, 0.0, 0.0, 0.0));
-    SIMD.float32x4.store(T1x, 4,  SIMD.float32x4(0.0, 1.0, 0.0, 0.0));
-    SIMD.float32x4.store(T1x, 8,  SIMD.float32x4(0.0, 0.0, 1.0, 0.0));
-    SIMD.float32x4.store(T1x, 12, SIMD.float32x4(0.0, 0.0, 0.0, 1.0));
+    SIMD.Float32x4.store(T1x, 0,  SIMD.Float32x4(1.0, 0.0, 0.0, 0.0));
+    SIMD.Float32x4.store(T1x, 4,  SIMD.Float32x4(0.0, 1.0, 0.0, 0.0));
+    SIMD.Float32x4.store(T1x, 8,  SIMD.Float32x4(0.0, 0.0, 1.0, 0.0));
+    SIMD.Float32x4.store(T1x, 12, SIMD.Float32x4(0.0, 0.0, 0.0, 1.0));
 
-    SIMD.float32x4.store(T2x, 0,  SIMD.float32x4(2.0, 0.0, 0.0, 0.0));
-    SIMD.float32x4.store(T2x, 4,  SIMD.float32x4(0.0, 2.0, 0.0, 0.0));
-    SIMD.float32x4.store(T2x, 8,  SIMD.float32x4(0.0, 0.0, 2.0, 0.0));
-    SIMD.float32x4.store(T2x, 12, SIMD.float32x4(0.0, 0.0, 0.0, 2.0));
+    SIMD.Float32x4.store(T2x, 0,  SIMD.Float32x4(2.0, 0.0, 0.0, 0.0));
+    SIMD.Float32x4.store(T2x, 4,  SIMD.Float32x4(0.0, 2.0, 0.0, 0.0));
+    SIMD.Float32x4.store(T2x, 8,  SIMD.Float32x4(0.0, 0.0, 2.0, 0.0));
+    SIMD.Float32x4.store(T2x, 12, SIMD.Float32x4(0.0, 0.0, 0.0, 2.0));
 
     multiply(1);
     simdMultiply(1);
@@ -132,46 +132,46 @@
 
   function simdMultiply(n) {
     for (var i = 0; i < n; i++) {
-      var a0 = SIMD.float32x4.load(T1x, 0);
-      var a1 = SIMD.float32x4.load(T1x, 4);
-      var a2 = SIMD.float32x4.load(T1x, 8);
-      var a3 = SIMD.float32x4.load(T1x, 12);
-      var b0 = SIMD.float32x4.load(T2x, 0);
-      SIMD.float32x4.store(Outx, 0,
-                  SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b0, 0, 0, 0, 0), a0),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b0, 1, 1, 1, 1), a1),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b0, 2, 2, 2, 2), a2),
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b0, 3, 3, 3, 3), a3)))));
-      var b1 = SIMD.float32x4.load(T2x, 4);
-      SIMD.float32x4.store(Outx, 4,
-                  SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b1, 0, 0, 0, 0), a0),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b1, 1, 1, 1, 1), a1),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b1, 2, 2, 2, 2), a2),
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b1, 3, 3, 3, 3), a3)))));
-      var b2 = SIMD.float32x4.load(T2x, 8);
-      SIMD.float32x4.store(Outx, 8,
-                  SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b2, 0, 0, 0, 0), a0),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b2, 1, 1, 1, 1), a1),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b2, 2, 2, 2, 2), a2),
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b2, 3, 3, 3, 3), a3)))));
-      var b3 = SIMD.float32x4.load(T2x, 12);
-      SIMD.float32x4.store(Outx, 12,
-                  SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b3, 0, 0, 0, 0), a0),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b3, 1, 1, 1, 1), a1),
-                    SIMD.float32x4.add(
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b3, 2, 2, 2, 2), a2),
-                      SIMD.float32x4.mul(SIMD.float32x4.swizzle(b3, 3, 3, 3, 3), a3)))));
+      var a0 = SIMD.Float32x4.load(T1x, 0);
+      var a1 = SIMD.Float32x4.load(T1x, 4);
+      var a2 = SIMD.Float32x4.load(T1x, 8);
+      var a3 = SIMD.Float32x4.load(T1x, 12);
+      var b0 = SIMD.Float32x4.load(T2x, 0);
+      SIMD.Float32x4.store(Outx, 0,
+                  SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b0, 0, 0, 0, 0), a0),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b0, 1, 1, 1, 1), a1),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b0, 2, 2, 2, 2), a2),
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b0, 3, 3, 3, 3), a3)))));
+      var b1 = SIMD.Float32x4.load(T2x, 4);
+      SIMD.Float32x4.store(Outx, 4,
+                  SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b1, 0, 0, 0, 0), a0),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b1, 1, 1, 1, 1), a1),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b1, 2, 2, 2, 2), a2),
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b1, 3, 3, 3, 3), a3)))));
+      var b2 = SIMD.Float32x4.load(T2x, 8);
+      SIMD.Float32x4.store(Outx, 8,
+                  SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b2, 0, 0, 0, 0), a0),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b2, 1, 1, 1, 1), a1),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b2, 2, 2, 2, 2), a2),
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b2, 3, 3, 3, 3), a3)))));
+      var b3 = SIMD.Float32x4.load(T2x, 12);
+      SIMD.Float32x4.store(Outx, 12,
+                  SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b3, 0, 0, 0, 0), a0),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b3, 1, 1, 1, 1), a1),
+                    SIMD.Float32x4.add(
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b3, 2, 2, 2, 2), a2),
+                      SIMD.Float32x4.mul(SIMD.Float32x4.swizzle(b3, 3, 3, 3, 3), a3)))));
     }
   }
 

--- a/src/benchmarks/memcpy.js
+++ b/src/benchmarks/memcpy.js
@@ -104,7 +104,7 @@
     var HEAP32 = new global.Int32Array(buffer);
     var HEAPU8 = new global.Uint8Array(buffer);
     var _emscripten_memcpy_big = imp._emscripten_memcpy_big;
-    var i4 = global.SIMD.int32x4;
+    var i4 = global.SIMD.Int32x4;
     var i4load  = i4.load;
     var i4store = i4.store;
 

--- a/src/benchmarks/memset.js
+++ b/src/benchmarks/memset.js
@@ -92,7 +92,7 @@
     var HEAP8 = new global.Int8Array(buffer);
     var HEAP32 = new global.Int32Array(buffer);
     var HEAPU8 = new global.Uint8Array(buffer);
-    var i4 = global.SIMD.int32x4;
+    var i4 = global.SIMD.Int32x4;
     var i4splat = i4.splat;
     var i4store = i4.store;
 

--- a/src/benchmarks/run.js
+++ b/src/benchmarks/run.js
@@ -18,6 +18,7 @@ load ('matrix-multiplication.js');
 load ('transform.js');
 load ('shiftrows.js');
 load ('aobench.js');
+load ('transform.js');
 load ('transpose4x4.js');
 load ('inverse4x4.js');
 load ('sinx4.js');

--- a/src/benchmarks/shiftrows.js
+++ b/src/benchmarks/shiftrows.js
@@ -102,15 +102,15 @@
       shiftRows(state, Nc);
     }
     for (var r = 1; r < 4; ++r) {
-      var rx4 = SIMD.int32x4.load(state, r << 2);
+      var rx4 = SIMD.Int32x4.load(state, r << 2);
       if (r == 1) {
-        SIMD.int32x4.store(state, 4, SIMD.int32x4.swizzle(rx4, 1, 2, 3, 0));
+        SIMD.Int32x4.store(state, 4, SIMD.Int32x4.swizzle(rx4, 1, 2, 3, 0));
       }
       else if (r == 2) {
-        SIMD.int32x4.store(state, 8, SIMD.int32x4.swizzle(rx4, 2, 3, 0, 1));
+        SIMD.Int32x4.store(state, 8, SIMD.Int32x4.swizzle(rx4, 2, 3, 0, 1));
       }
       else { // r == 3
-        SIMD.int32x4.store(state, 12, SIMD.int32x4.swizzle(rx4, 3, 0, 1, 2));
+        SIMD.Int32x4.store(state, 12, SIMD.Int32x4.swizzle(rx4, 3, 0, 1, 2));
       }
     }
   }

--- a/src/benchmarks/sinx4.js
+++ b/src/benchmarks/sinx4.js
@@ -58,50 +58,50 @@
   }
 
   function printFloat32x4(msg, v) {
-    print (msg, SIMD.float32x4.extractLane(v, 0).toFixed(6),
-                SIMD.float32x4.extractLane(v, 1).toFixed(6),
-                SIMD.float32x4.extractLane(v, 2).toFixed(6),
-                SIMD.float32x4.extractLane(v, 3).toFixed(6));
+    print (msg, SIMD.Float32x4.extractLane(v, 0).toFixed(6),
+                SIMD.Float32x4.extractLane(v, 1).toFixed(6),
+                SIMD.Float32x4.extractLane(v, 2).toFixed(6),
+                SIMD.Float32x4.extractLane(v, 3).toFixed(6));
   }
 
   function printInt32x4(msg, v) {
-    print (msg, SIMD.float32x4.extractLane(v, 0),
-                SIMD.float32x4.extractLane(v, 1),
-                SIMD.float32x4.extractLane(v, 2),
-                SIMD.float32x4.extractLane(v, 3));
+    print (msg, SIMD.Float32x4.extractLane(v, 0),
+                SIMD.Float32x4.extractLane(v, 1),
+                SIMD.Float32x4.extractLane(v, 2),
+                SIMD.Float32x4.extractLane(v, 3));
   }
 
   function sinx4Test() {
-    var x = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+    var x = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
     var sinx4 = simdSin(x);
-    print (SIMD.float32x4.extractLane(sinx4, 0),
-           SIMD.float32x4.extractLane(sinx4, 1),
-           SIMD.float32x4.extractLane(sinx4, 2),
-           SIMD.float32x4.extractLane(sinx4, 3));
-    print (Math.sin(SIMD.float32x4.extractLane(x, 0)),
-           Math.sin(SIMD.float32x4.extractLane(x, 1)),
-           Math.sin(SIMD.float32x4.extractLane(x, 2)),
-           Math.sin(SIMD.float32x4.extractLane(x, 3)));
+    print (SIMD.Float32x4.extractLane(sinx4, 0),
+           SIMD.Float32x4.extractLane(sinx4, 1),
+           SIMD.Float32x4.extractLane(sinx4, 2),
+           SIMD.Float32x4.extractLane(sinx4, 3));
+    print (Math.sin(SIMD.Float32x4.extractLane(x, 0)),
+           Math.sin(SIMD.Float32x4.extractLane(x, 1)),
+           Math.sin(SIMD.Float32x4.extractLane(x, 2)),
+           Math.sin(SIMD.Float32x4.extractLane(x, 3)));
   }
 
-  var _ps_sign_mask        = SIMD.int32x4.splat(0x80000000);
-  var _ps_inv_sign_mask    = SIMD.int32x4.not(_ps_sign_mask);
-  var _ps_cephes_FOPI      = SIMD.float32x4.splat(1.27323954473516);
-  var _pi32_1              = SIMD.int32x4.splat(1);
-  var _pi32_inv1           = SIMD.int32x4.not(_pi32_1);
-  var _pi32_4              = SIMD.int32x4.splat(4);
-  var _pi32_2              = SIMD.int32x4.splat(2);
-  var _ps_minus_cephes_DP1 = SIMD.float32x4.splat(-0.78515625);
-  var _ps_minus_cephes_DP2 = SIMD.float32x4.splat(-2.4187564849853515625E-4);
-  var _ps_minus_cephes_DP3 = SIMD.float32x4.splat(-3.77489497744594108E-8);
-  var _ps_coscof_p0        = SIMD.float32x4.splat(2.443315711809948E-5);
-  var _ps_coscof_p1        = SIMD.float32x4.splat(-1.388731625493765E-3);
-  var _ps_coscof_p2        = SIMD.float32x4.splat(4.166664568298827E-2);
-  var _ps_0p5              = SIMD.float32x4.splat(0.5);
-  var _ps_1                = SIMD.float32x4.splat(1.0);
-  var _ps_sincof_p0        = SIMD.float32x4.splat(-1.9515295891E-4);
-  var _ps_sincof_p1        = SIMD.float32x4.splat(8.3321608736E-3);
-  var _ps_sincof_p2        = SIMD.float32x4.splat(-1.6666654611E-1);
+  var _ps_sign_mask        = SIMD.Int32x4.splat(0x80000000);
+  var _ps_inv_sign_mask    = SIMD.Int32x4.not(_ps_sign_mask);
+  var _ps_cephes_FOPI      = SIMD.Float32x4.splat(1.27323954473516);
+  var _pi32_1              = SIMD.Int32x4.splat(1);
+  var _pi32_inv1           = SIMD.Int32x4.not(_pi32_1);
+  var _pi32_4              = SIMD.Int32x4.splat(4);
+  var _pi32_2              = SIMD.Int32x4.splat(2);
+  var _ps_minus_cephes_DP1 = SIMD.Float32x4.splat(-0.78515625);
+  var _ps_minus_cephes_DP2 = SIMD.Float32x4.splat(-2.4187564849853515625E-4);
+  var _ps_minus_cephes_DP3 = SIMD.Float32x4.splat(-3.77489497744594108E-8);
+  var _ps_coscof_p0        = SIMD.Float32x4.splat(2.443315711809948E-5);
+  var _ps_coscof_p1        = SIMD.Float32x4.splat(-1.388731625493765E-3);
+  var _ps_coscof_p2        = SIMD.Float32x4.splat(4.166664568298827E-2);
+  var _ps_0p5              = SIMD.Float32x4.splat(0.5);
+  var _ps_1                = SIMD.Float32x4.splat(1.0);
+  var _ps_sincof_p0        = SIMD.Float32x4.splat(-1.9515295891E-4);
+  var _ps_sincof_p1        = SIMD.Float32x4.splat(8.3321608736E-3);
+  var _ps_sincof_p2        = SIMD.Float32x4.splat(-1.6666654611E-1);
 
   function sinx4 (x) {
     var xmm1;
@@ -119,74 +119,74 @@
     var emm2;
 
     sign_bit = x;
-    x        = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(SIMD.int32x4.fromFloat32x4Bits(x), _ps_inv_sign_mask));
-    sign_bit = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(SIMD.int32x4.fromFloat32x4Bits(sign_bit), _ps_sign_mask));
-    y        = SIMD.float32x4.mul(x, _ps_cephes_FOPI);
+    x        = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(SIMD.Int32x4.fromFloat32x4Bits(x), _ps_inv_sign_mask));
+    sign_bit = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(SIMD.Int32x4.fromFloat32x4Bits(sign_bit), _ps_sign_mask));
+    y        = SIMD.Float32x4.mul(x, _ps_cephes_FOPI);
     //printFloat32x4 ("Probe 6", y);
-    emm2     = SIMD.int32x4.fromFloat32x4(y);
-    emm2     = SIMD.int32x4.add(emm2, _pi32_1);
-    emm2     = SIMD.int32x4.and(emm2, _pi32_inv1);
+    emm2     = SIMD.Int32x4.fromFloat32x4(y);
+    emm2     = SIMD.Int32x4.add(emm2, _pi32_1);
+    emm2     = SIMD.Int32x4.and(emm2, _pi32_inv1);
     //printInt32x4 ("Probe 8", emm2);
-    y        = SIMD.float32x4.fromInt32x4(emm2);
+    y        = SIMD.Float32x4.fromInt32x4(emm2);
     //printFloat32x4 ("Probe 7", y);
-    emm0     = SIMD.int32x4.and(emm2, _pi32_4);
-    emm0     = SIMD.int32x4.shiftLeftByScalar(emm0, 29);
+    emm0     = SIMD.Int32x4.and(emm2, _pi32_4);
+    emm0     = SIMD.Int32x4.shiftLeftByScalar(emm0, 29);
 
-    emm2     = SIMD.int32x4.and(emm2, _pi32_2);
-    emm2     = SIMD.int32x4.equal(emm2, SIMD.int32x4.splat(0));
+    emm2     = SIMD.Int32x4.and(emm2, _pi32_2);
+    emm2     = SIMD.Int32x4.equal(emm2, SIMD.Int32x4.splat(0));
 
-    swap_sign_bit = SIMD.float32x4.fromInt32x4Bits(emm0);
-    poly_mask     = SIMD.float32x4.fromInt32x4Bits(emm2);
-    sign_bit      = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.xor(SIMD.int32x4.fromFloat32x4Bits(sign_bit), SIMD.int32x4.fromFloat32x4Bits(swap_sign_bit)));
+    swap_sign_bit = SIMD.Float32x4.fromInt32x4Bits(emm0);
+    poly_mask     = SIMD.Float32x4.fromInt32x4Bits(emm2);
+    sign_bit      = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.xor(SIMD.Int32x4.fromFloat32x4Bits(sign_bit), SIMD.Int32x4.fromFloat32x4Bits(swap_sign_bit)));
     //printFloat32x4 ("Probe 1", sign_bit);
 
     //printFloat32x4 ("Probe 4", y);
     //printFloat32x4 ("Probe 5", _ps_minus_cephes_DP1);
-    xmm1 = SIMD.float32x4.mul(y, _ps_minus_cephes_DP1);
+    xmm1 = SIMD.Float32x4.mul(y, _ps_minus_cephes_DP1);
     //printFloat32x4 ("Probe 3", xmm1);
-    xmm2 = SIMD.float32x4.mul(y, _ps_minus_cephes_DP2);
-    xmm3 = SIMD.float32x4.mul(y, _ps_minus_cephes_DP3);
-    x    = SIMD.float32x4.add(x, xmm1);
-    x    = SIMD.float32x4.add(x, xmm2);
-    x    = SIMD.float32x4.add(x, xmm3);
+    xmm2 = SIMD.Float32x4.mul(y, _ps_minus_cephes_DP2);
+    xmm3 = SIMD.Float32x4.mul(y, _ps_minus_cephes_DP3);
+    x    = SIMD.Float32x4.add(x, xmm1);
+    x    = SIMD.Float32x4.add(x, xmm2);
+    x    = SIMD.Float32x4.add(x, xmm3);
     //printFloat32x4 ("Probe 2", x);
 
     y    = _ps_coscof_p0;
-    z    = SIMD.float32x4.mul(x, x);
-    y    = SIMD.float32x4.mul(y, z);
-    y    = SIMD.float32x4.add(y, _ps_coscof_p1);
-    y    = SIMD.float32x4.mul(y, z);
-    y    = SIMD.float32x4.add(y, _ps_coscof_p2);
-    y    = SIMD.float32x4.mul(y, z);
-    y    = SIMD.float32x4.mul(y, z);
-    tmp  = SIMD.float32x4.mul(z, _ps_0p5);
-    y    = SIMD.float32x4.sub(y, tmp);
-    y    = SIMD.float32x4.add(y, _ps_1);
+    z    = SIMD.Float32x4.mul(x, x);
+    y    = SIMD.Float32x4.mul(y, z);
+    y    = SIMD.Float32x4.add(y, _ps_coscof_p1);
+    y    = SIMD.Float32x4.mul(y, z);
+    y    = SIMD.Float32x4.add(y, _ps_coscof_p2);
+    y    = SIMD.Float32x4.mul(y, z);
+    y    = SIMD.Float32x4.mul(y, z);
+    tmp  = SIMD.Float32x4.mul(z, _ps_0p5);
+    y    = SIMD.Float32x4.sub(y, tmp);
+    y    = SIMD.Float32x4.add(y, _ps_1);
 
     y2   = _ps_sincof_p0;
     //printFloat32x4 ("Probe 11", y2);
     //printFloat32x4 ("Probe 12", z);
-    y2   = SIMD.float32x4.mul(y2, z);
-    y2   = SIMD.float32x4.add(y2, _ps_sincof_p1);
+    y2   = SIMD.Float32x4.mul(y2, z);
+    y2   = SIMD.Float32x4.add(y2, _ps_sincof_p1);
     //printFloat32x4 ("Probe 13", y2);
-    y2   = SIMD.float32x4.mul(y2, z);
-    y2   = SIMD.float32x4.add(y2, _ps_sincof_p2);
-    y2   = SIMD.float32x4.mul(y2, z);
-    y2   = SIMD.float32x4.mul(y2, x);
-    y2   = SIMD.float32x4.add(y2, x);
+    y2   = SIMD.Float32x4.mul(y2, z);
+    y2   = SIMD.Float32x4.add(y2, _ps_sincof_p2);
+    y2   = SIMD.Float32x4.mul(y2, z);
+    y2   = SIMD.Float32x4.mul(y2, x);
+    y2   = SIMD.Float32x4.add(y2, x);
 
     xmm3 = poly_mask;
-    y2   = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(SIMD.int32x4.fromFloat32x4Bits(xmm3), SIMD.int32x4.fromFloat32x4Bits(y2)));
+    y2   = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(SIMD.Int32x4.fromFloat32x4Bits(xmm3), SIMD.Int32x4.fromFloat32x4Bits(y2)));
     //printFloat32x4 ("Probe 10", y2);
-    y    = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(SIMD.int32x4.not(SIMD.int32x4.fromFloat32x4Bits(xmm3)), SIMD.int32x4.fromFloat32x4Bits(y)));
-    y    = SIMD.float32x4.add(y, y2);
+    y    = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(SIMD.Int32x4.not(SIMD.Int32x4.fromFloat32x4Bits(xmm3)), SIMD.Int32x4.fromFloat32x4Bits(y)));
+    y    = SIMD.Float32x4.add(y, y2);
 
     //printFloat32x4 ("Probe 9", y);
-    y    = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.xor(SIMD.int32x4.fromFloat32x4Bits(y), SIMD.int32x4.fromFloat32x4Bits(sign_bit)));
+    y    = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.xor(SIMD.Int32x4.fromFloat32x4Bits(y), SIMD.Int32x4.fromFloat32x4Bits(sign_bit)));
     return y;
   }
 
-  var simdInput    = SIMD.float32x4 (1.0, 2.0, 3.0, 4.0);
+  var simdInput    = SIMD.Float32x4 (1.0, 2.0, 3.0, 4.0);
   var nonSimdInput = [1.0, 2.0, 3.0, 4.0];
 
   // SIMD version of the kernel
@@ -195,10 +195,10 @@
     for (var i = 0; i < n; ++i) {
       result = sinx4 (simdInput);
     }
-    return [SIMD.float32x4.extractLane(result, 0),
-        SIMD.float32x4.extractLane(result, 1),
-        SIMD.float32x4.extractLane(result, 2),
-        SIMD.float32x4.extractLane(result, 3)];
+    return [SIMD.Float32x4.extractLane(result, 0),
+        SIMD.Float32x4.extractLane(result, 1),
+        SIMD.Float32x4.extractLane(result, 2),
+        SIMD.Float32x4.extractLane(result, 3)];
   }
 
   // Non SIMD version of the kernel

--- a/src/benchmarks/transform.js
+++ b/src/benchmarks/transform.js
@@ -33,17 +33,17 @@
     V[1] = 2.0;
     V[2] = 3.0;
     V[3] = 1.0;
-    SIMD.float32x4.store(Tx, 0,  SIMD.float32x4(1.0, 0.0, 0.0, 0.0));
-    SIMD.float32x4.store(Tx, 4,  SIMD.float32x4(0.0, 1.0, 0.0, 0.0));
-    SIMD.float32x4.store(Tx, 8,  SIMD.float32x4(0.0, 0.0, 1.0, 0.0));
-    SIMD.float32x4.store(Tx, 12, SIMD.float32x4(0.0, 0.0, 0.0, 1.0));
-    SIMD.float32x4.store(Vx, 0, SIMD.float32x4(1.0, 2.0, 3.0, 1.0));
+    SIMD.Float32x4.store(Tx, 0,  SIMD.Float32x4(1.0, 0.0, 0.0, 0.0));
+    SIMD.Float32x4.store(Tx, 4,  SIMD.Float32x4(0.0, 1.0, 0.0, 0.0));
+    SIMD.Float32x4.store(Tx, 8,  SIMD.Float32x4(0.0, 0.0, 1.0, 0.0));
+    SIMD.Float32x4.store(Tx, 12, SIMD.Float32x4(0.0, 0.0, 0.0, 1.0));
+    SIMD.Float32x4.store(Vx, 0, SIMD.Float32x4(1.0, 2.0, 3.0, 1.0));
     simdVertexTransform(1);
     vertexTransform(1);
-    return (SIMD.float32x4.extractLane(SIMD.float32x4.load(Outx, 0), 0) == Out[0]) &&
-        (SIMD.float32x4.extractLane(SIMD.float32x4.load(Outx, 0), 1) == Out[1]) &&
-        (SIMD.float32x4.extractLane(SIMD.float32x4.load(Outx, 0), 2) == Out[2]) &&
-        (SIMD.float32x4.extractLane(SIMD.float32x4.load(Outx, 0), 3) == Out[3]);
+    return (SIMD.Float32x4.extractLane(SIMD.Float32x4.load(Outx, 0), 0) == Out[0]) &&
+        (SIMD.Float32x4.extractLane(SIMD.Float32x4.load(Outx, 0), 1) == Out[1]) &&
+        (SIMD.Float32x4.extractLane(SIMD.Float32x4.load(Outx, 0), 2) == Out[2]) &&
+        (SIMD.Float32x4.extractLane(SIMD.Float32x4.load(Outx, 0), 3) == Out[3]);
   }
 
   function cleanup() {
@@ -81,16 +81,16 @@
 
   function simdVertexTransform(n) {
     for (var i = 0; i < n; i++) {
-      var xxxx = SIMD.float32x4.swizzle(SIMD.float32x4.load(Vx, 0), 0, 0, 0, 0);
-      var z = SIMD.float32x4.splat(0.0);
-      z = SIMD.float32x4.add(z, SIMD.float32x4.mul(xxxx, SIMD.float32x4.load(Tx, 0)));
-      var yyyy = SIMD.float32x4.swizzle(SIMD.float32x4.load(Vx, 0), 1, 1, 1, 1);
-      z = SIMD.float32x4.add(z, SIMD.float32x4.mul(yyyy, SIMD.float32x4.load(Tx, 4)));
-      var zzzz = SIMD.float32x4.swizzle(SIMD.float32x4.load(Vx, 0), 2, 2, 2, 2);
-      z = SIMD.float32x4.add(z, SIMD.float32x4.mul(zzzz, SIMD.float32x4.load(Tx, 8)));
-      var wwww = SIMD.float32x4.swizzle(SIMD.float32x4.load(Vx, 0), 3, 3, 3, 3);
-      z = SIMD.float32x4.add(z, SIMD.float32x4.mul(wwww, SIMD.float32x4.load(Tx, 12)));
-      SIMD.float32x4.store(Outx, 0, z);
+      var xxxx = SIMD.Float32x4.swizzle(SIMD.Float32x4.load(Vx, 0), 0, 0, 0, 0);
+      var z = SIMD.Float32x4.splat(0.0);
+      z = SIMD.Float32x4.add(z, SIMD.Float32x4.mul(xxxx, SIMD.Float32x4.load(Tx, 0)));
+      var yyyy = SIMD.Float32x4.swizzle(SIMD.Float32x4.load(Vx, 0), 1, 1, 1, 1);
+      z = SIMD.Float32x4.add(z, SIMD.Float32x4.mul(yyyy, SIMD.Float32x4.load(Tx, 4)));
+      var zzzz = SIMD.Float32x4.swizzle(SIMD.Float32x4.load(Vx, 0), 2, 2, 2, 2);
+      z = SIMD.Float32x4.add(z, SIMD.Float32x4.mul(zzzz, SIMD.Float32x4.load(Tx, 8)));
+      var wwww = SIMD.Float32x4.swizzle(SIMD.Float32x4.load(Vx, 0), 3, 3, 3, 3);
+      z = SIMD.Float32x4.add(z, SIMD.Float32x4.mul(wwww, SIMD.Float32x4.load(Tx, 12)));
+      SIMD.Float32x4.store(Outx, 0, z);
     }
   }
 

--- a/src/benchmarks/transpose4x4.js
+++ b/src/benchmarks/transpose4x4.js
@@ -21,7 +21,7 @@
   var dst    = new Float32Array(16);
   var tsrc   = new Float32Array(16);
 
-  var sel_ttff = SIMD.int32x4.bool(true, true, false, false);
+  var sel_ttff = SIMD.Int32x4.bool(true, true, false, false);
 
   function initMatrix(matrix, matrixTransposed) {
     for (var r = 0; r < 4; ++r) {
@@ -76,12 +76,12 @@
     return init();
   }
 
-  // SIMD version of the kernel with SIMD.float32x4.shuffle operation
+  // SIMD version of the kernel with SIMD.Float32x4.shuffle operation
   function simdTransposeMix() {
-    var src0     = SIMD.float32x4.load(src, 0);
-    var src1     = SIMD.float32x4.load(src, 4);
-    var src2     = SIMD.float32x4.load(src, 8);
-    var src3     = SIMD.float32x4.load(src, 12);
+    var src0     = SIMD.Float32x4.load(src, 0);
+    var src1     = SIMD.Float32x4.load(src, 4);
+    var src2     = SIMD.Float32x4.load(src, 8);
+    var src3     = SIMD.Float32x4.load(src, 12);
     var dst0;
     var dst1;
     var dst2;
@@ -89,28 +89,28 @@
     var tmp01;
     var tmp23;
 
-    tmp01 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-    tmp23 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-    dst0  = SIMD.float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
-    dst1  = SIMD.float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
+    tmp01 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+    tmp23 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+    dst0  = SIMD.Float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
+    dst1  = SIMD.Float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
 
-    tmp01 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-    tmp23 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-    dst2  = SIMD.float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
-    dst3  = SIMD.float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
+    tmp01 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+    tmp23 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+    dst2  = SIMD.Float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
+    dst3  = SIMD.Float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
 
-    SIMD.float32x4.store(dst, 0,  dst0);
-    SIMD.float32x4.store(dst, 4,  dst1);
-    SIMD.float32x4.store(dst, 8,  dst2);
-    SIMD.float32x4.store(dst, 12, dst3);
+    SIMD.Float32x4.store(dst, 0,  dst0);
+    SIMD.Float32x4.store(dst, 4,  dst1);
+    SIMD.Float32x4.store(dst, 8,  dst2);
+    SIMD.Float32x4.store(dst, 12, dst3);
   }
 
   // SIMD version of the kernel
   function simdTranspose() {
-    var src0     = SIMD.float32x4.load(src, 0);
-    var src1     = SIMD.float32x4.load(src, 4);
-    var src2     = SIMD.float32x4.load(src, 8);
-    var src3     = SIMD.float32x4.load(src, 12);
+    var src0     = SIMD.Float32x4.load(src, 0);
+    var src1     = SIMD.Float32x4.load(src, 4);
+    var src2     = SIMD.Float32x4.load(src, 8);
+    var src3     = SIMD.Float32x4.load(src, 12);
     var dst0;
     var dst1;
     var dst2;
@@ -118,20 +118,20 @@
     var tmp01;
     var tmp23;
 
-    tmp01 = SIMD.float32x4.select(sel_ttff, src0, SIMD.float32x4.swizzle(src1, 0, 0, 0, 1));
-    tmp23 = SIMD.float32x4.select(sel_ttff, src2, SIMD.float32x4.swizzle(src3, 0, 0, 0, 1));
-    dst0  = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(tmp01, 0, 2, 0, 0), SIMD.float32x4.swizzle(tmp23, 0, 0, 0, 2));
-    dst1  = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(tmp01, 1, 3, 0, 0), SIMD.float32x4.swizzle(tmp23, 0, 0, 1, 3));
+    tmp01 = SIMD.Float32x4.select(sel_ttff, src0, SIMD.Float32x4.swizzle(src1, 0, 0, 0, 1));
+    tmp23 = SIMD.Float32x4.select(sel_ttff, src2, SIMD.Float32x4.swizzle(src3, 0, 0, 0, 1));
+    dst0  = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(tmp01, 0, 2, 0, 0), SIMD.Float32x4.swizzle(tmp23, 0, 0, 0, 2));
+    dst1  = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(tmp01, 1, 3, 0, 0), SIMD.Float32x4.swizzle(tmp23, 0, 0, 1, 3));
 
-    tmp01 = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(src0, 2, 3, 0, 0), src1);
-    tmp23 = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(src2, 2, 3, 0, 0), src3);
-    dst2  = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(tmp01, 0, 2, 0, 0), SIMD.float32x4.swizzle(tmp23, 0, 0, 0, 2));
-    dst3  = SIMD.float32x4.select(sel_ttff, SIMD.float32x4.swizzle(tmp01, 1, 3, 0, 0), SIMD.float32x4.swizzle(tmp23, 0, 0, 1, 3));
+    tmp01 = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(src0, 2, 3, 0, 0), src1);
+    tmp23 = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(src2, 2, 3, 0, 0), src3);
+    dst2  = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(tmp01, 0, 2, 0, 0), SIMD.Float32x4.swizzle(tmp23, 0, 0, 0, 2));
+    dst3  = SIMD.Float32x4.select(sel_ttff, SIMD.Float32x4.swizzle(tmp01, 1, 3, 0, 0), SIMD.Float32x4.swizzle(tmp23, 0, 0, 1, 3));
 
-    SIMD.float32x4.store(dst, 0,  dst0);
-    SIMD.float32x4.store(dst, 4,  dst1);
-    SIMD.float32x4.store(dst, 8,  dst2);
-    SIMD.float32x4.store(dst, 12, dst3);
+    SIMD.Float32x4.store(dst, 0,  dst0);
+    SIMD.Float32x4.store(dst, 4,  dst1);
+    SIMD.Float32x4.store(dst, 8,  dst2);
+    SIMD.Float32x4.store(dst, 12, dst3);
   }
 
   // Non SIMD version of the kernel
@@ -156,10 +156,10 @@
 
   function simdTransposeN(n) {
     for (var i = 0; i < n; ++i) {
-      var src0 = SIMD.float32x4.load(src, 0);
-      var src1 = SIMD.float32x4.load(src, 4);
-      var src2 = SIMD.float32x4.load(src, 8);
-      var src3 = SIMD.float32x4.load(src, 12);
+      var src0 = SIMD.Float32x4.load(src, 0);
+      var src1 = SIMD.Float32x4.load(src, 4);
+      var src2 = SIMD.Float32x4.load(src, 8);
+      var src3 = SIMD.Float32x4.load(src, 12);
       var dst0;
       var dst1;
       var dst2;
@@ -167,20 +167,20 @@
       var tmp01;
       var tmp23;
 
-      tmp01 = SIMD.float32x4.shuffle(src0, src1, 0, 1, 4, 5);
-      tmp23 = SIMD.float32x4.shuffle(src2, src3, 0, 1, 4, 5);
-      dst0 = SIMD.float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
-      dst1 = SIMD.float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
+      tmp01 = SIMD.Float32x4.shuffle(src0, src1, 0, 1, 4, 5);
+      tmp23 = SIMD.Float32x4.shuffle(src2, src3, 0, 1, 4, 5);
+      dst0 = SIMD.Float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
+      dst1 = SIMD.Float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
 
-      tmp01 = SIMD.float32x4.shuffle(src0, src1, 2, 3, 6, 7);
-      tmp23 = SIMD.float32x4.shuffle(src2, src3, 2, 3, 6, 7);
-      dst2 = SIMD.float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
-      dst3 = SIMD.float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
+      tmp01 = SIMD.Float32x4.shuffle(src0, src1, 2, 3, 6, 7);
+      tmp23 = SIMD.Float32x4.shuffle(src2, src3, 2, 3, 6, 7);
+      dst2 = SIMD.Float32x4.shuffle(tmp01, tmp23, 0, 2, 4, 6);
+      dst3 = SIMD.Float32x4.shuffle(tmp01, tmp23, 1, 3, 5, 7);
 
-      SIMD.float32x4.store(dst, 0,  dst0);
-      SIMD.float32x4.store(dst, 4,  dst1);
-      SIMD.float32x4.store(dst, 8,  dst2);
-      SIMD.float32x4.store(dst, 12, dst3);
+      SIMD.Float32x4.store(dst, 0,  dst0);
+      SIMD.Float32x4.store(dst, 4,  dst1);
+      SIMD.Float32x4.store(dst, 8,  dst2);
+      SIMD.Float32x4.store(dst, 12, dst3);
     }
   }
 

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -128,100 +128,100 @@ var check32 = checkLaneIndex(32);
 // Save/Restore utilities for implementing bitwise conversions.
 
 function saveFloat64x2(x) {
-  x = SIMD.float64x2.check(x);
-  _f64x2[0] = SIMD.float64x2.extractLane(x, 0);
-  _f64x2[1] = SIMD.float64x2.extractLane(x, 1);
+  x = SIMD.Float64x2.check(x);
+  _f64x2[0] = SIMD.Float64x2.extractLane(x, 0);
+  _f64x2[1] = SIMD.Float64x2.extractLane(x, 1);
 }
 
 function saveFloat32x4(x) {
-  x = SIMD.float32x4.check(x);
-  _f32x4[0] = SIMD.float32x4.extractLane(x, 0);
-  _f32x4[1] = SIMD.float32x4.extractLane(x, 1);
-  _f32x4[2] = SIMD.float32x4.extractLane(x, 2);
-  _f32x4[3] = SIMD.float32x4.extractLane(x, 3);
+  x = SIMD.Float32x4.check(x);
+  _f32x4[0] = SIMD.Float32x4.extractLane(x, 0);
+  _f32x4[1] = SIMD.Float32x4.extractLane(x, 1);
+  _f32x4[2] = SIMD.Float32x4.extractLane(x, 2);
+  _f32x4[3] = SIMD.Float32x4.extractLane(x, 3);
 }
 
 function saveInt32x4(x) {
-  x = SIMD.int32x4.check(x);
-  _i32x4[0] = SIMD.int32x4.extractLane(x, 0);
-  _i32x4[1] = SIMD.int32x4.extractLane(x, 1);
-  _i32x4[2] = SIMD.int32x4.extractLane(x, 2);
-  _i32x4[3] = SIMD.int32x4.extractLane(x, 3);
+  x = SIMD.Int32x4.check(x);
+  _i32x4[0] = SIMD.Int32x4.extractLane(x, 0);
+  _i32x4[1] = SIMD.Int32x4.extractLane(x, 1);
+  _i32x4[2] = SIMD.Int32x4.extractLane(x, 2);
+  _i32x4[3] = SIMD.Int32x4.extractLane(x, 3);
 }
 
 function saveInt16x8(x) {
-  x = SIMD.int16x8.check(x);
-  _i16x8[0] = SIMD.int16x8.extractLane(x, 0);
-  _i16x8[1] = SIMD.int16x8.extractLane(x, 1);
-  _i16x8[2] = SIMD.int16x8.extractLane(x, 2);
-  _i16x8[3] = SIMD.int16x8.extractLane(x, 3);
-  _i16x8[4] = SIMD.int16x8.extractLane(x, 4);
-  _i16x8[5] = SIMD.int16x8.extractLane(x, 5);
-  _i16x8[6] = SIMD.int16x8.extractLane(x, 6);
-  _i16x8[7] = SIMD.int16x8.extractLane(x, 7);
+  x = SIMD.Int16x8.check(x);
+  _i16x8[0] = SIMD.Int16x8.extractLane(x, 0);
+  _i16x8[1] = SIMD.Int16x8.extractLane(x, 1);
+  _i16x8[2] = SIMD.Int16x8.extractLane(x, 2);
+  _i16x8[3] = SIMD.Int16x8.extractLane(x, 3);
+  _i16x8[4] = SIMD.Int16x8.extractLane(x, 4);
+  _i16x8[5] = SIMD.Int16x8.extractLane(x, 5);
+  _i16x8[6] = SIMD.Int16x8.extractLane(x, 6);
+  _i16x8[7] = SIMD.Int16x8.extractLane(x, 7);
 }
 
 function saveInt8x16(x) {
-  x = SIMD.int8x16.check(x);
-  _i8x16[0] = SIMD.int8x16.extractLane(x, 0);
-  _i8x16[1] = SIMD.int8x16.extractLane(x, 1);
-  _i8x16[2] = SIMD.int8x16.extractLane(x, 2);
-  _i8x16[3] = SIMD.int8x16.extractLane(x, 3);
-  _i8x16[4] = SIMD.int8x16.extractLane(x, 4);
-  _i8x16[5] = SIMD.int8x16.extractLane(x, 5);
-  _i8x16[6] = SIMD.int8x16.extractLane(x, 6);
-  _i8x16[7] = SIMD.int8x16.extractLane(x, 7);
-  _i8x16[8] = SIMD.int8x16.extractLane(x, 8);
-  _i8x16[9] = SIMD.int8x16.extractLane(x, 9);
-  _i8x16[10] = SIMD.int8x16.extractLane(x, 10);
-  _i8x16[11] = SIMD.int8x16.extractLane(x, 11);
-  _i8x16[12] = SIMD.int8x16.extractLane(x, 12);
-  _i8x16[13] = SIMD.int8x16.extractLane(x, 13);
-  _i8x16[14] = SIMD.int8x16.extractLane(x, 14);
-  _i8x16[15] = SIMD.int8x16.extractLane(x, 15);
+  x = SIMD.Int8x16.check(x);
+  _i8x16[0] = SIMD.Int8x16.extractLane(x, 0);
+  _i8x16[1] = SIMD.Int8x16.extractLane(x, 1);
+  _i8x16[2] = SIMD.Int8x16.extractLane(x, 2);
+  _i8x16[3] = SIMD.Int8x16.extractLane(x, 3);
+  _i8x16[4] = SIMD.Int8x16.extractLane(x, 4);
+  _i8x16[5] = SIMD.Int8x16.extractLane(x, 5);
+  _i8x16[6] = SIMD.Int8x16.extractLane(x, 6);
+  _i8x16[7] = SIMD.Int8x16.extractLane(x, 7);
+  _i8x16[8] = SIMD.Int8x16.extractLane(x, 8);
+  _i8x16[9] = SIMD.Int8x16.extractLane(x, 9);
+  _i8x16[10] = SIMD.Int8x16.extractLane(x, 10);
+  _i8x16[11] = SIMD.Int8x16.extractLane(x, 11);
+  _i8x16[12] = SIMD.Int8x16.extractLane(x, 12);
+  _i8x16[13] = SIMD.Int8x16.extractLane(x, 13);
+  _i8x16[14] = SIMD.Int8x16.extractLane(x, 14);
+  _i8x16[15] = SIMD.Int8x16.extractLane(x, 15);
 }
 
 function restoreFloat64x2() {
   var alias = _f64x2;
-  return SIMD.float64x2(alias[0], alias[1]);
+  return SIMD.Float64x2(alias[0], alias[1]);
 }
 
 function restoreFloat32x4() {
   var alias = _f32x4;
-  return SIMD.float32x4(alias[0], alias[1], alias[2], alias[3]);
+  return SIMD.Float32x4(alias[0], alias[1], alias[2], alias[3]);
 }
 
 function restoreInt32x4() {
   var alias = _i32x4;
-  return SIMD.int32x4(alias[0], alias[1], alias[2], alias[3]);
+  return SIMD.Int32x4(alias[0], alias[1], alias[2], alias[3]);
 }
 
 function restoreInt16x8() {
   var alias = _i16x8;
-  return SIMD.int16x8(alias[0], alias[1], alias[2], alias[3],
+  return SIMD.Int16x8(alias[0], alias[1], alias[2], alias[3],
                       alias[4], alias[5], alias[6], alias[7]);
 }
 
 function restoreInt8x16() {
   var alias = _i8x16;
-  return SIMD.int8x16(alias[0], alias[1], alias[2], alias[3],
+  return SIMD.Int8x16(alias[0], alias[1], alias[2], alias[3],
                       alias[4], alias[5], alias[6], alias[7],
                       alias[8], alias[9], alias[10], alias[11],
                       alias[12], alias[13], alias[14], alias[15]);
 }
 
-if (typeof SIMD.float32x4 === "undefined") {
+if (typeof SIMD.Float32x4 === "undefined") {
   /**
-    * Construct a new instance of float32x4 number.
+    * Construct a new instance of Float32x4 number.
     * @param {double} value used for x lane.
     * @param {double} value used for y lane.
     * @param {double} value used for z lane.
     * @param {double} value used for w lane.
     * @constructor
     */
-  SIMD.float32x4 = function(x, y, z, w) {
-    if (!(this instanceof SIMD.float32x4)) {
-      return new SIMD.float32x4(x, y, z, w);
+  SIMD.Float32x4 = function(x, y, z, w) {
+    if (!(this instanceof SIMD.Float32x4)) {
+      return new SIMD.Float32x4(x, y, z, w);
     }
 
     this.x_ = truncatef32(x);
@@ -231,14 +231,14 @@ if (typeof SIMD.float32x4 === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.extractLane === "undefined") {
+if (typeof SIMD.Float32x4.extractLane === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {double} The value in lane i of t.
     */
-  SIMD.float32x4.extractLane = function(t, i) {
-    t = SIMD.float32x4.check(t);
+  SIMD.Float32x4.extractLane = function(t, i) {
+    t = SIMD.Float32x4.check(t);
     check4(i);
     switch(i) {
       case 0: return t.x_;
@@ -249,16 +249,16 @@ if (typeof SIMD.float32x4.extractLane === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.replaceLane === "undefined") {
+if (typeof SIMD.Float32x4.replaceLane === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {integer} i Index in concatenation of t for lane i
     * @param {double} value used for lane i.
-    * @return {float32x4} New instance of float32x4 with the values in t and
+    * @return {Float32x4} New instance of Float32x4 with the values in t and
     * lane i replaced with {v}.
     */
-  SIMD.float32x4.replaceLane = function(t, i, v) {
-    t = SIMD.float32x4.check(t);
+  SIMD.Float32x4.replaceLane = function(t, i, v) {
+    t = SIMD.Float32x4.check(t);
     check4(i);
     saveFloat32x4(t);
     _f32x4[i] = v;
@@ -266,108 +266,108 @@ if (typeof SIMD.float32x4.replaceLane === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.check === "undefined") {
+if (typeof SIMD.Float32x4.check === "undefined") {
   /**
-    * Check whether the argument is a float32x4.
-    * @param {float32x4} v An instance of float32x4.
-    * @return {float32x4} The float32x4 instance.
+    * Check whether the argument is a Float32x4.
+    * @param {Float32x4} v An instance of Float32x4.
+    * @return {Float32x4} The Float32x4 instance.
     */
-  SIMD.float32x4.check = function(v) {
-    if (!(v instanceof SIMD.float32x4)) {
-      throw new TypeError("argument is not a float32x4.");
+  SIMD.Float32x4.check = function(v) {
+    if (!(v instanceof SIMD.Float32x4)) {
+      throw new TypeError("argument is not a Float32x4.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.float32x4.splat === "undefined") {
+if (typeof SIMD.Float32x4.splat === "undefined") {
   /**
-    * Construct a new instance of float32x4 number with the same value
+    * Construct a new instance of Float32x4 number with the same value
     * in all lanes.
     * @param {double} value used for all lanes.
     * @constructor
     */
-  SIMD.float32x4.splat = function(s) {
-    return SIMD.float32x4(s, s, s, s);
+  SIMD.Float32x4.splat = function(s) {
+    return SIMD.Float32x4(s, s, s, s);
   }
 }
 
-if (typeof SIMD.float32x4.fromFloat64x2 === "undefined") {
+if (typeof SIMD.Float32x4.fromFloat64x2 === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float32x4} A float32x4 with .x and .y from t
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float32x4} A Float32x4 with .x and .y from t
     */
-  SIMD.float32x4.fromFloat64x2 = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float32x4(SIMD.float64x2.extractLane(t, 0),
-                          SIMD.float64x2.extractLane(t, 1), 0, 0);
+  SIMD.Float32x4.fromFloat64x2 = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float32x4(SIMD.Float64x2.extractLane(t, 0),
+                          SIMD.Float64x2.extractLane(t, 1), 0, 0);
   }
 }
 
-if (typeof SIMD.float32x4.fromInt32x4 === "undefined") {
+if (typeof SIMD.Float32x4.fromInt32x4 === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {float32x4} An integer to float conversion copy of t.
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Float32x4} An integer to float conversion copy of t.
     */
-  SIMD.float32x4.fromInt32x4 = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.float32x4(SIMD.int32x4.extractLane(t, 0),
-                          SIMD.int32x4.extractLane(t, 1),
-                          SIMD.int32x4.extractLane(t, 2),
-                          SIMD.int32x4.extractLane(t, 3));
+  SIMD.Float32x4.fromInt32x4 = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Float32x4(SIMD.Int32x4.extractLane(t, 0),
+                          SIMD.Int32x4.extractLane(t, 1),
+                          SIMD.Int32x4.extractLane(t, 2),
+                          SIMD.Int32x4.extractLane(t, 3));
   }
 }
 
-if (typeof SIMD.float32x4.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromFloat64x2Bits = function(t) {
+  SIMD.Float32x4.fromFloat64x2Bits = function(t) {
     saveFloat64x2(t);
     return restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt32x4Bits === "undefined") {
   /**
-   * @param {int32x4} t An instance of int32x4.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Int32x4} t An instance of Int32x4.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt32x4Bits = function(t) {
+  SIMD.Float32x4.fromInt32x4Bits = function(t) {
     saveInt32x4(t);
     return restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt16x8Bits === "undefined") {
   /**
-   * @param {int16x8} t An instance of int16x8.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Int16x8} t An instance of Int16x8.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt16x8Bits = function(t) {
+  SIMD.Float32x4.fromInt16x8Bits = function(t) {
     saveInt16x8(t);
     return restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt8x16Bits === "undefined") {
   /**
-   * @param {int8x16} t An instance of int8x16.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Int8x16} t An instance of Int8x16.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt8x16Bits = function(t) {
+  SIMD.Float32x4.fromInt8x16Bits = function(t) {
     saveInt8x16(t);
     return restoreFloat32x4();
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toString')) {
+if (!Object.hasOwnProperty(SIMD.Float32x4.prototype, 'toString')) {
   /**
-   * @return {String} a string representing the float32x4.
+   * @return {String} a string representing the Float32x4.
    */
-  SIMD.float32x4.prototype.toString = function() {
-    return "float32x4(" +
+  SIMD.Float32x4.prototype.toString = function() {
+    return "Float32x4(" +
       this.x_ + ", " +
       this.y_ + ", " +
       this.z_ + ", " +
@@ -375,12 +375,12 @@ if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toLocaleString')) {
+if (!Object.hasOwnProperty(SIMD.Float32x4.prototype, 'toLocaleString')) {
   /**
-   * @return {String} a locale-sensitive string representing the float32x4.
+   * @return {String} a locale-sensitive string representing the Float32x4.
    */
-  SIMD.float32x4.prototype.toLocaleString = function() {
-    return "float32x4(" +
+  SIMD.Float32x4.prototype.toLocaleString = function() {
+    return "Float32x4(" +
       this.x_.toLocaleString() + ", " +
       this.y_.toLocaleString() + ", " +
       this.z_.toLocaleString() + ", " +
@@ -388,22 +388,22 @@ if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'toLocaleString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float32x4.prototype, 'valueOf')) {
-  SIMD.float32x4.prototype.valueOf = function() {
-    throw new TypeError("float32x4 cannot be converted to a number");
+if (!Object.hasOwnProperty(SIMD.Float32x4.prototype, 'valueOf')) {
+  SIMD.Float32x4.prototype.valueOf = function() {
+    throw new TypeError("Float32x4 cannot be converted to a number");
   }
 }
 
-if (typeof SIMD.float64x2 === "undefined") {
+if (typeof SIMD.Float64x2 === "undefined") {
   /**
-    * Construct a new instance of float64x2 number.
+    * Construct a new instance of Float64x2 number.
     * @param {double} value used for x lane.
     * @param {double} value used for y lane.
     * @constructor
     */
-  SIMD.float64x2 = function(x, y) {
-    if (!(this instanceof SIMD.float64x2)) {
-      return new SIMD.float64x2(x, y);
+  SIMD.Float64x2 = function(x, y) {
+    if (!(this instanceof SIMD.Float64x2)) {
+      return new SIMD.Float64x2(x, y);
     }
 
     // Use unary + to force coercion to Number.
@@ -412,14 +412,14 @@ if (typeof SIMD.float64x2 === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.extractLane === "undefined") {
+if (typeof SIMD.Float64x2.extractLane === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
+    * @param {Float64x2} t An instance of Float64x2.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {double} The value in lane i of t.
     */
-  SIMD.float64x2.extractLane = function(t, i) {
-    t = SIMD.float64x2.check(t);
+  SIMD.Float64x2.extractLane = function(t, i) {
+    t = SIMD.Float64x2.check(t);
     check2(i);
     switch(i) {
       case 0: return t.x_;
@@ -428,16 +428,16 @@ if (typeof SIMD.float64x2.extractLane === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.replaceLane === "undefined") {
+if (typeof SIMD.Float64x2.replaceLane === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
+    * @param {Float64x2} t An instance of Float64x2.
     * @param {integer} i Index in concatenation of t for lane i
     * @param {double} value used for lane i.
-    * @return {float64x2} New instance of float64x2 with the values in t and
+    * @return {Float64x2} New instance of Float64x2 with the values in t and
     * lane i replaced with {v}.
     */
-  SIMD.float64x2.replaceLane = function(t, i, v) {
-    t = SIMD.float64x2.check(t);
+  SIMD.Float64x2.replaceLane = function(t, i, v) {
+    t = SIMD.Float64x2.check(t);
     check2(i);
     saveFloat64x2(t);
     _f64x2[i] = v;
@@ -445,151 +445,151 @@ if (typeof SIMD.float64x2.replaceLane === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.check === "undefined") {
+if (typeof SIMD.Float64x2.check === "undefined") {
   /**
-    * Check whether the argument is a float64x2.
-    * @param {float64x2} v An instance of float64x2.
-    * @return {float64x2} The float64x2 instance.
+    * Check whether the argument is a Float64x2.
+    * @param {Float64x2} v An instance of Float64x2.
+    * @return {Float64x2} The Float64x2 instance.
     */
-  SIMD.float64x2.check = function(v) {
-    if (!(v instanceof SIMD.float64x2)) {
-      throw new TypeError("argument is not a float64x2.");
+  SIMD.Float64x2.check = function(v) {
+    if (!(v instanceof SIMD.Float64x2)) {
+      throw new TypeError("argument is not a Float64x2.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.float64x2.splat === "undefined") {
+if (typeof SIMD.Float64x2.splat === "undefined") {
   /**
-    * Construct a new instance of float64x2 number with the same value
+    * Construct a new instance of Float64x2 number with the same value
     * in all lanes.
     * @param {double} value used for all lanes.
     * @constructor
     */
-  SIMD.float64x2.splat = function(s) {
-    return SIMD.float64x2(s, s);
+  SIMD.Float64x2.splat = function(s) {
+    return SIMD.Float64x2(s, s);
   }
 }
 
-if (typeof SIMD.float64x2.fromFloat32x4 === "undefined") {
+if (typeof SIMD.Float64x2.fromFloat32x4 === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float64x2} A float64x2 with .x and .y from t
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float64x2} A Float64x2 with .x and .y from t
     */
-  SIMD.float64x2.fromFloat32x4 = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float64x2(SIMD.float32x4.extractLane(t, 0),
-                          SIMD.float32x4.extractLane(t, 1));
+  SIMD.Float64x2.fromFloat32x4 = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float64x2(SIMD.Float32x4.extractLane(t, 0),
+                          SIMD.Float32x4.extractLane(t, 1));
   }
 }
 
-if (typeof SIMD.float64x2.fromInt32x4 === "undefined") {
+if (typeof SIMD.Float64x2.fromInt32x4 === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {float64x2} A float64x2 with .x and .y from t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Float64x2} A Float64x2 with .x and .y from t
     */
-  SIMD.float64x2.fromInt32x4 = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.float64x2(SIMD.int32x4.extractLane(t, 0),
-                          SIMD.int32x4.extractLane(t, 1));
+  SIMD.Float64x2.fromInt32x4 = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Float64x2(SIMD.Int32x4.extractLane(t, 0),
+                          SIMD.Int32x4.extractLane(t, 1));
   }
 }
 
-if (typeof SIMD.float64x2.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromFloat32x4Bits === "undefined") {
   /**
-   * @param {float32x4} t An instance of float32x4.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Float32x4} t An instance of Float32x4.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromFloat32x4Bits = function(t) {
+  SIMD.Float64x2.fromFloat32x4Bits = function(t) {
     saveFloat32x4(t);
     return restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt64x2Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt64x2Bits === "undefined") {
   /**
-   * @param {int64x2} t An instance of int64x2.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Int64x2} t An instance of Int64x2.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt64x2Bits = function(t) {
-    return SIMD.float64x2.fromInt32x4Bits(t.int32x4_);
+  SIMD.Float64x2.fromInt64x2Bits = function(t) {
+    return SIMD.Float64x2.fromInt32x4Bits(t.int32x4_);
   }
 }
 
-if (typeof SIMD.float64x2.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt32x4Bits === "undefined") {
   /**
-   * @param {int32x4} t An instance of int32x4.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Int32x4} t An instance of Int32x4.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt32x4Bits = function(t) {
+  SIMD.Float64x2.fromInt32x4Bits = function(t) {
     saveInt32x4(t);
     return restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt16x8Bits === "undefined") {
   /**
-   * @param {int16x8} t An instance of int16x8.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Int16x8} t An instance of Int16x8.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt16x8Bits = function(t) {
+  SIMD.Float64x2.fromInt16x8Bits = function(t) {
     saveInt16x8(t);
     return restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt8x16Bits === "undefined") {
   /**
-   * @param {int8x16} t An instance of int8x16.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Int8x16} t An instance of Int8x16.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt8x16Bits = function(t) {
+  SIMD.Float64x2.fromInt8x16Bits = function(t) {
     saveInt8x16(t);
     return restoreFloat64x2();
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float64x2.prototype, 'toString')) {
+if (!Object.hasOwnProperty(SIMD.Float64x2.prototype, 'toString')) {
   /**
-   * @return {String} a string representing the float64x2.
+   * @return {String} a string representing the Float64x2.
    */
-  SIMD.float64x2.prototype.toString = function() {
-    return "float64x2(" +
+  SIMD.Float64x2.prototype.toString = function() {
+    return "Float64x2(" +
       this.x_ + ", " +
       this.y_ + ")";
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float64x2.prototype, 'toLocaleString')) {
+if (!Object.hasOwnProperty(SIMD.Float64x2.prototype, 'toLocaleString')) {
   /**
-   * @return {String} a locale-sensitive string representing the float64x2.
+   * @return {String} a locale-sensitive string representing the Float64x2.
    */
-  SIMD.float64x2.prototype.toLocaleString = function() {
-    return "float64x2(" +
+  SIMD.Float64x2.prototype.toLocaleString = function() {
+    return "Float64x2(" +
       this.x_.toLocaleString() + ", " +
       this.y_.toLocaleString() + ")";
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.float64x2.prototype, 'valueOf')) {
-  SIMD.float64x2.prototype.valueOf = function() {
-    throw new TypeError("float64x2 cannot be converted to a number");
+if (!Object.hasOwnProperty(SIMD.Float64x2.prototype, 'valueOf')) {
+  SIMD.Float64x2.prototype.valueOf = function() {
+    throw new TypeError("Float64x2 cannot be converted to a number");
   }
 }
 
 
-if (typeof SIMD.int32x4 === "undefined") {
+if (typeof SIMD.Int32x4 === "undefined") {
   /**
-    * Construct a new instance of int32x4 number.
+    * Construct a new instance of Int32x4 number.
     * @param {integer} 32-bit value used for x lane.
     * @param {integer} 32-bit value used for y lane.
     * @param {integer} 32-bit value used for z lane.
     * @param {integer} 32-bit value used for w lane.
     * @constructor
     */
-  SIMD.int32x4 = function(x, y, z, w) {
-    if (!(this instanceof SIMD.int32x4)) {
-      return new SIMD.int32x4(x, y, z, w);
+  SIMD.Int32x4 = function(x, y, z, w) {
+    if (!(this instanceof SIMD.Int32x4)) {
+      return new SIMD.Int32x4(x, y, z, w);
     }
 
     this.x_ = x|0;
@@ -599,14 +599,14 @@ if (typeof SIMD.int32x4 === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.extractLane === "undefined") {
+if (typeof SIMD.Int32x4.extractLane === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {integer} The value in lane i of t.
     */
-  SIMD.int32x4.extractLane = function(t, i) {
-    t = SIMD.int32x4.check(t);
+  SIMD.Int32x4.extractLane = function(t, i) {
+    t = SIMD.Int32x4.check(t);
     check4(i);
     switch(i) {
       case 0: return t.x_;
@@ -617,27 +617,27 @@ if (typeof SIMD.int32x4.extractLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.extractLaneAsBool === "undefined") {
+if (typeof SIMD.Int32x4.extractLaneAsBool === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {Boolean} The value in lane i of t as a boolean.
     */
-  SIMD.int32x4.extractLaneAsBool = function(t, i) {
-    return toBool(SIMD.int32x4.extractLane(t, i));
+  SIMD.Int32x4.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.Int32x4.extractLane(t, i));
   }
 }
 
-if (typeof SIMD.int32x4.replaceLane === "undefined") {
+if (typeof SIMD.Int32x4.replaceLane === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} i Index in concatenation of t for lane i
     * @param {integer} value used for lane i.
-    * @return {int32x4} New instance of int32x4 with the values in t and
+    * @return {Int32x4} New instance of Int32x4 with the values in t and
     * lane i replaced with {v}.
     */
-  SIMD.int32x4.replaceLane = function(t, i, v) {
-    t = SIMD.int32x4.check(t);
+  SIMD.Int32x4.replaceLane = function(t, i, v) {
+    t = SIMD.Int32x4.check(t);
     check4(i);
     saveInt32x4(t);
     _i32x4[i] = v;
@@ -645,57 +645,57 @@ if (typeof SIMD.int32x4.replaceLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.allTrue === "undefined") {
+if (typeof SIMD.Int32x4.allTrue === "undefined") {
   /**
     * Check if all 4 lanes hold a true value (bit 31 == 1)
-    * @param {int32x4} v An instance of int32x4.
+    * @param {Int32x4} v An instance of Int32x4.
     * @return {Boolean} All 4 lanes holds a true value
     */
-  SIMD.int32x4.allTrue = function(v) {
-    if (!(v instanceof SIMD.int32x4)) {
-      throw new TypeError("argument is not a int32x4.");
+  SIMD.Int32x4.allTrue = function(v) {
+    if (!(v instanceof SIMD.Int32x4)) {
+      throw new TypeError("argument is not a Int32x4.");
     }
-    return SIMD.int32x4.extractLaneAsBool(v, 0) &&
-        SIMD.int32x4.extractLaneAsBool(v, 1) &&
-        SIMD.int32x4.extractLaneAsBool(v, 2) &&
-        SIMD.int32x4.extractLaneAsBool(v, 3);
+    return SIMD.Int32x4.extractLaneAsBool(v, 0) &&
+        SIMD.Int32x4.extractLaneAsBool(v, 1) &&
+        SIMD.Int32x4.extractLaneAsBool(v, 2) &&
+        SIMD.Int32x4.extractLaneAsBool(v, 3);
   }
 }
 
-if (typeof SIMD.int32x4.anyTrue === "undefined") {
+if (typeof SIMD.Int32x4.anyTrue === "undefined") {
   /**
     * Check if any of the 4 lanes hold a true value (bit 31 == 1)
-    * @param {int32x4} v An instance of int32x4.
+    * @param {Int32x4} v An instance of Int32x4.
     * @return {Boolean} Any of the 4 lanes holds a true value
     */
-  SIMD.int32x4.anyTrue = function(v) {
-    if (!(v instanceof SIMD.int32x4)) {
-      throw new TypeError("argument is not a int32x4.");
+  SIMD.Int32x4.anyTrue = function(v) {
+    if (!(v instanceof SIMD.Int32x4)) {
+      throw new TypeError("argument is not a Int32x4.");
     }
-    return SIMD.int32x4.extractLaneAsBool(v, 0) ||
-        SIMD.int32x4.extractLaneAsBool(v, 1) ||
-        SIMD.int32x4.extractLaneAsBool(v, 2) ||
-        SIMD.int32x4.extractLaneAsBool(v, 3);
+    return SIMD.Int32x4.extractLaneAsBool(v, 0) ||
+        SIMD.Int32x4.extractLaneAsBool(v, 1) ||
+        SIMD.Int32x4.extractLaneAsBool(v, 2) ||
+        SIMD.Int32x4.extractLaneAsBool(v, 3);
   }
 }
 
-if (typeof SIMD.int32x4.check === "undefined") {
+if (typeof SIMD.Int32x4.check === "undefined") {
   /**
-    * Check whether the argument is a int32x4.
-    * @param {int32x4} v An instance of int32x4.
-    * @return {int32x4} The int32x4 instance.
+    * Check whether the argument is a Int32x4.
+    * @param {Int32x4} v An instance of Int32x4.
+    * @return {Int32x4} The Int32x4 instance.
     */
-  SIMD.int32x4.check = function(v) {
-    if (!(v instanceof SIMD.int32x4)) {
-      throw new TypeError("argument is not a int32x4.");
+  SIMD.Int32x4.check = function(v) {
+    if (!(v instanceof SIMD.Int32x4)) {
+      throw new TypeError("argument is not a Int32x4.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.int32x4.bool === "undefined") {
+if (typeof SIMD.Int32x4.bool === "undefined") {
   /**
-    * Construct a new instance of int32x4 number with either true or false in
+    * Construct a new instance of Int32x4 number with either true or false in
     * each lane, depending on the truth values in x, y, z, and w.
     * @param {boolean} flag used for x lane.
     * @param {boolean} flag used for y lane.
@@ -703,114 +703,114 @@ if (typeof SIMD.int32x4.bool === "undefined") {
     * @param {boolean} flag used for w lane.
     * @constructor
     */
-  SIMD.int32x4.bool = function(x, y, z, w) {
-    return SIMD.int32x4(fromBool(x),
+  SIMD.Int32x4.bool = function(x, y, z, w) {
+    return SIMD.Int32x4(fromBool(x),
                         fromBool(y),
                         fromBool(z),
                         fromBool(w));
   }
 }
 
-if (typeof SIMD.int32x4.splat === "undefined") {
+if (typeof SIMD.Int32x4.splat === "undefined") {
   /**
-    * Construct a new instance of int32x4 number with the same value
+    * Construct a new instance of Int32x4 number with the same value
     * in all lanes.
     * @param {integer} value used for all lanes.
     * @constructor
     */
-  SIMD.int32x4.splat = function(s) {
-    return SIMD.int32x4(s, s, s, s);
+  SIMD.Int32x4.splat = function(s) {
+    return SIMD.Int32x4(s, s, s, s);
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat32x4 === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat32x4 === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int32x4} with a integer to float conversion of t.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int32x4} with a integer to float conversion of t.
     */
-  SIMD.int32x4.fromFloat32x4 = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.int32x4(int32FromFloat(SIMD.float32x4.extractLane(t, 0)),
-                        int32FromFloat(SIMD.float32x4.extractLane(t, 1)),
-                        int32FromFloat(SIMD.float32x4.extractLane(t, 2)),
-                        int32FromFloat(SIMD.float32x4.extractLane(t, 3)));
+  SIMD.Int32x4.fromFloat32x4 = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Int32x4(int32FromFloat(SIMD.Float32x4.extractLane(t, 0)),
+                        int32FromFloat(SIMD.Float32x4.extractLane(t, 1)),
+                        int32FromFloat(SIMD.Float32x4.extractLane(t, 2)),
+                        int32FromFloat(SIMD.Float32x4.extractLane(t, 3)));
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat64x2 === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat64x2 === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {int32x4}  An int32x4 with .x and .y from t
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Int32x4}  An Int32x4 with .x and .y from t
     */
-  SIMD.int32x4.fromFloat64x2 = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.int32x4(int32FromFloat(SIMD.float64x2.extractLane(t, 0)),
-                        int32FromFloat(SIMD.float64x2.extractLane(t, 1)),
+  SIMD.Int32x4.fromFloat64x2 = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Int32x4(int32FromFloat(SIMD.Float64x2.extractLane(t, 0)),
+                        int32FromFloat(SIMD.Float64x2.extractLane(t, 1)),
                         0,
                         0);
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromFloat32x4Bits = function(t) {
+  SIMD.Int32x4.fromFloat32x4Bits = function(t) {
     saveFloat32x4(t);
     return restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromInt64x2Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromInt64x2Bits === "undefined") {
   /**
-   * @param {int64x2} t An instance of int64x2.
-   * @return {int32x4} a bit-wise copy of t as an int32x4.
+   * @param {Int64x2} t An instance of Int64x2.
+   * @return {Int32x4} a bit-wise copy of t as an Int32x4.
    */
-  SIMD.int32x4.fromInt64x2Bits = function(t) {
+  SIMD.Int32x4.fromInt64x2Bits = function(t) {
     return t.int32x4_;
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {int32x4} a bit-wise copy of t as an int32x4.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Int32x4} a bit-wise copy of t as an Int32x4.
    */
-  SIMD.int32x4.fromFloat64x2Bits = function(t) {
+  SIMD.Int32x4.fromFloat64x2Bits = function(t) {
     saveFloat64x2(t);
     return restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromInt16x8Bits === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @param {Int16x8} t An instance of Int16x8.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromInt16x8Bits = function(t) {
+  SIMD.Int32x4.fromInt16x8Bits = function(t) {
     saveInt16x8(t);
     return restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromInt8x16Bits === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @param {Int8x16} t An instance of Int8x16.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromInt8x16Bits = function(t) {
+  SIMD.Int32x4.fromInt8x16Bits = function(t) {
     saveInt8x16(t);
     return restoreInt32x4();
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toString')) {
+if (!Object.hasOwnProperty(SIMD.Int32x4.prototype, 'toString')) {
   /**
-   * @return {String} a string representing the int32x4.
+   * @return {String} a string representing the Int32x4.
    */
-  SIMD.int32x4.prototype.toString = function() {
-    return "int32x4(" +
+  SIMD.Int32x4.prototype.toString = function() {
+    return "Int32x4(" +
       this.x_ + ", " +
       this.y_ + ", " +
       this.z_ + ", " +
@@ -818,12 +818,12 @@ if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toLocaleString')) {
+if (!Object.hasOwnProperty(SIMD.Int32x4.prototype, 'toLocaleString')) {
   /**
-   * @return {String} a locale-sensitive string representing the int32x4.
+   * @return {String} a locale-sensitive string representing the Int32x4.
    */
-  SIMD.int32x4.prototype.toLocaleString = function() {
-    return "int32x4(" +
+  SIMD.Int32x4.prototype.toLocaleString = function() {
+    return "Int32x4(" +
       this.x_.toLocaleString() + ", " +
       this.y_.toLocaleString() + ", " +
       this.z_.toLocaleString() + ", " +
@@ -831,15 +831,15 @@ if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'toLocaleString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int32x4.prototype, 'valueOf')) {
-  SIMD.int32x4.prototype.valueOf = function() {
-    throw new TypeError("int32x4 cannot be converted to a number");
+if (!Object.hasOwnProperty(SIMD.Int32x4.prototype, 'valueOf')) {
+  SIMD.Int32x4.prototype.valueOf = function() {
+    throw new TypeError("Int32x4 cannot be converted to a number");
   }
 }
 
-if (typeof SIMD.int16x8 === "undefined") {
+if (typeof SIMD.Int16x8 === "undefined") {
   /**
-    * Construct a new instance of int16x8 number.
+    * Construct a new instance of Int16x8 number.
     * @param {integer} 16-bit value used for s0 lane.
     * @param {integer} 16-bit value used for s1 lane.
     * @param {integer} 16-bit value used for s2 lane.
@@ -850,9 +850,9 @@ if (typeof SIMD.int16x8 === "undefined") {
     * @param {integer} 16-bit value used for s7 lane.
     * @constructor
     */
-  SIMD.int16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
-    if (!(this instanceof SIMD.int16x8)) {
-      return new SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+  SIMD.Int16x8 = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+    if (!(this instanceof SIMD.Int16x8)) {
+      return new SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
     }
 
     this.s0_ = s0 << 16 >> 16;
@@ -866,14 +866,14 @@ if (typeof SIMD.int16x8 === "undefined") {
   }
 }
 
-if (typeof SIMD.int16x8.extractLane === "undefined") {
+if (typeof SIMD.Int16x8.extractLane === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
+    * @param {Int16x8} t An instance of Int16x8.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {integer} The value in lane i of t.
     */
-  SIMD.int16x8.extractLane = function(t, i) {
-    t = SIMD.int16x8.check(t);
+  SIMD.Int16x8.extractLane = function(t, i) {
+    t = SIMD.Int16x8.check(t);
     check8(i);
     switch(i) {
       case 0: return t.s0_;
@@ -888,27 +888,27 @@ if (typeof SIMD.int16x8.extractLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int16x8.extractLaneAsBool === "undefined") {
+if (typeof SIMD.Int16x8.extractLaneAsBool === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
+    * @param {Int16x8} t An instance of Int16x8.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {Boolean} The value in lane i of t as a boolean.
     */
-  SIMD.int16x8.extractLaneAsBool = function(t, i) {
-    return toBool(SIMD.int16x8.extractLane(t, i));
+  SIMD.Int16x8.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.Int16x8.extractLane(t, i));
   }
 }
 
-if (typeof SIMD.int16x8.replaceLane === "undefined") {
+if (typeof SIMD.Int16x8.replaceLane === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
+    * @param {Int16x8} t An instance of Int16x8.
     * @param {integer} i Index in concatenation of t for lane i
     * @param {integer} value used for lane i.
-    * @return {int16x8} New instance of int16x8 with the values in t and
+    * @return {Int16x8} New instance of Int16x8 with the values in t and
     * lane i replaced with {v}.
     */
-  SIMD.int16x8.replaceLane = function(t, i, v) {
-    t = SIMD.int16x8.check(t);
+  SIMD.Int16x8.replaceLane = function(t, i, v) {
+    t = SIMD.Int16x8.check(t);
     check8(i);
     saveInt16x8(t);
     _i16x8[i] = v;
@@ -916,65 +916,65 @@ if (typeof SIMD.int16x8.replaceLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int16x8.allTrue === "undefined") {
+if (typeof SIMD.Int16x8.allTrue === "undefined") {
   /**
     * Check if all 8 lanes hold a true value (bit 15 == 1)
-    * @param {int16x8} v An instance of int16x8.
+    * @param {Int16x8} v An instance of Int16x8.
     * @return {Boolean} All 8 lanes holds a true value
     */
-  SIMD.int16x8.allTrue = function(v) {
-    if (!(v instanceof SIMD.int16x8)) {
-      throw new TypeError("argument is not a int16x8.");
+  SIMD.Int16x8.allTrue = function(v) {
+    if (!(v instanceof SIMD.Int16x8)) {
+      throw new TypeError("argument is not a Int16x8.");
     }
-    return SIMD.int16x8.extractLaneAsBool(v, 0) &&
-           SIMD.int16x8.extractLaneAsBool(v, 1) &&
-           SIMD.int16x8.extractLaneAsBool(v, 2) &&
-           SIMD.int16x8.extractLaneAsBool(v, 3) &&
-           SIMD.int16x8.extractLaneAsBool(v, 4) &&
-           SIMD.int16x8.extractLaneAsBool(v, 5) &&
-           SIMD.int16x8.extractLaneAsBool(v, 6) &&
-           SIMD.int16x8.extractLaneAsBool(v, 7);
+    return SIMD.Int16x8.extractLaneAsBool(v, 0) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 1) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 2) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 3) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 4) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 5) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 6) &&
+           SIMD.Int16x8.extractLaneAsBool(v, 7);
   }
 }
 
-if (typeof SIMD.int16x8.anyTrue === "undefined") {
+if (typeof SIMD.Int16x8.anyTrue === "undefined") {
   /**
     * Check if any of the 8 lanes hold a true value (bit 15 == 1)
-    * @param {int16x8} v An instance of int16x8.
+    * @param {Int16x8} v An instance of Int16x8.
     * @return {Boolean} Any of the 8 lanes holds a true value
     */
-  SIMD.int16x8.anyTrue = function(v) {
-    if (!(v instanceof SIMD.int16x8)) {
-      throw new TypeError("argument is not a int16x8.");
+  SIMD.Int16x8.anyTrue = function(v) {
+    if (!(v instanceof SIMD.Int16x8)) {
+      throw new TypeError("argument is not a Int16x8.");
     }
-    return SIMD.int16x8.extractLaneAsBool(v, 0) ||
-           SIMD.int16x8.extractLaneAsBool(v, 1) ||
-           SIMD.int16x8.extractLaneAsBool(v, 2) ||
-           SIMD.int16x8.extractLaneAsBool(v, 3) ||
-           SIMD.int16x8.extractLaneAsBool(v, 4) ||
-           SIMD.int16x8.extractLaneAsBool(v, 5) ||
-           SIMD.int16x8.extractLaneAsBool(v, 6) ||
-           SIMD.int16x8.extractLaneAsBool(v, 7);
+    return SIMD.Int16x8.extractLaneAsBool(v, 0) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 1) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 2) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 3) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 4) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 5) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 6) ||
+           SIMD.Int16x8.extractLaneAsBool(v, 7);
   }
 }
 
-if (typeof SIMD.int16x8.check === "undefined") {
+if (typeof SIMD.Int16x8.check === "undefined") {
   /**
-    * Check whether the argument is a int16x8.
-    * @param {int16x8} v An instance of int16x8.
-    * @return {int16x8} The int16x8 instance.
+    * Check whether the argument is a Int16x8.
+    * @param {Int16x8} v An instance of Int16x8.
+    * @return {Int16x8} The Int16x8 instance.
     */
-  SIMD.int16x8.check = function(v) {
-    if (!(v instanceof SIMD.int16x8)) {
-      throw new TypeError("argument is not a int16x8.");
+  SIMD.Int16x8.check = function(v) {
+    if (!(v instanceof SIMD.Int16x8)) {
+      throw new TypeError("argument is not a Int16x8.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.int16x8.bool === "undefined") {
+if (typeof SIMD.Int16x8.bool === "undefined") {
   /**
-    * Construct a new instance of int16x8 number with true or false in each
+    * Construct a new instance of Int16x8 number with true or false in each
     * lane, depending on the truth value in s0, s1, s2, s3, s4, s5, s6, and s7.
     * @param {boolean} flag used for s0 lane.
     * @param {boolean} flag used for s1 lane.
@@ -986,8 +986,8 @@ if (typeof SIMD.int16x8.bool === "undefined") {
     * @param {boolean} flag used for s7 lane.
     * @constructor
     */
-  SIMD.int16x8.bool = function(s0, s1, s2, s3, s4, s5, s6, s7) {
-    return SIMD.int16x8(fromBool(s0),
+  SIMD.Int16x8.bool = function(s0, s1, s2, s3, s4, s5, s6, s7) {
+    return SIMD.Int16x8(fromBool(s0),
                         fromBool(s1),
                         fromBool(s2),
                         fromBool(s3),
@@ -998,68 +998,68 @@ if (typeof SIMD.int16x8.bool === "undefined") {
   }
 }
 
-if (typeof SIMD.int16x8.splat === "undefined") {
+if (typeof SIMD.Int16x8.splat === "undefined") {
   /**
-    * Construct a new instance of int16x8 number with the same value
+    * Construct a new instance of Int16x8 number with the same value
     * in all lanes.
     * @param {integer} value used for all lanes.
     * @constructor
     */
-  SIMD.int16x8.splat = function(s) {
-    return SIMD.int16x8(s, s, s, s, s, s, s, s);
+  SIMD.Int16x8.splat = function(s) {
+    return SIMD.Int16x8(s, s, s, s, s, s, s, s);
   }
 }
 
-if (typeof SIMD.int16x8.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Int16x8.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int16x8} a bit-wise copy of t as a int16x8.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int16x8} a bit-wise copy of t as a Int16x8.
     */
-  SIMD.int16x8.fromFloat32x4Bits = function(t) {
+  SIMD.Int16x8.fromFloat32x4Bits = function(t) {
     saveFloat32x4(t);
     return restoreInt16x8();
   }
 }
 
-if (typeof SIMD.int16x8.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Int16x8.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {int16x8} a bit-wise copy of t as an int16x8.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Int16x8} a bit-wise copy of t as an Int16x8.
    */
-  SIMD.int16x8.fromFloat64x2Bits = function(t) {
+  SIMD.Int16x8.fromFloat64x2Bits = function(t) {
     saveFloat64x2(t);
     return restoreInt16x8();
   }
 }
 
-if (typeof SIMD.int16x8.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Int16x8.fromInt32x4Bits === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int16x8} a bit-wise copy of t as a int16x8.
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int16x8} a bit-wise copy of t as a Int16x8.
     */
-  SIMD.int16x8.fromInt32x4Bits = function(t) {
+  SIMD.Int16x8.fromInt32x4Bits = function(t) {
     saveInt32x4(t);
     return restoreInt16x8();
   }
 }
 
-if (typeof SIMD.int16x8.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Int16x8.fromInt8x16Bits === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @return {int16x8} a bit-wise copy of t as a int16x8.
+    * @param {Int8x16} t An instance of Int8x16.
+    * @return {Int16x8} a bit-wise copy of t as a Int16x8.
     */
-  SIMD.int16x8.fromInt8x16Bits = function(t) {
+  SIMD.Int16x8.fromInt8x16Bits = function(t) {
     saveInt8x16(t);
     return restoreInt16x8();
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int16x8.prototype, 'toString')) {
+if (!Object.hasOwnProperty(SIMD.Int16x8.prototype, 'toString')) {
   /**
-   * @return {String} a string representing the int16x8.
+   * @return {String} a string representing the Int16x8.
    */
-  SIMD.int16x8.prototype.toString = function() {
-    return "int16x8(" +
+  SIMD.Int16x8.prototype.toString = function() {
+    return "Int16x8(" +
       this.s0_ + ", " +
       this.s1_ + ", " +
       this.s2_ + ", " +
@@ -1071,12 +1071,12 @@ if (!Object.hasOwnProperty(SIMD.int16x8.prototype, 'toString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int16x8.prototype, 'toLocaleString')) {
+if (!Object.hasOwnProperty(SIMD.Int16x8.prototype, 'toLocaleString')) {
   /**
-   * @return {String} a locale-sensitive string representing the int16x8.
+   * @return {String} a locale-sensitive string representing the Int16x8.
    */
-  SIMD.int16x8.prototype.toLocaleString = function() {
-    return "int16x8(" +
+  SIMD.Int16x8.prototype.toLocaleString = function() {
+    return "Int16x8(" +
       this.s0_.toLocaleString() + ", " +
       this.s1_.toLocaleString() + ", " +
       this.s2_.toLocaleString() + ", " +
@@ -1088,15 +1088,15 @@ if (!Object.hasOwnProperty(SIMD.int16x8.prototype, 'toLocaleString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int16x8.prototype, 'valueOf')) {
-  SIMD.int16x8.prototype.valueOf = function() {
-    throw new TypeError("int16x8 cannot be converted to a number");
+if (!Object.hasOwnProperty(SIMD.Int16x8.prototype, 'valueOf')) {
+  SIMD.Int16x8.prototype.valueOf = function() {
+    throw new TypeError("Int16x8 cannot be converted to a number");
   }
 }
 
-if (typeof SIMD.int8x16 === "undefined") {
+if (typeof SIMD.Int8x16 === "undefined") {
   /**
-    * Construct a new instance of int8x16 number.
+    * Construct a new instance of Int8x16 number.
     * @param {integer} 8-bit value used for s0 lane.
     * @param {integer} 8-bit value used for s1 lane.
     * @param {integer} 8-bit value used for s2 lane.
@@ -1115,10 +1115,10 @@ if (typeof SIMD.int8x16 === "undefined") {
     * @param {integer} 8-bit value used for s15 lane.
     * @constructor
     */
-  SIMD.int8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
+  SIMD.Int8x16 = function(s0, s1, s2, s3, s4, s5, s6, s7,
                           s8, s9, s10, s11, s12, s13, s14, s15) {
-    if (!(this instanceof SIMD.int8x16)) {
-      return new SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+    if (!(this instanceof SIMD.Int8x16)) {
+      return new SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
                               s8, s9, s10, s11, s12, s13, s14, s15);
     }
 
@@ -1141,14 +1141,14 @@ if (typeof SIMD.int8x16 === "undefined") {
   }
 }
 
-if (typeof SIMD.int8x16.extractLane === "undefined") {
+if (typeof SIMD.Int8x16.extractLane === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
+    * @param {Int8x16} t An instance of Int8x16.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {integer} The value in lane i of t.
     */
-  SIMD.int8x16.extractLane = function(t, i) {
-    t = SIMD.int8x16.check(t);
+  SIMD.Int8x16.extractLane = function(t, i) {
+    t = SIMD.Int8x16.check(t);
     check16(i);
     switch(i) {
       case 0: return t.s0_;
@@ -1171,27 +1171,27 @@ if (typeof SIMD.int8x16.extractLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int8x16.extractLaneAsBool === "undefined") {
+if (typeof SIMD.Int8x16.extractLaneAsBool === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
+    * @param {Int8x16} t An instance of Int8x16.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {Boolean} The value in lane i of t as a boolean.
     */
-  SIMD.int8x16.extractLaneAsBool = function(t, i) {
-    return toBool(SIMD.int8x16.extractLane(t, i));
+  SIMD.Int8x16.extractLaneAsBool = function(t, i) {
+    return toBool(SIMD.Int8x16.extractLane(t, i));
   }
 }
 
-if (typeof SIMD.int8x16.replaceLane === "undefined") {
+if (typeof SIMD.Int8x16.replaceLane === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
+    * @param {Int8x16} t An instance of Int8x16.
     * @param {integer} i Index in concatenation of t for lane i
     * @param {integer} value used for lane i.
-    * @return {int8x16} New instance of int8x16 with the values in t and
+    * @return {Int8x16} New instance of Int8x16 with the values in t and
     * lane i replaced with {v}.
     */
-  SIMD.int8x16.replaceLane = function(t, i, v) {
-    t = SIMD.int8x16.check(t);
+  SIMD.Int8x16.replaceLane = function(t, i, v) {
+    t = SIMD.Int8x16.check(t);
     check16(i);
     saveInt8x16(t);
     _i8x16[i] = v;
@@ -1199,81 +1199,81 @@ if (typeof SIMD.int8x16.replaceLane === "undefined") {
   }
 }
 
-if (typeof SIMD.int8x16.allTrue === "undefined") {
+if (typeof SIMD.Int8x16.allTrue === "undefined") {
   /**
     * Check if all 16 lanes hold a true value (bit 7 == 1)
-    * @param {int8x16} v An instance of int8x16.
+    * @param {Int8x16} v An instance of Int8x16.
     * @return {Boolean} All 16 lanes holds a true value
     */
-  SIMD.int8x16.allTrue = function(v) {
-    if (!(v instanceof SIMD.int8x16)) {
-      throw new TypeError("argument is not a int8x16.");
+  SIMD.Int8x16.allTrue = function(v) {
+    if (!(v instanceof SIMD.Int8x16)) {
+      throw new TypeError("argument is not a Int8x16.");
     }
-    return SIMD.int8x16.extractLaneAsBool(v, 0) &&
-           SIMD.int8x16.extractLaneAsBool(v, 1) &&
-           SIMD.int8x16.extractLaneAsBool(v, 2) &&
-           SIMD.int8x16.extractLaneAsBool(v, 3) &&
-           SIMD.int8x16.extractLaneAsBool(v, 4) &&
-           SIMD.int8x16.extractLaneAsBool(v, 5) &&
-           SIMD.int8x16.extractLaneAsBool(v, 6) &&
-           SIMD.int8x16.extractLaneAsBool(v, 7) &&
-           SIMD.int8x16.extractLaneAsBool(v, 8) &&
-           SIMD.int8x16.extractLaneAsBool(v, 9) &&
-           SIMD.int8x16.extractLaneAsBool(v, 10) &&
-           SIMD.int8x16.extractLaneAsBool(v, 11) &&
-           SIMD.int8x16.extractLaneAsBool(v, 12) &&
-           SIMD.int8x16.extractLaneAsBool(v, 13) &&
-           SIMD.int8x16.extractLaneAsBool(v, 14) &&
-           SIMD.int8x16.extractLaneAsBool(v, 15);
+    return SIMD.Int8x16.extractLaneAsBool(v, 0) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 1) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 2) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 3) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 4) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 5) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 6) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 7) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 8) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 9) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 10) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 11) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 12) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 13) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 14) &&
+           SIMD.Int8x16.extractLaneAsBool(v, 15);
   }
 }
 
-if (typeof SIMD.int8x16.anyTrue === "undefined") {
+if (typeof SIMD.Int8x16.anyTrue === "undefined") {
   /**
     * Check if any of the 16 lanes hold a true value (bit 7 == 1)
-    * @param {int8x16} v An instance of int16x8.
+    * @param {Int8x16} v An instance of Int16x8.
     * @return {Boolean} Any of the 16 lanes holds a true value
     */
-  SIMD.int8x16.anyTrue = function(v) {
-    if (!(v instanceof SIMD.int8x16)) {
-      throw new TypeError("argument is not a int8x16.");
+  SIMD.Int8x16.anyTrue = function(v) {
+    if (!(v instanceof SIMD.Int8x16)) {
+      throw new TypeError("argument is not a Int8x16.");
     }
-    return SIMD.int8x16.extractLaneAsBool(v, 0) ||
-           SIMD.int8x16.extractLaneAsBool(v, 1) ||
-           SIMD.int8x16.extractLaneAsBool(v, 2) ||
-           SIMD.int8x16.extractLaneAsBool(v, 3) ||
-           SIMD.int8x16.extractLaneAsBool(v, 4) ||
-           SIMD.int8x16.extractLaneAsBool(v, 5) ||
-           SIMD.int8x16.extractLaneAsBool(v, 6) ||
-           SIMD.int8x16.extractLaneAsBool(v, 7) ||
-           SIMD.int8x16.extractLaneAsBool(v, 8) ||
-           SIMD.int8x16.extractLaneAsBool(v, 9) ||
-           SIMD.int8x16.extractLaneAsBool(v, 10) ||
-           SIMD.int8x16.extractLaneAsBool(v, 11) ||
-           SIMD.int8x16.extractLaneAsBool(v, 12) ||
-           SIMD.int8x16.extractLaneAsBool(v, 13) ||
-           SIMD.int8x16.extractLaneAsBool(v, 14) ||
-           SIMD.int8x16.extractLaneAsBool(v, 15);
+    return SIMD.Int8x16.extractLaneAsBool(v, 0) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 1) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 2) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 3) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 4) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 5) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 6) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 7) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 8) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 9) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 10) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 11) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 12) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 13) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 14) ||
+           SIMD.Int8x16.extractLaneAsBool(v, 15);
   }
 }
 
-if (typeof SIMD.int8x16.check === "undefined") {
+if (typeof SIMD.Int8x16.check === "undefined") {
   /**
-    * Check whether the argument is a int8x16.
-    * @param {int8x16} v An instance of int8x16.
-    * @return {int8x16} The int8x16 instance.
+    * Check whether the argument is a Int8x16.
+    * @param {Int8x16} v An instance of Int8x16.
+    * @return {Int8x16} The Int8x16 instance.
     */
-  SIMD.int8x16.check = function(v) {
-    if (!(v instanceof SIMD.int8x16)) {
-      throw new TypeError("argument is not a int8x16.");
+  SIMD.Int8x16.check = function(v) {
+    if (!(v instanceof SIMD.Int8x16)) {
+      throw new TypeError("argument is not a Int8x16.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.int8x16.bool === "undefined") {
+if (typeof SIMD.Int8x16.bool === "undefined") {
   /**
-    * Construct a new instance of int8x16 number with true or false in each
+    * Construct a new instance of Int8x16 number with true or false in each
     * lane, depending on the truth value in s0, s1, s2, s3, s4, s5, s6, s7,
     * s8, s9, s10, s11, s12, s13, s14, and s15.
     * @param {boolean} flag used for s0 lane.
@@ -1294,9 +1294,9 @@ if (typeof SIMD.int8x16.bool === "undefined") {
     * @param {boolean} flag used for s15 lane.
     * @constructor
     */
-  SIMD.int8x16.bool = function(s0, s1, s2, s3, s4, s5, s6, s7,
+  SIMD.Int8x16.bool = function(s0, s1, s2, s3, s4, s5, s6, s7,
                                s8, s9, s10, s11, s12, s13, s14, s15) {
-    return SIMD.int8x16(fromBool(s0),
+    return SIMD.Int8x16(fromBool(s0),
                         fromBool(s1),
                         fromBool(s2),
                         fromBool(s3),
@@ -1315,69 +1315,69 @@ if (typeof SIMD.int8x16.bool === "undefined") {
   }
 }
 
-if (typeof SIMD.int8x16.splat === "undefined") {
+if (typeof SIMD.Int8x16.splat === "undefined") {
   /**
-    * Construct a new instance of int8x16 number with the same value
+    * Construct a new instance of Int8x16 number with the same value
     * in all lanes.
     * @param {integer} value used for all lanes.
     * @constructor
     */
-  SIMD.int8x16.splat = function(s) {
-    return SIMD.int8x16(s, s, s, s, s, s, s, s,
+  SIMD.Int8x16.splat = function(s) {
+    return SIMD.Int8x16(s, s, s, s, s, s, s, s,
                         s, s, s, s, s, s, s, s);
   }
 }
 
-if (typeof SIMD.int8x16.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Int8x16.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int8x16} a bit-wise copy of t as a int8x16.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int8x16} a bit-wise copy of t as a Int8x16.
     */
-  SIMD.int8x16.fromFloat32x4Bits = function(t) {
+  SIMD.Int8x16.fromFloat32x4Bits = function(t) {
     saveFloat32x4(t);
     return restoreInt8x16();
   }
 }
 
-if (typeof SIMD.int8x16.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Int8x16.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {int8x16} a bit-wise copy of t as an int8x16.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Int8x16} a bit-wise copy of t as an Int8x16.
    */
-  SIMD.int8x16.fromFloat64x2Bits = function(t) {
+  SIMD.Int8x16.fromFloat64x2Bits = function(t) {
     saveFloat64x2(t);
     return restoreInt8x16();
   }
 }
 
-if (typeof SIMD.int8x16.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Int8x16.fromInt32x4Bits === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int8x16} a bit-wise copy of t as a int8x16.
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int8x16} a bit-wise copy of t as a Int8x16.
     */
-  SIMD.int8x16.fromInt32x4Bits = function(t) {
+  SIMD.Int8x16.fromInt32x4Bits = function(t) {
     saveInt32x4(t);
     return restoreInt8x16();
   }
 }
 
-if (typeof SIMD.int8x16.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Int8x16.fromInt16x8Bits === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @return {int8x16} a bit-wise copy of t as a int8x16.
+    * @param {Int16x8} t An instance of Int16x8.
+    * @return {Int8x16} a bit-wise copy of t as a Int8x16.
     */
-  SIMD.int8x16.fromInt16x8Bits = function(t) {
+  SIMD.Int8x16.fromInt16x8Bits = function(t) {
     saveInt16x8(t);
     return restoreInt8x16();
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int8x16.prototype, 'toString')) {
+if (!Object.hasOwnProperty(SIMD.Int8x16.prototype, 'toString')) {
   /**
-   * @return {String} a string representing the int8x16.
+   * @return {String} a string representing the Int8x16.
    */
-  SIMD.int8x16.prototype.toString = function() {
-    return "int8x16(" +
+  SIMD.Int8x16.prototype.toString = function() {
+    return "Int8x16(" +
       this.s0_ + ", " +
       this.s1_ + ", " +
       this.s2_ + ", " +
@@ -1397,12 +1397,12 @@ if (!Object.hasOwnProperty(SIMD.int8x16.prototype, 'toString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int8x16.prototype, 'toLocaleString')) {
+if (!Object.hasOwnProperty(SIMD.Int8x16.prototype, 'toLocaleString')) {
   /**
-   * @return {String} a locale-sensitive string representing the int8x16.
+   * @return {String} a locale-sensitive string representing the Int8x16.
    */
-  SIMD.int8x16.prototype.toLocaleString = function() {
-    return "int8x16(" +
+  SIMD.Int8x16.prototype.toLocaleString = function() {
+    return "Int8x16(" +
       this.s0_.toLocaleString() + ", " +
       this.s1_.toLocaleString() + ", " +
       this.s2_.toLocaleString() + ", " +
@@ -1422,661 +1422,661 @@ if (!Object.hasOwnProperty(SIMD.int8x16.prototype, 'toLocaleString')) {
   }
 }
 
-if (!Object.hasOwnProperty(SIMD.int8x16.prototype, 'valueOf')) {
-  SIMD.int8x16.prototype.valueOf = function() {
-    throw new TypeError("int8x16 cannot be converted to a number");
+if (!Object.hasOwnProperty(SIMD.Int8x16.prototype, 'valueOf')) {
+  SIMD.Int8x16.prototype.valueOf = function() {
+    throw new TypeError("Int8x16 cannot be converted to a number");
   }
 }
 
-if (typeof SIMD.int64x2 === "undefined") {
+if (typeof SIMD.Int64x2 === "undefined") {
   /**
-    * Construct a new instance of int64x2 number.
+    * Construct a new instance of Int64x2 number.
     * This function conceptually requires 64-bit integer arguments. Until JS
     * has support for that, this function cannot be passed any arguments. To
-    * produce an int64x2 value, use int64x2.load, int64x2.bool, or a
-    * float64x2 comparison.
+    * produce an Int64x2 value, use Int64x2.load, Int64x2.bool, or a
+    * Float64x2 comparison.
     * @constructor
     */
-  SIMD.int64x2 = function() {
-    if (!(this instanceof SIMD.int64x2)) {
-      return new SIMD.int64x2();
+  SIMD.Int64x2 = function() {
+    if (!(this instanceof SIMD.Int64x2)) {
+      return new SIMD.Int64x2();
     }
     if (arguments.length != 0) {
-      throw new Error("int64x2 cannot currently be directly constructed");
+      throw new Error("Int64x2 cannot currently be directly constructed");
     }
 
-    this.int32x4_ = SIMD.int32x4.splat(0);
+    this.int32x4_ = SIMD.Int32x4.splat(0);
   }
 }
 
-if (typeof SIMD.int64x2.extractLaneAsBool === "undefined") {
+if (typeof SIMD.Int64x2.extractLaneAsBool === "undefined") {
   /**
-    * @param {int64x2} t An instance of int64x2.
+    * @param {Int64x2} t An instance of Int64x2.
     * @param {integer} i Index in concatenation of t for lane i
     * @return {Boolean} The value in lane i of t as a boolean.
     */
-  SIMD.int64x2.extractLaneAsBool = function(t, i) {
-    t = SIMD.int64x2.check(t);
-    return SIMD.int32x4.extractLaneAsBool(t.int32x4_, i << 1)
+  SIMD.Int64x2.extractLaneAsBool = function(t, i) {
+    t = SIMD.Int64x2.check(t);
+    return SIMD.Int32x4.extractLaneAsBool(t.int32x4_, i << 1)
   }
 }
 
 
-if (typeof SIMD.int64x2.allTrue === "undefined") {
+if (typeof SIMD.Int64x2.allTrue === "undefined") {
   /**
     * Check if all 2 lanes hold a true value (bit 63 == 1)
-    * @param {int64x2} v An instance of int64x2.
+    * @param {Int64x2} v An instance of Int64x2.
     * @return {Boolean} All 2 lanes hold a true value
     */
-  SIMD.int64x2.allTrue = function(v) {
-    if (!(v instanceof SIMD.int64x2)) {
-      throw new TypeError("argument is not a int64x2.");
+  SIMD.Int64x2.allTrue = function(v) {
+    if (!(v instanceof SIMD.Int64x2)) {
+      throw new TypeError("argument is not a Int64x2.");
     }
-    return SIMD.int64x2.extractLaneAsBool(v, 0) &&
-        SIMD.int64x2.extractLaneAsBool(v, 1);
+    return SIMD.Int64x2.extractLaneAsBool(v, 0) &&
+        SIMD.Int64x2.extractLaneAsBool(v, 1);
   }
 }
 
-if (typeof SIMD.int64x2.anyTrue === "undefined") {
+if (typeof SIMD.Int64x2.anyTrue === "undefined") {
   /**
     * Check if any of the 2 lanes hold a true value (bit 63 == 1)
-    * @param {int64x2} v An instance of int64x2.
+    * @param {Int64x2} v An instance of Int64x2.
     * @return {Boolean} Any of the 2 lanes holds a true value
     */
-  SIMD.int64x2.anyTrue = function(v) {
-    if (!(v instanceof SIMD.int64x2)) {
-      throw new TypeError("argument is not a int64x2.");
+  SIMD.Int64x2.anyTrue = function(v) {
+    if (!(v instanceof SIMD.Int64x2)) {
+      throw new TypeError("argument is not a Int64x2.");
     }
-    return SIMD.int64x2.extractLaneAsBool(v, 0) ||
-        SIMD.int64x2.extractLaneAsBool(v, 1);
+    return SIMD.Int64x2.extractLaneAsBool(v, 0) ||
+        SIMD.Int64x2.extractLaneAsBool(v, 1);
   }
 }
 
-if (typeof SIMD.int64x2.check === "undefined") {
+if (typeof SIMD.Int64x2.check === "undefined") {
   /**
-    * Check whether the argument is a int64x2.
-    * @param {int64x2} v An instance of int64x2.
-    * @return {int64x2} The int64x2 instance.
+    * Check whether the argument is a Int64x2.
+    * @param {Int64x2} v An instance of Int64x2.
+    * @return {Int64x2} The Int64x2 instance.
     */
-  SIMD.int64x2.check = function(v) {
-    if (!(v instanceof SIMD.int64x2)) {
-      throw new TypeError("argument is not a int64x2.");
+  SIMD.Int64x2.check = function(v) {
+    if (!(v instanceof SIMD.Int64x2)) {
+      throw new TypeError("argument is not a Int64x2.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.bool === "undefined") {
+if (typeof SIMD.Int64x2.bool === "undefined") {
   /**
-    * Construct a new instance of int64x2 number with either true or false in
+    * Construct a new instance of Int64x2 number with either true or false in
     * each lane, depending on the truth values in x and y.
     * @param {boolean} flag used for x lane.
     * @param {boolean} flag used for y lane.
     * @constructor
     */
-  SIMD.int64x2.bool = function(x, y) {
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.bool(x, 0, y, 0);
+  SIMD.Int64x2.bool = function(x, y) {
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.bool(x, 0, y, 0);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Int64x2.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {int64x2} a bit-wise copy of t as an int64x2.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Int64x2} a bit-wise copy of t as an Int64x2.
    */
-  SIMD.int64x2.fromFloat64x2Bits = function(t) {
+  SIMD.Int64x2.fromFloat64x2Bits = function(t) {
     saveFloat64x2(t);
-    var v = SIMD.int64x2();
+    var v = SIMD.Int64x2();
     v.int32x4_ = restoreInt32x4();
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Int64x2.fromInt32x4Bits === "undefined") {
   /**
-   * @param {int32x4} t An instance of int32x4.
-   * @return {int64x2} a bit-wise copy of t as an int64x2.
+   * @param {Int32x4} t An instance of Int32x4.
+   * @return {Int64x2} a bit-wise copy of t as an Int64x2.
    */
-  SIMD.int64x2.fromInt32x4Bits = function(t) {
-    t = SIMD.int32x4.check(t);
-    var v = SIMD.int64x2();
+  SIMD.Int64x2.fromInt32x4Bits = function(t) {
+    t = SIMD.Int32x4.check(t);
+    var v = SIMD.Int64x2();
     v.int32x4_ = t;
     return v;
   }
 }
 
-if (typeof SIMD.float32x4.abs === "undefined") {
+if (typeof SIMD.Float32x4.abs === "undefined") {
   /**
-   * @param {float32x4} t An instance of float32x4.
-   * @return {float32x4} New instance of float32x4 with absolute values of
+   * @param {Float32x4} t An instance of Float32x4.
+   * @return {Float32x4} New instance of Float32x4 with absolute values of
    * t.
    */
-  SIMD.float32x4.abs = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(Math.abs(SIMD.float32x4.extractLane(t, 0)),
-                          Math.abs(SIMD.float32x4.extractLane(t, 1)),
-                          Math.abs(SIMD.float32x4.extractLane(t, 2)),
-                          Math.abs(SIMD.float32x4.extractLane(t, 3)));
+  SIMD.Float32x4.abs = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(Math.abs(SIMD.Float32x4.extractLane(t, 0)),
+                          Math.abs(SIMD.Float32x4.extractLane(t, 1)),
+                          Math.abs(SIMD.Float32x4.extractLane(t, 2)),
+                          Math.abs(SIMD.Float32x4.extractLane(t, 3)));
   }
 }
 
-if (typeof SIMD.float32x4.neg === "undefined") {
+if (typeof SIMD.Float32x4.neg === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with negated values of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with negated values of
     * t.
     */
-  SIMD.float32x4.neg = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(-SIMD.float32x4.extractLane(t, 0),
-                          -SIMD.float32x4.extractLane(t, 1),
-                          -SIMD.float32x4.extractLane(t, 2),
-                          -SIMD.float32x4.extractLane(t, 3));
+  SIMD.Float32x4.neg = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(-SIMD.Float32x4.extractLane(t, 0),
+                          -SIMD.Float32x4.extractLane(t, 1),
+                          -SIMD.Float32x4.extractLane(t, 2),
+                          -SIMD.Float32x4.extractLane(t, 3));
   }
 }
 
-if (typeof SIMD.float32x4.add === "undefined") {
+if (typeof SIMD.Float32x4.add === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a + b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a + b.
     */
-  SIMD.float32x4.add = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(
-        SIMD.float32x4.extractLane(a, 0) + SIMD.float32x4.extractLane(b, 0),
-        SIMD.float32x4.extractLane(a, 1) + SIMD.float32x4.extractLane(b, 1),
-        SIMD.float32x4.extractLane(a, 2) + SIMD.float32x4.extractLane(b, 2),
-        SIMD.float32x4.extractLane(a, 3) + SIMD.float32x4.extractLane(b, 3));
+  SIMD.Float32x4.add = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(
+        SIMD.Float32x4.extractLane(a, 0) + SIMD.Float32x4.extractLane(b, 0),
+        SIMD.Float32x4.extractLane(a, 1) + SIMD.Float32x4.extractLane(b, 1),
+        SIMD.Float32x4.extractLane(a, 2) + SIMD.Float32x4.extractLane(b, 2),
+        SIMD.Float32x4.extractLane(a, 3) + SIMD.Float32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.float32x4.sub === "undefined") {
+if (typeof SIMD.Float32x4.sub === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a - b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a - b.
     */
-  SIMD.float32x4.sub = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(
-        SIMD.float32x4.extractLane(a, 0) - SIMD.float32x4.extractLane(b, 0),
-        SIMD.float32x4.extractLane(a, 1) - SIMD.float32x4.extractLane(b, 1),
-        SIMD.float32x4.extractLane(a, 2) - SIMD.float32x4.extractLane(b, 2),
-        SIMD.float32x4.extractLane(a, 3) - SIMD.float32x4.extractLane(b, 3));
+  SIMD.Float32x4.sub = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(
+        SIMD.Float32x4.extractLane(a, 0) - SIMD.Float32x4.extractLane(b, 0),
+        SIMD.Float32x4.extractLane(a, 1) - SIMD.Float32x4.extractLane(b, 1),
+        SIMD.Float32x4.extractLane(a, 2) - SIMD.Float32x4.extractLane(b, 2),
+        SIMD.Float32x4.extractLane(a, 3) - SIMD.Float32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.float32x4.mul === "undefined") {
+if (typeof SIMD.Float32x4.mul === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a * b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a * b.
     */
-  SIMD.float32x4.mul = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(
-        SIMD.float32x4.extractLane(a, 0) * SIMD.float32x4.extractLane(b, 0),
-        SIMD.float32x4.extractLane(a, 1) * SIMD.float32x4.extractLane(b, 1),
-        SIMD.float32x4.extractLane(a, 2) * SIMD.float32x4.extractLane(b, 2),
-        SIMD.float32x4.extractLane(a, 3) * SIMD.float32x4.extractLane(b, 3));
+  SIMD.Float32x4.mul = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(
+        SIMD.Float32x4.extractLane(a, 0) * SIMD.Float32x4.extractLane(b, 0),
+        SIMD.Float32x4.extractLane(a, 1) * SIMD.Float32x4.extractLane(b, 1),
+        SIMD.Float32x4.extractLane(a, 2) * SIMD.Float32x4.extractLane(b, 2),
+        SIMD.Float32x4.extractLane(a, 3) * SIMD.Float32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.float32x4.div === "undefined") {
+if (typeof SIMD.Float32x4.div === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a / b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a / b.
     */
-  SIMD.float32x4.div = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(
-        SIMD.float32x4.extractLane(a, 0) / SIMD.float32x4.extractLane(b, 0),
-        SIMD.float32x4.extractLane(a, 1) / SIMD.float32x4.extractLane(b, 1),
-        SIMD.float32x4.extractLane(a, 2) / SIMD.float32x4.extractLane(b, 2),
-        SIMD.float32x4.extractLane(a, 3) / SIMD.float32x4.extractLane(b, 3));
+  SIMD.Float32x4.div = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(
+        SIMD.Float32x4.extractLane(a, 0) / SIMD.Float32x4.extractLane(b, 0),
+        SIMD.Float32x4.extractLane(a, 1) / SIMD.Float32x4.extractLane(b, 1),
+        SIMD.Float32x4.extractLane(a, 2) / SIMD.Float32x4.extractLane(b, 2),
+        SIMD.Float32x4.extractLane(a, 3) / SIMD.Float32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.float32x4.min === "undefined") {
+if (typeof SIMD.Float32x4.min === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the minimum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the minimum value of
     * t and other.
     */
-  SIMD.float32x4.min = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = Math.min(SIMD.float32x4.extractLane(t, 0),
-                      SIMD.float32x4.extractLane(other, 0));
-    var cy = Math.min(SIMD.float32x4.extractLane(t, 1),
-                      SIMD.float32x4.extractLane(other, 1));
-    var cz = Math.min(SIMD.float32x4.extractLane(t, 2),
-                      SIMD.float32x4.extractLane(other, 2));
-    var cw = Math.min(SIMD.float32x4.extractLane(t, 3),
-                      SIMD.float32x4.extractLane(other, 3));
-    return SIMD.float32x4(cx, cy, cz, cw);
+  SIMD.Float32x4.min = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = Math.min(SIMD.Float32x4.extractLane(t, 0),
+                      SIMD.Float32x4.extractLane(other, 0));
+    var cy = Math.min(SIMD.Float32x4.extractLane(t, 1),
+                      SIMD.Float32x4.extractLane(other, 1));
+    var cz = Math.min(SIMD.Float32x4.extractLane(t, 2),
+                      SIMD.Float32x4.extractLane(other, 2));
+    var cw = Math.min(SIMD.Float32x4.extractLane(t, 3),
+                      SIMD.Float32x4.extractLane(other, 3));
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.max === "undefined") {
+if (typeof SIMD.Float32x4.max === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the maximum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the maximum value of
     * t and other.
     */
-  SIMD.float32x4.max = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = Math.max(SIMD.float32x4.extractLane(t, 0),
-                      SIMD.float32x4.extractLane(other, 0));
-    var cy = Math.max(SIMD.float32x4.extractLane(t, 1),
-                      SIMD.float32x4.extractLane(other, 1));
-    var cz = Math.max(SIMD.float32x4.extractLane(t, 2),
-                      SIMD.float32x4.extractLane(other, 2));
-    var cw = Math.max(SIMD.float32x4.extractLane(t, 3),
-                      SIMD.float32x4.extractLane(other, 3));
-    return SIMD.float32x4(cx, cy, cz, cw);
+  SIMD.Float32x4.max = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = Math.max(SIMD.Float32x4.extractLane(t, 0),
+                      SIMD.Float32x4.extractLane(other, 0));
+    var cy = Math.max(SIMD.Float32x4.extractLane(t, 1),
+                      SIMD.Float32x4.extractLane(other, 1));
+    var cz = Math.max(SIMD.Float32x4.extractLane(t, 2),
+                      SIMD.Float32x4.extractLane(other, 2));
+    var cw = Math.max(SIMD.Float32x4.extractLane(t, 3),
+                      SIMD.Float32x4.extractLane(other, 3));
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.minNum === "undefined") {
+if (typeof SIMD.Float32x4.minNum === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the minimum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the minimum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float32x4.minNum = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = minNum(SIMD.float32x4.extractLane(t, 0),
-                    SIMD.float32x4.extractLane(other, 0));
-    var cy = minNum(SIMD.float32x4.extractLane(t, 1),
-                    SIMD.float32x4.extractLane(other, 1));
-    var cz = minNum(SIMD.float32x4.extractLane(t, 2),
-                    SIMD.float32x4.extractLane(other, 2));
-    var cw = minNum(SIMD.float32x4.extractLane(t, 3),
-                    SIMD.float32x4.extractLane(other, 3));
-    return SIMD.float32x4(cx, cy, cz, cw);
+  SIMD.Float32x4.minNum = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = minNum(SIMD.Float32x4.extractLane(t, 0),
+                    SIMD.Float32x4.extractLane(other, 0));
+    var cy = minNum(SIMD.Float32x4.extractLane(t, 1),
+                    SIMD.Float32x4.extractLane(other, 1));
+    var cz = minNum(SIMD.Float32x4.extractLane(t, 2),
+                    SIMD.Float32x4.extractLane(other, 2));
+    var cw = minNum(SIMD.Float32x4.extractLane(t, 3),
+                    SIMD.Float32x4.extractLane(other, 3));
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.maxNum === "undefined") {
+if (typeof SIMD.Float32x4.maxNum === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the maximum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the maximum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float32x4.maxNum = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = maxNum(SIMD.float32x4.extractLane(t, 0),
-                    SIMD.float32x4.extractLane(other, 0));
-    var cy = maxNum(SIMD.float32x4.extractLane(t, 1),
-                    SIMD.float32x4.extractLane(other, 1));
-    var cz = maxNum(SIMD.float32x4.extractLane(t, 2),
-                    SIMD.float32x4.extractLane(other, 2));
-    var cw = maxNum(SIMD.float32x4.extractLane(t, 3),
-                    SIMD.float32x4.extractLane(other, 3));
-    return SIMD.float32x4(cx, cy, cz, cw);
+  SIMD.Float32x4.maxNum = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = maxNum(SIMD.Float32x4.extractLane(t, 0),
+                    SIMD.Float32x4.extractLane(other, 0));
+    var cy = maxNum(SIMD.Float32x4.extractLane(t, 1),
+                    SIMD.Float32x4.extractLane(other, 1));
+    var cz = maxNum(SIMD.Float32x4.extractLane(t, 2),
+                    SIMD.Float32x4.extractLane(other, 2));
+    var cw = maxNum(SIMD.Float32x4.extractLane(t, 3),
+                    SIMD.Float32x4.extractLane(other, 3));
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.reciprocalApproximation === "undefined") {
+if (typeof SIMD.Float32x4.reciprocalApproximation === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with an approximation of the
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with an approximation of the
     * reciprocal value of t.
     */
-  SIMD.float32x4.reciprocalApproximation = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4.div(SIMD.float32x4.splat(1.0), t);
+  SIMD.Float32x4.reciprocalApproximation = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4.div(SIMD.Float32x4.splat(1.0), t);
   }
 }
 
-if (typeof SIMD.float32x4.reciprocalSqrtApproximation === "undefined") {
+if (typeof SIMD.Float32x4.reciprocalSqrtApproximation === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with an approximation of the
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with an approximation of the
     * reciprocal value of the square root of t.
     */
-  SIMD.float32x4.reciprocalSqrtApproximation = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4.reciprocalApproximation(SIMD.float32x4.sqrt(t));
+  SIMD.Float32x4.reciprocalSqrtApproximation = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4.reciprocalApproximation(SIMD.Float32x4.sqrt(t));
   }
 }
 
-if (typeof SIMD.float32x4.sqrt === "undefined") {
+if (typeof SIMD.Float32x4.sqrt === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with square root of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with square root of
     * values of t.
     */
-  SIMD.float32x4.sqrt = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(Math.sqrt(SIMD.float32x4.extractLane(t, 0)),
-                          Math.sqrt(SIMD.float32x4.extractLane(t, 1)),
-                          Math.sqrt(SIMD.float32x4.extractLane(t, 2)),
-                          Math.sqrt(SIMD.float32x4.extractLane(t, 3)));
+  SIMD.Float32x4.sqrt = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(Math.sqrt(SIMD.Float32x4.extractLane(t, 0)),
+                          Math.sqrt(SIMD.Float32x4.extractLane(t, 1)),
+                          Math.sqrt(SIMD.Float32x4.extractLane(t, 2)),
+                          Math.sqrt(SIMD.Float32x4.extractLane(t, 3)));
   }
 }
 
-if (typeof SIMD.float32x4.swizzle === "undefined") {
+if (typeof SIMD.Float32x4.swizzle === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4 to be swizzled.
+    * @param {Float32x4} t An instance of Float32x4 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
     * @param {integer} z - Index in t for lane z
     * @param {integer} w - Index in t for lane w
-    * @return {float32x4} New instance of float32x4 with lanes swizzled.
+    * @return {Float32x4} New instance of Float32x4 with lanes swizzled.
     */
-  SIMD.float32x4.swizzle = function(t, x, y, z, w) {
-    t = SIMD.float32x4.check(t);
+  SIMD.Float32x4.swizzle = function(t, x, y, z, w) {
+    t = SIMD.Float32x4.check(t);
     check4(x);
     check4(y);
     check4(z);
     check4(w);
-    _f32x4[0] = SIMD.float32x4.extractLane(t, 0);
-    _f32x4[1] = SIMD.float32x4.extractLane(t, 1);
-    _f32x4[2] = SIMD.float32x4.extractLane(t, 2);
-    _f32x4[3] = SIMD.float32x4.extractLane(t, 3);
+    _f32x4[0] = SIMD.Float32x4.extractLane(t, 0);
+    _f32x4[1] = SIMD.Float32x4.extractLane(t, 1);
+    _f32x4[2] = SIMD.Float32x4.extractLane(t, 2);
+    _f32x4[3] = SIMD.Float32x4.extractLane(t, 3);
     var storage = _f32x4;
-    return SIMD.float32x4(storage[x], storage[y], storage[z], storage[w]);
+    return SIMD.Float32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.float32x4.shuffle === "undefined") {
+if (typeof SIMD.Float32x4.shuffle === "undefined") {
 
   _f32x8 = new Float32Array(8);
 
   /**
-    * @param {float32x4} t1 An instance of float32x4 to be shuffled.
-    * @param {float32x4} t2 An instance of float32x4 to be shuffled.
+    * @param {Float32x4} t1 An instance of Float32x4 to be shuffled.
+    * @param {Float32x4} t2 An instance of Float32x4 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
     * @param {integer} z - Index in concatenation of t1 and t2 for lane z
     * @param {integer} w - Index in concatenation of t1 and t2 for lane w
-    * @return {float32x4} New instance of float32x4 with lanes shuffled.
+    * @return {Float32x4} New instance of Float32x4 with lanes shuffled.
     */
-  SIMD.float32x4.shuffle = function(t1, t2, x, y, z, w) {
-    t1 = SIMD.float32x4.check(t1);
-    t2 = SIMD.float32x4.check(t2);
+  SIMD.Float32x4.shuffle = function(t1, t2, x, y, z, w) {
+    t1 = SIMD.Float32x4.check(t1);
+    t2 = SIMD.Float32x4.check(t2);
     check8(x);
     check8(y);
     check8(z);
     check8(w);
     var storage = _f32x8;
-    storage[0] = SIMD.float32x4.extractLane(t1, 0);
-    storage[1] = SIMD.float32x4.extractLane(t1, 1);
-    storage[2] = SIMD.float32x4.extractLane(t1, 2);
-    storage[3] = SIMD.float32x4.extractLane(t1, 3);
-    storage[4] = SIMD.float32x4.extractLane(t2, 0);
-    storage[5] = SIMD.float32x4.extractLane(t2, 1);
-    storage[6] = SIMD.float32x4.extractLane(t2, 2);
-    storage[7] = SIMD.float32x4.extractLane(t2, 3);
-    return SIMD.float32x4(storage[x], storage[y], storage[z], storage[w]);
+    storage[0] = SIMD.Float32x4.extractLane(t1, 0);
+    storage[1] = SIMD.Float32x4.extractLane(t1, 1);
+    storage[2] = SIMD.Float32x4.extractLane(t1, 2);
+    storage[3] = SIMD.Float32x4.extractLane(t1, 3);
+    storage[4] = SIMD.Float32x4.extractLane(t2, 0);
+    storage[5] = SIMD.Float32x4.extractLane(t2, 1);
+    storage[6] = SIMD.Float32x4.extractLane(t2, 2);
+    storage[7] = SIMD.Float32x4.extractLane(t2, 3);
+    return SIMD.Float32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.float32x4.lessThan === "undefined") {
+if (typeof SIMD.Float32x4.lessThan === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.float32x4.lessThan = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.lessThan = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx =
-        SIMD.float32x4.extractLane(t, 0) < SIMD.float32x4.extractLane(other, 0);
+        SIMD.Float32x4.extractLane(t, 0) < SIMD.Float32x4.extractLane(other, 0);
     var cy =
-        SIMD.float32x4.extractLane(t, 1) < SIMD.float32x4.extractLane(other, 1);
+        SIMD.Float32x4.extractLane(t, 1) < SIMD.Float32x4.extractLane(other, 1);
     var cz =
-        SIMD.float32x4.extractLane(t, 2) < SIMD.float32x4.extractLane(other, 2);
+        SIMD.Float32x4.extractLane(t, 2) < SIMD.Float32x4.extractLane(other, 2);
     var cw =
-        SIMD.float32x4.extractLane(t, 3) < SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Float32x4.extractLane(t, 3) < SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Float32x4.lessThanOrEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.float32x4.lessThanOrEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = SIMD.float32x4.extractLane(t, 0) <=
-        SIMD.float32x4.extractLane(other, 0);
-    var cy = SIMD.float32x4.extractLane(t, 1) <=
-        SIMD.float32x4.extractLane(other, 1);
-    var cz = SIMD.float32x4.extractLane(t, 2) <=
-        SIMD.float32x4.extractLane(other, 2);
-    var cw = SIMD.float32x4.extractLane(t, 3) <=
-        SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+  SIMD.Float32x4.lessThanOrEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = SIMD.Float32x4.extractLane(t, 0) <=
+        SIMD.Float32x4.extractLane(other, 0);
+    var cy = SIMD.Float32x4.extractLane(t, 1) <=
+        SIMD.Float32x4.extractLane(other, 1);
+    var cz = SIMD.Float32x4.extractLane(t, 2) <=
+        SIMD.Float32x4.extractLane(other, 2);
+    var cw = SIMD.Float32x4.extractLane(t, 3) <=
+        SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.equal === "undefined") {
+if (typeof SIMD.Float32x4.equal === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.float32x4.equal = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = SIMD.float32x4.extractLane(t, 0) ==
-        SIMD.float32x4.extractLane(other, 0);
-    var cy = SIMD.float32x4.extractLane(t, 1) ==
-        SIMD.float32x4.extractLane(other, 1);
-    var cz = SIMD.float32x4.extractLane(t, 2) ==
-        SIMD.float32x4.extractLane(other, 2);
-    var cw = SIMD.float32x4.extractLane(t, 3) ==
-        SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+  SIMD.Float32x4.equal = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = SIMD.Float32x4.extractLane(t, 0) ==
+        SIMD.Float32x4.extractLane(other, 0);
+    var cy = SIMD.Float32x4.extractLane(t, 1) ==
+        SIMD.Float32x4.extractLane(other, 1);
+    var cz = SIMD.Float32x4.extractLane(t, 2) ==
+        SIMD.Float32x4.extractLane(other, 2);
+    var cw = SIMD.Float32x4.extractLane(t, 3) ==
+        SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.notEqual === "undefined") {
+if (typeof SIMD.Float32x4.notEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.float32x4.notEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = SIMD.float32x4.extractLane(t, 0) !=
-        SIMD.float32x4.extractLane(other, 0);
-    var cy = SIMD.float32x4.extractLane(t, 1) !=
-        SIMD.float32x4.extractLane(other, 1);
-    var cz = SIMD.float32x4.extractLane(t, 2) !=
-        SIMD.float32x4.extractLane(other, 2);
-    var cw = SIMD.float32x4.extractLane(t, 3) !=
-        SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+  SIMD.Float32x4.notEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = SIMD.Float32x4.extractLane(t, 0) !=
+        SIMD.Float32x4.extractLane(other, 0);
+    var cy = SIMD.Float32x4.extractLane(t, 1) !=
+        SIMD.Float32x4.extractLane(other, 1);
+    var cz = SIMD.Float32x4.extractLane(t, 2) !=
+        SIMD.Float32x4.extractLane(other, 2);
+    var cw = SIMD.Float32x4.extractLane(t, 3) !=
+        SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Float32x4.greaterThanOrEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.float32x4.greaterThanOrEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
-    var cx = SIMD.float32x4.extractLane(t, 0) >=
-        SIMD.float32x4.extractLane(other, 0);
-    var cy = SIMD.float32x4.extractLane(t, 1) >=
-        SIMD.float32x4.extractLane(other, 1);
-    var cz = SIMD.float32x4.extractLane(t, 2) >=
-        SIMD.float32x4.extractLane(other, 2);
-    var cw = SIMD.float32x4.extractLane(t, 3) >=
-        SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+  SIMD.Float32x4.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
+    var cx = SIMD.Float32x4.extractLane(t, 0) >=
+        SIMD.Float32x4.extractLane(other, 0);
+    var cy = SIMD.Float32x4.extractLane(t, 1) >=
+        SIMD.Float32x4.extractLane(other, 1);
+    var cz = SIMD.Float32x4.extractLane(t, 2) >=
+        SIMD.Float32x4.extractLane(other, 2);
+    var cw = SIMD.Float32x4.extractLane(t, 3) >=
+        SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.greaterThan === "undefined") {
+if (typeof SIMD.Float32x4.greaterThan === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.float32x4.greaterThan = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.greaterThan = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx =
-        SIMD.float32x4.extractLane(t, 0) > SIMD.float32x4.extractLane(other, 0);
+        SIMD.Float32x4.extractLane(t, 0) > SIMD.Float32x4.extractLane(other, 0);
     var cy =
-        SIMD.float32x4.extractLane(t, 1) > SIMD.float32x4.extractLane(other, 1);
+        SIMD.Float32x4.extractLane(t, 1) > SIMD.Float32x4.extractLane(other, 1);
     var cz =
-        SIMD.float32x4.extractLane(t, 2) > SIMD.float32x4.extractLane(other, 2);
+        SIMD.Float32x4.extractLane(t, 2) > SIMD.Float32x4.extractLane(other, 2);
     var cw =
-        SIMD.float32x4.extractLane(t, 3) > SIMD.float32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Float32x4.extractLane(t, 3) > SIMD.Float32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.select === "undefined") {
+if (typeof SIMD.Float32x4.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float32x4} trueValue Pick lane from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float32x4} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {float32x4} falseValue Pick lane from here if corresponding
+    * @param {Float32x4} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {float32x4} Mix of lanes from trueValue or falseValue as
+    * @return {Float32x4} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.float32x4.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float32x4.check(trueValue);
-    falseValue = SIMD.float32x4.check(falseValue);
-    return SIMD.float32x4(
-        SIMD.int32x4.extractLaneAsBool(t, 0) ?
-            SIMD.float32x4.extractLane(trueValue, 0) :
-                SIMD.float32x4.extractLane(falseValue, 0),
-        SIMD.int32x4.extractLaneAsBool(t, 1) ?
-            SIMD.float32x4.extractLane(trueValue, 1) :
-                SIMD.float32x4.extractLane(falseValue, 1),
-        SIMD.int32x4.extractLaneAsBool(t, 2) ?
-            SIMD.float32x4.extractLane(trueValue, 2) :
-                SIMD.float32x4.extractLane(falseValue, 2),
-        SIMD.int32x4.extractLaneAsBool(t, 3) ?
-            SIMD.float32x4.extractLane(trueValue, 3) :
-                SIMD.float32x4.extractLane(falseValue, 3));
+  SIMD.Float32x4.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float32x4.check(trueValue);
+    falseValue = SIMD.Float32x4.check(falseValue);
+    return SIMD.Float32x4(
+        SIMD.Int32x4.extractLaneAsBool(t, 0) ?
+            SIMD.Float32x4.extractLane(trueValue, 0) :
+                SIMD.Float32x4.extractLane(falseValue, 0),
+        SIMD.Int32x4.extractLaneAsBool(t, 1) ?
+            SIMD.Float32x4.extractLane(trueValue, 1) :
+                SIMD.Float32x4.extractLane(falseValue, 1),
+        SIMD.Int32x4.extractLaneAsBool(t, 2) ?
+            SIMD.Float32x4.extractLane(trueValue, 2) :
+                SIMD.Float32x4.extractLane(falseValue, 2),
+        SIMD.Int32x4.extractLaneAsBool(t, 3) ?
+            SIMD.Float32x4.extractLane(trueValue, 3) :
+                SIMD.Float32x4.extractLane(falseValue, 3));
   }
 }
 
-if (typeof SIMD.float32x4.selectBits === "undefined") {
+if (typeof SIMD.Float32x4.selectBits === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float32x4} trueValue Pick bit from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float32x4} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {float32x4} falseValue Pick bit from here if corresponding
+    * @param {Float32x4} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {float32x4} Mix of bits from trueValue or falseValue as
+    * @return {Float32x4} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.float32x4.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float32x4.check(trueValue);
-    falseValue = SIMD.float32x4.check(falseValue);
-    var tv = SIMD.int32x4.fromFloat32x4Bits(trueValue);
-    var fv = SIMD.int32x4.fromFloat32x4Bits(falseValue);
-    var tr = SIMD.int32x4.and(t, tv);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+  SIMD.Float32x4.selectBits = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float32x4.check(trueValue);
+    falseValue = SIMD.Float32x4.check(falseValue);
+    var tv = SIMD.Int32x4.fromFloat32x4Bits(trueValue);
+    var fv = SIMD.Int32x4.fromFloat32x4Bits(falseValue);
+    var tr = SIMD.Int32x4.and(t, tv);
+    var fr = SIMD.Int32x4.and(SIMD.Int32x4.not(t), fv);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.or(tr, fr));
   }
 }
 
-if (typeof SIMD.float32x4.and === "undefined") {
+if (typeof SIMD.Float32x4.and === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a & b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a & b.
     */
-  SIMD.float32x4.and = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(aInt, bInt));
+  SIMD.Float32x4.and = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.or === "undefined") {
+if (typeof SIMD.Float32x4.or === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a | b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a | b.
     */
-  SIMD.float32x4.or = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.or(aInt, bInt));
+  SIMD.Float32x4.or = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.or(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.xor === "undefined") {
+if (typeof SIMD.Float32x4.xor === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a ^ b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a ^ b.
     */
-  SIMD.float32x4.xor = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.xor(aInt, bInt));
+  SIMD.Float32x4.xor = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.xor(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.not === "undefined") {
+if (typeof SIMD.Float32x4.not === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of ~a.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of ~a.
     */
-  SIMD.float32x4.not = function(a) {
-    a = SIMD.float32x4.check(a);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.not(aInt));
+  SIMD.Float32x4.not = function(a) {
+    a = SIMD.Float32x4.check(a);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.not(aInt));
   }
 }
 
-if (typeof SIMD.float32x4.load === "undefined") {
+if (typeof SIMD.Float32x4.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.load = function(tarray, index) {
+  SIMD.Float32x4.load = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2092,17 +2092,17 @@ if (typeof SIMD.float32x4.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float32x4(f32temp[0], f32temp[1], f32temp[2], f32temp[3]);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], f32temp[2], f32temp[3]);
   }
 }
 
-if (typeof SIMD.float32x4.load1 === "undefined") {
+if (typeof SIMD.Float32x4.load1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.load1 = function(tarray, index) {
+  SIMD.Float32x4.load1 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2118,17 +2118,17 @@ if (typeof SIMD.float32x4.load1 === "undefined") {
     var n = 4 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float32x4(f32temp[0], 0.0, 0.0, 0.0);
+    return SIMD.Float32x4(f32temp[0], 0.0, 0.0, 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.load2 === "undefined") {
+if (typeof SIMD.Float32x4.load2 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.load2 = function(tarray, index) {
+  SIMD.Float32x4.load2 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2144,17 +2144,17 @@ if (typeof SIMD.float32x4.load2 === "undefined") {
     var n = 8 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float32x4(f32temp[0], f32temp[1], 0.0, 0.0);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], 0.0, 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.load3 === "undefined") {
+if (typeof SIMD.Float32x4.load3 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.load3 = function(tarray, index) {
+  SIMD.Float32x4.load3 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2170,18 +2170,18 @@ if (typeof SIMD.float32x4.load3 === "undefined") {
     var n = 12 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float32x4(f32temp[0], f32temp[1], f32temp[2], 0.0);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], f32temp[2], 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.store === "undefined") {
+if (typeof SIMD.Float32x4.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
-    * @return {float32x4} value
+    * @param {Float32x4} value An instance of Float32x4.
+    * @return {Float32x4} value
     */
-  SIMD.float32x4.store = function(tarray, index, value) {
+  SIMD.Float32x4.store = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2189,11 +2189,11 @@ if (typeof SIMD.float32x4.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
-    _f32x4[0] = SIMD.float32x4.extractLane(value, 0);
-    _f32x4[1] = SIMD.float32x4.extractLane(value, 1);
-    _f32x4[2] = SIMD.float32x4.extractLane(value, 2);
-    _f32x4[3] = SIMD.float32x4.extractLane(value, 3);
+    value = SIMD.Float32x4.check(value);
+    _f32x4[0] = SIMD.Float32x4.extractLane(value, 0);
+    _f32x4[1] = SIMD.Float32x4.extractLane(value, 1);
+    _f32x4[2] = SIMD.Float32x4.extractLane(value, 2);
+    _f32x4[3] = SIMD.Float32x4.extractLane(value, 3);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -2205,14 +2205,14 @@ if (typeof SIMD.float32x4.store === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.store1 === "undefined") {
+if (typeof SIMD.Float32x4.store1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
-    * @return {float32x4} value
+    * @param {Float32x4} value An instance of Float32x4.
+    * @return {Float32x4} value
     */
-  SIMD.float32x4.store1 = function(tarray, index, value) {
+  SIMD.Float32x4.store1 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2220,14 +2220,14 @@ if (typeof SIMD.float32x4.store1 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 4) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Float32Array(tarray.buffer,
                                   tarray.byteOffset + index * 8, 1);
-      view[0] = SIMD.float32x4.extractLane(value, 0);
+      view[0] = SIMD.Float32x4.extractLane(value, 0);
     } else {
-      _f32x4[0] = SIMD.float32x4.extractLane(value, 0);
+      _f32x4[0] = SIMD.Float32x4.extractLane(value, 0);
       var array = bpe == 1 ? _i8x16 :
                   bpe == 2 ? _i16x8 :
                   (tarray instanceof Float32Array ? _f32x4 : _i32x4);
@@ -2239,14 +2239,14 @@ if (typeof SIMD.float32x4.store1 === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.store2 === "undefined") {
+if (typeof SIMD.Float32x4.store2 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
-    * @return {float32x4} value
+    * @param {Float32x4} value An instance of Float32x4.
+    * @return {Float32x4} value
     */
-  SIMD.float32x4.store2 = function(tarray, index, value) {
+  SIMD.Float32x4.store2 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2254,9 +2254,9 @@ if (typeof SIMD.float32x4.store2 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
-    _f32x4[0] = SIMD.float32x4.extractLane(value, 0);
-    _f32x4[1] = SIMD.float32x4.extractLane(value, 1);
+    value = SIMD.Float32x4.check(value);
+    _f32x4[0] = SIMD.Float32x4.extractLane(value, 0);
+    _f32x4[1] = SIMD.Float32x4.extractLane(value, 1);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -2268,14 +2268,14 @@ if (typeof SIMD.float32x4.store2 === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.store3 === "undefined") {
+if (typeof SIMD.Float32x4.store3 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
-    * @return {float32x4} value
+    * @param {Float32x4} value An instance of Float32x4.
+    * @return {Float32x4} value
     */
-  SIMD.float32x4.store3 = function(tarray, index, value) {
+  SIMD.Float32x4.store3 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2283,18 +2283,18 @@ if (typeof SIMD.float32x4.store3 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 12) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Float32Array(tarray.buffer,
                                   tarray.byteOffset + index * 8, 3);
-      view[0] = SIMD.float32x4.extractLane(value, 0);
-      view[1] = SIMD.float32x4.extractLane(value, 1);
-      view[2] = SIMD.float32x4.extractLane(value, 2);
+      view[0] = SIMD.Float32x4.extractLane(value, 0);
+      view[1] = SIMD.Float32x4.extractLane(value, 1);
+      view[2] = SIMD.Float32x4.extractLane(value, 2);
     } else {
-      _f32x4[0] = SIMD.float32x4.extractLane(value, 0);
-      _f32x4[1] = SIMD.float32x4.extractLane(value, 1);
-      _f32x4[2] = SIMD.float32x4.extractLane(value, 2);
+      _f32x4[0] = SIMD.Float32x4.extractLane(value, 0);
+      _f32x4[1] = SIMD.Float32x4.extractLane(value, 1);
+      _f32x4[2] = SIMD.Float32x4.extractLane(value, 2);
       var array = bpe == 1 ? _i8x16 :
                   bpe == 2 ? _i16x8 :
                   (tarray instanceof Float32Array ? _f32x4 : _i32x4);
@@ -2306,405 +2306,405 @@ if (typeof SIMD.float32x4.store3 === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.abs === "undefined") {
+if (typeof SIMD.Float64x2.abs === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {float64x2} New instance of float64x2 with absolute values of
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Float64x2} New instance of Float64x2 with absolute values of
    * t.
    */
-  SIMD.float64x2.abs = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(Math.abs(SIMD.float64x2.extractLane(t, 0)),
-                          Math.abs(SIMD.float64x2.extractLane(t, 1)));
+  SIMD.Float64x2.abs = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(Math.abs(SIMD.Float64x2.extractLane(t, 0)),
+                          Math.abs(SIMD.Float64x2.extractLane(t, 1)));
   }
 }
 
-if (typeof SIMD.float64x2.neg === "undefined") {
+if (typeof SIMD.Float64x2.neg === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with negated values of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with negated values of
     * t.
     */
-  SIMD.float64x2.neg = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(-SIMD.float64x2.extractLane(t, 0),
-                          -SIMD.float64x2.extractLane(t, 1));
+  SIMD.Float64x2.neg = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(-SIMD.Float64x2.extractLane(t, 0),
+                          -SIMD.Float64x2.extractLane(t, 1));
   }
 }
 
-if (typeof SIMD.float64x2.add === "undefined") {
+if (typeof SIMD.Float64x2.add === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a + b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a + b.
     */
-  SIMD.float64x2.add = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(
-        SIMD.float64x2.extractLane(a, 0) + SIMD.float64x2.extractLane(b, 0),
-        SIMD.float64x2.extractLane(a, 1) + SIMD.float64x2.extractLane(b, 1));
+  SIMD.Float64x2.add = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(
+        SIMD.Float64x2.extractLane(a, 0) + SIMD.Float64x2.extractLane(b, 0),
+        SIMD.Float64x2.extractLane(a, 1) + SIMD.Float64x2.extractLane(b, 1));
   }
 }
 
-if (typeof SIMD.float64x2.sub === "undefined") {
+if (typeof SIMD.Float64x2.sub === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a - b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a - b.
     */
-  SIMD.float64x2.sub = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(
-        SIMD.float64x2.extractLane(a, 0) - SIMD.float64x2.extractLane(b, 0),
-        SIMD.float64x2.extractLane(a, 1) - SIMD.float64x2.extractLane(b, 1));
+  SIMD.Float64x2.sub = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(
+        SIMD.Float64x2.extractLane(a, 0) - SIMD.Float64x2.extractLane(b, 0),
+        SIMD.Float64x2.extractLane(a, 1) - SIMD.Float64x2.extractLane(b, 1));
   }
 }
 
-if (typeof SIMD.float64x2.mul === "undefined") {
+if (typeof SIMD.Float64x2.mul === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a * b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a * b.
     */
-  SIMD.float64x2.mul = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(
-        SIMD.float64x2.extractLane(a, 0) * SIMD.float64x2.extractLane(b, 0),
-        SIMD.float64x2.extractLane(a, 1) * SIMD.float64x2.extractLane(b, 1));
+  SIMD.Float64x2.mul = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(
+        SIMD.Float64x2.extractLane(a, 0) * SIMD.Float64x2.extractLane(b, 0),
+        SIMD.Float64x2.extractLane(a, 1) * SIMD.Float64x2.extractLane(b, 1));
   }
 }
 
-if (typeof SIMD.float64x2.div === "undefined") {
+if (typeof SIMD.Float64x2.div === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a / b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a / b.
     */
-  SIMD.float64x2.div = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(
-        SIMD.float64x2.extractLane(a, 0) / SIMD.float64x2.extractLane(b, 0),
-        SIMD.float64x2.extractLane(a, 1) / SIMD.float64x2.extractLane(b, 1));
+  SIMD.Float64x2.div = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(
+        SIMD.Float64x2.extractLane(a, 0) / SIMD.Float64x2.extractLane(b, 0),
+        SIMD.Float64x2.extractLane(a, 1) / SIMD.Float64x2.extractLane(b, 1));
   }
 }
 
-if (typeof SIMD.float64x2.min === "undefined") {
+if (typeof SIMD.Float64x2.min === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the minimum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the minimum value of
     * t and other.
     */
-  SIMD.float64x2.min = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = Math.min(SIMD.float64x2.extractLane(t, 0),
-                      SIMD.float64x2.extractLane(other, 0));
-    var cy = Math.min(SIMD.float64x2.extractLane(t, 1),
-                      SIMD.float64x2.extractLane(other, 1));
-    return SIMD.float64x2(cx, cy);
+  SIMD.Float64x2.min = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = Math.min(SIMD.Float64x2.extractLane(t, 0),
+                      SIMD.Float64x2.extractLane(other, 0));
+    var cy = Math.min(SIMD.Float64x2.extractLane(t, 1),
+                      SIMD.Float64x2.extractLane(other, 1));
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.max === "undefined") {
+if (typeof SIMD.Float64x2.max === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the maximum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the maximum value of
     * t and other.
     */
-  SIMD.float64x2.max = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = Math.max(SIMD.float64x2.extractLane(t, 0),
-                      SIMD.float64x2.extractLane(other, 0));
-    var cy = Math.max(SIMD.float64x2.extractLane(t, 1),
-                      SIMD.float64x2.extractLane(other, 1));
-    return SIMD.float64x2(cx, cy);
+  SIMD.Float64x2.max = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = Math.max(SIMD.Float64x2.extractLane(t, 0),
+                      SIMD.Float64x2.extractLane(other, 0));
+    var cy = Math.max(SIMD.Float64x2.extractLane(t, 1),
+                      SIMD.Float64x2.extractLane(other, 1));
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.minNum === "undefined") {
+if (typeof SIMD.Float64x2.minNum === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the minimum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the minimum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float64x2.minNum = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = minNum(SIMD.float64x2.extractLane(t, 0),
-                    SIMD.float64x2.extractLane(other, 0));
-    var cy = minNum(SIMD.float64x2.extractLane(t, 1),
-                    SIMD.float64x2.extractLane(other, 1));
-    return SIMD.float64x2(cx, cy);
+  SIMD.Float64x2.minNum = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = minNum(SIMD.Float64x2.extractLane(t, 0),
+                    SIMD.Float64x2.extractLane(other, 0));
+    var cy = minNum(SIMD.Float64x2.extractLane(t, 1),
+                    SIMD.Float64x2.extractLane(other, 1));
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.maxNum === "undefined") {
+if (typeof SIMD.Float64x2.maxNum === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the maximum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the maximum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float64x2.maxNum = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = maxNum(SIMD.float64x2.extractLane(t, 0),
-                    SIMD.float64x2.extractLane(other, 0));
-    var cy = maxNum(SIMD.float64x2.extractLane(t, 1),
-                    SIMD.float64x2.extractLane(other, 1));
-    return SIMD.float64x2(cx, cy);
+  SIMD.Float64x2.maxNum = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = maxNum(SIMD.Float64x2.extractLane(t, 0),
+                    SIMD.Float64x2.extractLane(other, 0));
+    var cy = maxNum(SIMD.Float64x2.extractLane(t, 1),
+                    SIMD.Float64x2.extractLane(other, 1));
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.reciprocalApproximation === "undefined") {
+if (typeof SIMD.Float64x2.reciprocalApproximation === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with an approximation of the
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with an approximation of the
     * reciprocal value of t.
     */
-  SIMD.float64x2.reciprocalApproximation = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2.div(SIMD.float64x2.splat(1.0), t);
+  SIMD.Float64x2.reciprocalApproximation = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2.div(SIMD.Float64x2.splat(1.0), t);
   }
 }
 
-if (typeof SIMD.float64x2.reciprocalSqrtApproximation === "undefined") {
+if (typeof SIMD.Float64x2.reciprocalSqrtApproximation === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with an approximation of the
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with an approximation of the
     * reciprocal value of the square root of t.
     */
-  SIMD.float64x2.reciprocalSqrtApproximation = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2.reciprocalApproximation(SIMD.float64x2.sqrt(t));
+  SIMD.Float64x2.reciprocalSqrtApproximation = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2.reciprocalApproximation(SIMD.Float64x2.sqrt(t));
   }
 }
 
-if (typeof SIMD.float64x2.sqrt === "undefined") {
+if (typeof SIMD.Float64x2.sqrt === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with square root of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with square root of
     * values of t.
     */
-  SIMD.float64x2.sqrt = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(Math.sqrt(SIMD.float64x2.extractLane(t, 0)),
-                          Math.sqrt(SIMD.float64x2.extractLane(t, 1)));
+  SIMD.Float64x2.sqrt = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(Math.sqrt(SIMD.Float64x2.extractLane(t, 0)),
+                          Math.sqrt(SIMD.Float64x2.extractLane(t, 1)));
   }
 }
 
-if (typeof SIMD.float64x2.swizzle === "undefined") {
+if (typeof SIMD.Float64x2.swizzle === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2 to be swizzled.
+    * @param {Float64x2} t An instance of Float64x2 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
-    * @return {float64x2} New instance of float64x2 with lanes swizzled.
+    * @return {Float64x2} New instance of Float64x2 with lanes swizzled.
     */
-  SIMD.float64x2.swizzle = function(t, x, y) {
-    t = SIMD.float64x2.check(t);
+  SIMD.Float64x2.swizzle = function(t, x, y) {
+    t = SIMD.Float64x2.check(t);
     check2(x);
     check2(y);
     var storage = _f64x2;
-    storage[0] = SIMD.float64x2.extractLane(t, 0);
-    storage[1] = SIMD.float64x2.extractLane(t, 1);
-    return SIMD.float64x2(storage[x], storage[y]);
+    storage[0] = SIMD.Float64x2.extractLane(t, 0);
+    storage[1] = SIMD.Float64x2.extractLane(t, 1);
+    return SIMD.Float64x2(storage[x], storage[y]);
   }
 }
 
-if (typeof SIMD.float64x2.shuffle === "undefined") {
+if (typeof SIMD.Float64x2.shuffle === "undefined") {
 
   _f64x4 = new Float64Array(4);
 
   /**
-    * @param {float64x2} t1 An instance of float64x2 to be shuffled.
-    * @param {float64x2} t2 An instance of float64x2 to be shuffled.
+    * @param {Float64x2} t1 An instance of Float64x2 to be shuffled.
+    * @param {Float64x2} t2 An instance of Float64x2 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
-    * @return {float64x2} New instance of float64x2 with lanes shuffled.
+    * @return {Float64x2} New instance of Float64x2 with lanes shuffled.
     */
-  SIMD.float64x2.shuffle = function(t1, t2, x, y) {
-    t1 = SIMD.float64x2.check(t1);
-    t2 = SIMD.float64x2.check(t2);
+  SIMD.Float64x2.shuffle = function(t1, t2, x, y) {
+    t1 = SIMD.Float64x2.check(t1);
+    t2 = SIMD.Float64x2.check(t2);
     check4(x);
     check4(y);
     var storage = _f64x4;
-    storage[0] = SIMD.float64x2.extractLane(t1, 0);
-    storage[1] = SIMD.float64x2.extractLane(t1, 1);
-    storage[2] = SIMD.float64x2.extractLane(t2, 0);
-    storage[3] = SIMD.float64x2.extractLane(t2, 1);
-    return SIMD.float64x2(storage[x], storage[y]);
+    storage[0] = SIMD.Float64x2.extractLane(t1, 0);
+    storage[1] = SIMD.Float64x2.extractLane(t1, 1);
+    storage[2] = SIMD.Float64x2.extractLane(t2, 0);
+    storage[3] = SIMD.Float64x2.extractLane(t2, 1);
+    return SIMD.Float64x2(storage[x], storage[y]);
   }
 }
 
-if (typeof SIMD.float64x2.lessThan === "undefined") {
+if (typeof SIMD.Float64x2.lessThan === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.float64x2.lessThan = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.lessThan = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx =
-        SIMD.float64x2.extractLane(t, 0) < SIMD.float64x2.extractLane(other, 0);
+        SIMD.Float64x2.extractLane(t, 0) < SIMD.Float64x2.extractLane(other, 0);
     var cy =
-        SIMD.float64x2.extractLane(t, 1) < SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+        SIMD.Float64x2.extractLane(t, 1) < SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Float64x2.lessThanOrEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.float64x2.lessThanOrEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = SIMD.float64x2.extractLane(t, 0) <=
-        SIMD.float64x2.extractLane(other, 0);
-    var cy = SIMD.float64x2.extractLane(t, 1) <=
-        SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+  SIMD.Float64x2.lessThanOrEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = SIMD.Float64x2.extractLane(t, 0) <=
+        SIMD.Float64x2.extractLane(other, 0);
+    var cy = SIMD.Float64x2.extractLane(t, 1) <=
+        SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.equal === "undefined") {
+if (typeof SIMD.Float64x2.equal === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.float64x2.equal = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = SIMD.float64x2.extractLane(t, 0) ==
-        SIMD.float64x2.extractLane(other, 0);
-    var cy = SIMD.float64x2.extractLane(t, 1) ==
-        SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+  SIMD.Float64x2.equal = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = SIMD.Float64x2.extractLane(t, 0) ==
+        SIMD.Float64x2.extractLane(other, 0);
+    var cy = SIMD.Float64x2.extractLane(t, 1) ==
+        SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.notEqual === "undefined") {
+if (typeof SIMD.Float64x2.notEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.float64x2.notEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = SIMD.float64x2.extractLane(t, 0) !=
-        SIMD.float64x2.extractLane(other, 0);
-    var cy = SIMD.float64x2.extractLane(t, 1) !=
-        SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+  SIMD.Float64x2.notEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = SIMD.Float64x2.extractLane(t, 0) !=
+        SIMD.Float64x2.extractLane(other, 0);
+    var cy = SIMD.Float64x2.extractLane(t, 1) !=
+        SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Float64x2.greaterThanOrEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.float64x2.greaterThanOrEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
-    var cx = SIMD.float64x2.extractLane(t, 0) >=
-        SIMD.float64x2.extractLane(other, 0);
-    var cy = SIMD.float64x2.extractLane(t, 1) >=
-        SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+  SIMD.Float64x2.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
+    var cx = SIMD.Float64x2.extractLane(t, 0) >=
+        SIMD.Float64x2.extractLane(other, 0);
+    var cy = SIMD.Float64x2.extractLane(t, 1) >=
+        SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.greaterThan === "undefined") {
+if (typeof SIMD.Float64x2.greaterThan === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.float64x2.greaterThan = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.greaterThan = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx =
-        SIMD.float64x2.extractLane(t, 0) > SIMD.float64x2.extractLane(other, 0);
+        SIMD.Float64x2.extractLane(t, 0) > SIMD.Float64x2.extractLane(other, 0);
     var cy =
-        SIMD.float64x2.extractLane(t, 1) > SIMD.float64x2.extractLane(other, 1);
-    return SIMD.int64x2.bool(cx, cy);
+        SIMD.Float64x2.extractLane(t, 1) > SIMD.Float64x2.extractLane(other, 1);
+    return SIMD.Int64x2.bool(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.select === "undefined") {
+if (typeof SIMD.Float64x2.select === "undefined") {
   /**
-    * @param {int64x2} t Selector mask. An instance of int64x2
-    * @param {float64x2} trueValue Pick lane from here if corresponding
+    * @param {Int64x2} t Selector mask. An instance of Int64x2
+    * @param {Float64x2} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {float64x2} falseValue Pick lane from here if corresponding
+    * @param {Float64x2} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {float64x2} Mix of lanes from trueValue or falseValue as
+    * @return {Float64x2} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.float64x2.select = function(t, trueValue, falseValue) {
-    t = SIMD.int64x2.check(t);
-    trueValue = SIMD.float64x2.check(trueValue);
-    falseValue = SIMD.float64x2.check(falseValue);
-    return SIMD.float64x2(
-        SIMD.int64x2.extractLaneAsBool(t, 0) ?
-            SIMD.float64x2.extractLane(trueValue, 0) :
-                SIMD.float64x2.extractLane(falseValue, 0),
-        SIMD.int64x2.extractLaneAsBool(t, 1) ?
-            SIMD.float64x2.extractLane(trueValue, 1) :
-                SIMD.float64x2.extractLane(falseValue, 1));
+  SIMD.Float64x2.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int64x2.check(t);
+    trueValue = SIMD.Float64x2.check(trueValue);
+    falseValue = SIMD.Float64x2.check(falseValue);
+    return SIMD.Float64x2(
+        SIMD.Int64x2.extractLaneAsBool(t, 0) ?
+            SIMD.Float64x2.extractLane(trueValue, 0) :
+                SIMD.Float64x2.extractLane(falseValue, 0),
+        SIMD.Int64x2.extractLaneAsBool(t, 1) ?
+            SIMD.Float64x2.extractLane(trueValue, 1) :
+                SIMD.Float64x2.extractLane(falseValue, 1));
   }
 }
 
-if (typeof SIMD.float64x2.selectBits === "undefined") {
+if (typeof SIMD.Float64x2.selectBits === "undefined") {
   /**
-    * @param {int64x2} t Selector mask. An instance of int64x2
-    * @param {float64x2} trueValue Pick bit from here if corresponding
+    * @param {Int64x2} t Selector mask. An instance of Int64x2
+    * @param {Float64x2} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {float64x2} falseValue Pick bit from here if corresponding
+    * @param {Float64x2} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {float64x2} Mix of bits from trueValue or falseValue as
+    * @return {Float64x2} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.float64x2.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int64x2.check(t);
-    trueValue = SIMD.float64x2.check(trueValue);
-    falseValue = SIMD.float64x2.check(falseValue);
-    var tv = SIMD.int64x2.fromFloat64x2Bits(trueValue);
-    var fv = SIMD.int64x2.fromFloat64x2Bits(falseValue);
-    var tr = SIMD.int64x2.and(t, tv);
-    var fr = SIMD.int64x2.and(SIMD.int64x2.not(t), fv);
-    return SIMD.float64x2.fromInt64x2Bits(SIMD.int64x2.or(tr, fr));
+  SIMD.Float64x2.selectBits = function(t, trueValue, falseValue) {
+    t = SIMD.Int64x2.check(t);
+    trueValue = SIMD.Float64x2.check(trueValue);
+    falseValue = SIMD.Float64x2.check(falseValue);
+    var tv = SIMD.Int64x2.fromFloat64x2Bits(trueValue);
+    var fv = SIMD.Int64x2.fromFloat64x2Bits(falseValue);
+    var tr = SIMD.Int64x2.and(t, tv);
+    var fr = SIMD.Int64x2.and(SIMD.Int64x2.not(t), fv);
+    return SIMD.Float64x2.fromInt64x2Bits(SIMD.Int64x2.or(tr, fr));
   }
 }
 
-if (typeof SIMD.float64x2.load === "undefined") {
+if (typeof SIMD.Float64x2.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float64x2} New instance of float64x2.
+    * @return {Float64x2} New instance of Float64x2.
     */
-  SIMD.float64x2.load = function(tarray, index) {
+  SIMD.Float64x2.load = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2720,17 +2720,17 @@ if (typeof SIMD.float64x2.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float64x2(f64temp[0], f64temp[1]);
+    return SIMD.Float64x2(f64temp[0], f64temp[1]);
   }
 }
 
-if (typeof SIMD.float64x2.load1 === "undefined") {
+if (typeof SIMD.Float64x2.load1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float64x2} New instance of float64x2.
+    * @return {Float64x2} New instance of Float64x2.
     */
-  SIMD.float64x2.load1 = function(tarray, index) {
+  SIMD.Float64x2.load1 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2746,18 +2746,18 @@ if (typeof SIMD.float64x2.load1 === "undefined") {
     var n = 8 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float64x2(f64temp[0], 0.0);
+    return SIMD.Float64x2(f64temp[0], 0.0);
   }
 }
 
-if (typeof SIMD.float64x2.store === "undefined") {
+if (typeof SIMD.Float64x2.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float64x2} value An instance of float64x2.
-    * @return {float64x2} value
+    * @param {Float64x2} value An instance of Float64x2.
+    * @return {Float64x2} value
     */
-  SIMD.float64x2.store = function(tarray, index, value) {
+  SIMD.Float64x2.store = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2765,9 +2765,9 @@ if (typeof SIMD.float64x2.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float64x2.check(value);
-    _f64x2[0] = SIMD.float64x2.extractLane(value, 0);
-    _f64x2[1] = SIMD.float64x2.extractLane(value, 1);
+    value = SIMD.Float64x2.check(value);
+    _f64x2[0] = SIMD.Float64x2.extractLane(value, 0);
+    _f64x2[1] = SIMD.Float64x2.extractLane(value, 1);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -2779,14 +2779,14 @@ if (typeof SIMD.float64x2.store === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.store1 === "undefined") {
+if (typeof SIMD.Float64x2.store1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float64x2} value An instance of float64x2.
-    * @return {float64x2} value
+    * @param {Float64x2} value An instance of Float64x2.
+    * @return {Float64x2} value
     */
-  SIMD.float64x2.store1 = function(tarray, index, value) {
+  SIMD.Float64x2.store1 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -2794,8 +2794,8 @@ if (typeof SIMD.float64x2.store1 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float64x2.check(value);
-    _f64x2[0] = SIMD.float64x2.extractLane(value, 0);
+    value = SIMD.Float64x2.check(value);
+    _f64x2[0] = SIMD.Float64x2.extractLane(value, 0);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -2807,582 +2807,582 @@ if (typeof SIMD.float64x2.store1 === "undefined") {
   }
 }
 
-if (typeof SIMD.int64x2.and === "undefined") {
+if (typeof SIMD.Int64x2.and === "undefined") {
   /**
-    * @param {int64x2} a An instance of int64x2.
-    * @param {int64x2} b An instance of int64x2.
-    * @return {int64x2} New instance of int64x2 with values of a & b.
+    * @param {Int64x2} a An instance of Int64x2.
+    * @param {Int64x2} b An instance of Int64x2.
+    * @return {Int64x2} New instance of Int64x2 with values of a & b.
     */
-  SIMD.int64x2.and = function(a, b) {
-    a = SIMD.int64x2.check(a);
-    b = SIMD.int64x2.check(b);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.and(a.int32x4_, b.int32x4_);
+  SIMD.Int64x2.and = function(a, b) {
+    a = SIMD.Int64x2.check(a);
+    b = SIMD.Int64x2.check(b);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.and(a.int32x4_, b.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.or === "undefined") {
+if (typeof SIMD.Int64x2.or === "undefined") {
   /**
-    * @param {int64x2} a An instance of int64x2.
-    * @param {int64x2} b An instance of int64x2.
-    * @return {int64x2} New instance of int64x2 with values of a | b.
+    * @param {Int64x2} a An instance of Int64x2.
+    * @param {Int64x2} b An instance of Int64x2.
+    * @return {Int64x2} New instance of Int64x2 with values of a | b.
     */
-  SIMD.int64x2.or = function(a, b) {
-    a = SIMD.int64x2.check(a);
-    b = SIMD.int64x2.check(b);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.or(a.int32x4_, b.int32x4_);
+  SIMD.Int64x2.or = function(a, b) {
+    a = SIMD.Int64x2.check(a);
+    b = SIMD.Int64x2.check(b);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.or(a.int32x4_, b.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.xor === "undefined") {
+if (typeof SIMD.Int64x2.xor === "undefined") {
   /**
-    * @param {int64x2} a An instance of int64x2.
-    * @param {int64x2} b An instance of int64x2.
-    * @return {int64x2} New instance of int64x2 with values of a ^ b.
+    * @param {Int64x2} a An instance of Int64x2.
+    * @param {Int64x2} b An instance of Int64x2.
+    * @return {Int64x2} New instance of Int64x2 with values of a ^ b.
     */
-  SIMD.int64x2.xor = function(a, b) {
-    a = SIMD.int64x2.check(a);
-    b = SIMD.int64x2.check(b);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.xor(a.int32x4_, b.int32x4_);
+  SIMD.Int64x2.xor = function(a, b) {
+    a = SIMD.Int64x2.check(a);
+    b = SIMD.Int64x2.check(b);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.xor(a.int32x4_, b.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.not === "undefined") {
+if (typeof SIMD.Int64x2.not === "undefined") {
   /**
-    * @param {int64x2} t An instance of int64x2.
-    * @return {int64x2} New instance of int64x2 with values of ~t
+    * @param {Int64x2} t An instance of Int64x2.
+    * @return {Int64x2} New instance of Int64x2 with values of ~t
     */
-  SIMD.int64x2.not = function(t) {
-    t = SIMD.int64x2.check(t);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.not(t.int32x4_);
+  SIMD.Int64x2.not = function(t) {
+    t = SIMD.Int64x2.check(t);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.not(t.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.equal === "undefined") {
+if (typeof SIMD.Int64x2.equal === "undefined") {
   /**
-    * @param {int64x2} t An instance of int64x2.
-    * @param {int64x2} other An instance of int64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Int64x2} t An instance of Int64x2.
+    * @param {Int64x2} other An instance of Int64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.int64x2.equal = function(t, other) {
-    t = SIMD.int64x2.check(t);
-    other = SIMD.int64x2.check(other);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.equal(t.int32x4_, other.int32x4_);
+  SIMD.Int64x2.equal = function(t, other) {
+    t = SIMD.Int64x2.check(t);
+    other = SIMD.Int64x2.check(other);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.equal(t.int32x4_, other.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.notEqual === "undefined") {
+if (typeof SIMD.Int64x2.notEqual === "undefined") {
   /**
-    * @param {int64x2} t An instance of int64x2.
-    * @param {int64x2} other An instance of int64x2.
-    * @return {int64x2} true or false in each lane depending on
+    * @param {Int64x2} t An instance of Int64x2.
+    * @param {Int64x2} other An instance of Int64x2.
+    * @return {Int64x2} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.int64x2.notEqual = function(t, other) {
-    t = SIMD.int64x2.check(t);
-    other = SIMD.int64x2.check(other);
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.notEqual(t.int32x4_, other.int32x4_);
+  SIMD.Int64x2.notEqual = function(t, other) {
+    t = SIMD.Int64x2.check(t);
+    other = SIMD.Int64x2.check(other);
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.notEqual(t.int32x4_, other.int32x4_);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.load === "undefined") {
+if (typeof SIMD.Int64x2.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int64x2} New instance of int64x2.
+    * @return {Int64x2} New instance of Int64x2.
     */
-  SIMD.int64x2.load = function(tarray, index) {
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.load(tarray, index);
+  SIMD.Int64x2.load = function(tarray, index) {
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.load(tarray, index);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.load1 === "undefined") {
+if (typeof SIMD.Int64x2.load1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int64x2} New instance of int64x2.
+    * @return {Int64x2} New instance of Int64x2.
     */
-  SIMD.int64x2.load1 = function(tarray, index) {
-    var v = SIMD.int64x2();
-    v.int32x4_ = SIMD.int32x4.load2(tarray, index);
+  SIMD.Int64x2.load1 = function(tarray, index) {
+    var v = SIMD.Int64x2();
+    v.int32x4_ = SIMD.Int32x4.load2(tarray, index);
     return v;
   }
 }
 
-if (typeof SIMD.int64x2.store === "undefined") {
+if (typeof SIMD.Int64x2.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int64x2} value An instance of int64x2.
+    * @param {Int64x2} value An instance of Int64x2.
     * @return {void}
     */
-  SIMD.int64x2.store = function(tarray, index, value) {
-    value = SIMD.int64x2.check(value);
-    return SIMD.int32x4.store(tarray, index, value.int32x4_);
+  SIMD.Int64x2.store = function(tarray, index, value) {
+    value = SIMD.Int64x2.check(value);
+    return SIMD.Int32x4.store(tarray, index, value.int32x4_);
   }
 }
 
-if (typeof SIMD.int64x2.store1 === "undefined") {
+if (typeof SIMD.Int64x2.store1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int64x2} value An instance of int64x2.
+    * @param {Int64x2} value An instance of Int64x2.
     * @return {void}
     */
-  SIMD.int64x2.store1 = function(tarray, index, value) {
-    value = SIMD.int64x2.check(value);
-    return SIMD.int32x4.store2(tarray, index, value.int32x4_);
+  SIMD.Int64x2.store1 = function(tarray, index, value) {
+    value = SIMD.Int64x2.check(value);
+    return SIMD.Int32x4.store2(tarray, index, value.int32x4_);
   }
 }
 
-if (typeof SIMD.int32x4.and === "undefined") {
+if (typeof SIMD.Int32x4.and === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a & b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a & b.
     */
-  SIMD.int32x4.and = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLane(a, 0) & SIMD.int32x4.extractLane(b, 0),
-        SIMD.int32x4.extractLane(a, 1) & SIMD.int32x4.extractLane(b, 1),
-        SIMD.int32x4.extractLane(a, 2) & SIMD.int32x4.extractLane(b, 2),
-        SIMD.int32x4.extractLane(a, 3) & SIMD.int32x4.extractLane(b, 3));
+  SIMD.Int32x4.and = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLane(a, 0) & SIMD.Int32x4.extractLane(b, 0),
+        SIMD.Int32x4.extractLane(a, 1) & SIMD.Int32x4.extractLane(b, 1),
+        SIMD.Int32x4.extractLane(a, 2) & SIMD.Int32x4.extractLane(b, 2),
+        SIMD.Int32x4.extractLane(a, 3) & SIMD.Int32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.int32x4.or === "undefined") {
+if (typeof SIMD.Int32x4.or === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a | b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a | b.
     */
-  SIMD.int32x4.or = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLane(a, 0) | SIMD.int32x4.extractLane(b, 0),
-        SIMD.int32x4.extractLane(a, 1) | SIMD.int32x4.extractLane(b, 1),
-        SIMD.int32x4.extractLane(a, 2) | SIMD.int32x4.extractLane(b, 2),
-        SIMD.int32x4.extractLane(a, 3) | SIMD.int32x4.extractLane(b, 3));
+  SIMD.Int32x4.or = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLane(a, 0) | SIMD.Int32x4.extractLane(b, 0),
+        SIMD.Int32x4.extractLane(a, 1) | SIMD.Int32x4.extractLane(b, 1),
+        SIMD.Int32x4.extractLane(a, 2) | SIMD.Int32x4.extractLane(b, 2),
+        SIMD.Int32x4.extractLane(a, 3) | SIMD.Int32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.int32x4.xor === "undefined") {
+if (typeof SIMD.Int32x4.xor === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a ^ b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a ^ b.
     */
-  SIMD.int32x4.xor = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLane(a, 0) ^ SIMD.int32x4.extractLane(b, 0),
-        SIMD.int32x4.extractLane(a, 1) ^ SIMD.int32x4.extractLane(b, 1),
-        SIMD.int32x4.extractLane(a, 2) ^ SIMD.int32x4.extractLane(b, 2),
-        SIMD.int32x4.extractLane(a, 3) ^ SIMD.int32x4.extractLane(b, 3));
+  SIMD.Int32x4.xor = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLane(a, 0) ^ SIMD.Int32x4.extractLane(b, 0),
+        SIMD.Int32x4.extractLane(a, 1) ^ SIMD.Int32x4.extractLane(b, 1),
+        SIMD.Int32x4.extractLane(a, 2) ^ SIMD.Int32x4.extractLane(b, 2),
+        SIMD.Int32x4.extractLane(a, 3) ^ SIMD.Int32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.int32x4.not === "undefined") {
+if (typeof SIMD.Int32x4.not === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of ~t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of ~t
     */
-  SIMD.int32x4.not = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.int32x4(~SIMD.int32x4.extractLane(t, 0),
-                        ~SIMD.int32x4.extractLane(t, 1),
-                        ~SIMD.int32x4.extractLane(t, 2),
-                        ~SIMD.int32x4.extractLane(t, 3));
+  SIMD.Int32x4.not = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Int32x4(~SIMD.Int32x4.extractLane(t, 0),
+                        ~SIMD.Int32x4.extractLane(t, 1),
+                        ~SIMD.Int32x4.extractLane(t, 2),
+                        ~SIMD.Int32x4.extractLane(t, 3));
   }
 }
 
-if (typeof SIMD.int32x4.neg === "undefined") {
+if (typeof SIMD.Int32x4.neg === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of -t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of -t
     */
-  SIMD.int32x4.neg = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.int32x4(-SIMD.int32x4.extractLane(t, 0),
-                        -SIMD.int32x4.extractLane(t, 1),
-                        -SIMD.int32x4.extractLane(t, 2),
-                        -SIMD.int32x4.extractLane(t, 3));
+  SIMD.Int32x4.neg = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Int32x4(-SIMD.Int32x4.extractLane(t, 0),
+                        -SIMD.Int32x4.extractLane(t, 1),
+                        -SIMD.Int32x4.extractLane(t, 2),
+                        -SIMD.Int32x4.extractLane(t, 3));
   }
 }
 
-if (typeof SIMD.int32x4.add === "undefined") {
+if (typeof SIMD.Int32x4.add === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a + b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a + b.
     */
-  SIMD.int32x4.add = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLane(a, 0) + SIMD.int32x4.extractLane(b, 0),
-        SIMD.int32x4.extractLane(a, 1) + SIMD.int32x4.extractLane(b, 1),
-        SIMD.int32x4.extractLane(a, 2) + SIMD.int32x4.extractLane(b, 2),
-        SIMD.int32x4.extractLane(a, 3) + SIMD.int32x4.extractLane(b, 3));
+  SIMD.Int32x4.add = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLane(a, 0) + SIMD.Int32x4.extractLane(b, 0),
+        SIMD.Int32x4.extractLane(a, 1) + SIMD.Int32x4.extractLane(b, 1),
+        SIMD.Int32x4.extractLane(a, 2) + SIMD.Int32x4.extractLane(b, 2),
+        SIMD.Int32x4.extractLane(a, 3) + SIMD.Int32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.int32x4.sub === "undefined") {
+if (typeof SIMD.Int32x4.sub === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a - b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a - b.
     */
-  SIMD.int32x4.sub = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLane(a, 0) - SIMD.int32x4.extractLane(b, 0),
-        SIMD.int32x4.extractLane(a, 1) - SIMD.int32x4.extractLane(b, 1),
-        SIMD.int32x4.extractLane(a, 2) - SIMD.int32x4.extractLane(b, 2),
-        SIMD.int32x4.extractLane(a, 3) - SIMD.int32x4.extractLane(b, 3));
+  SIMD.Int32x4.sub = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLane(a, 0) - SIMD.Int32x4.extractLane(b, 0),
+        SIMD.Int32x4.extractLane(a, 1) - SIMD.Int32x4.extractLane(b, 1),
+        SIMD.Int32x4.extractLane(a, 2) - SIMD.Int32x4.extractLane(b, 2),
+        SIMD.Int32x4.extractLane(a, 3) - SIMD.Int32x4.extractLane(b, 3));
   }
 }
 
-if (typeof SIMD.int32x4.mul === "undefined") {
+if (typeof SIMD.Int32x4.mul === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a * b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a * b.
     */
-  SIMD.int32x4.mul = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(
-        Math.imul(SIMD.int32x4.extractLane(a, 0),
-                  SIMD.int32x4.extractLane(b, 0)),
-        Math.imul(SIMD.int32x4.extractLane(a, 1),
-                  SIMD.int32x4.extractLane(b, 1)),
-        Math.imul(SIMD.int32x4.extractLane(a, 2),
-                  SIMD.int32x4.extractLane(b, 2)),
-        Math.imul(SIMD.int32x4.extractLane(a, 3),
-                  SIMD.int32x4.extractLane(b, 3)));
+  SIMD.Int32x4.mul = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(
+        Math.imul(SIMD.Int32x4.extractLane(a, 0),
+                  SIMD.Int32x4.extractLane(b, 0)),
+        Math.imul(SIMD.Int32x4.extractLane(a, 1),
+                  SIMD.Int32x4.extractLane(b, 1)),
+        Math.imul(SIMD.Int32x4.extractLane(a, 2),
+                  SIMD.Int32x4.extractLane(b, 2)),
+        Math.imul(SIMD.Int32x4.extractLane(a, 3),
+                  SIMD.Int32x4.extractLane(b, 3)));
   }
 }
 
-if (typeof SIMD.int32x4.swizzle === "undefined") {
+if (typeof SIMD.Int32x4.swizzle === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4 to be swizzled.
+    * @param {Int32x4} t An instance of Int32x4 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
     * @param {integer} z - Index in t for lane z
     * @param {integer} w - Index in t for lane w
-    * @return {int32x4} New instance of int32x4 with lanes swizzled.
+    * @return {Int32x4} New instance of Int32x4 with lanes swizzled.
     */
-  SIMD.int32x4.swizzle = function(t, x, y, z, w) {
-    t = SIMD.int32x4.check(t);
+  SIMD.Int32x4.swizzle = function(t, x, y, z, w) {
+    t = SIMD.Int32x4.check(t);
     check4(x);
     check4(y);
     check4(z);
     check4(w);
     var storage = _i32x4;
-    storage[0] = SIMD.int32x4.extractLane(t, 0);
-    storage[1] = SIMD.int32x4.extractLane(t, 1);
-    storage[2] = SIMD.int32x4.extractLane(t, 2);
-    storage[3] = SIMD.int32x4.extractLane(t, 3);
-    return SIMD.int32x4(storage[x], storage[y], storage[z], storage[w]);
+    storage[0] = SIMD.Int32x4.extractLane(t, 0);
+    storage[1] = SIMD.Int32x4.extractLane(t, 1);
+    storage[2] = SIMD.Int32x4.extractLane(t, 2);
+    storage[3] = SIMD.Int32x4.extractLane(t, 3);
+    return SIMD.Int32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.int32x4.shuffle === "undefined") {
+if (typeof SIMD.Int32x4.shuffle === "undefined") {
 
   _i32x8 = new Int32Array(8);
 
   /**
-    * @param {int32x4} t1 An instance of int32x4 to be shuffled.
-    * @param {int32x4} t2 An instance of int32x4 to be shuffled.
+    * @param {Int32x4} t1 An instance of Int32x4 to be shuffled.
+    * @param {Int32x4} t2 An instance of Int32x4 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
     * @param {integer} z - Index in concatenation of t1 and t2 for lane z
     * @param {integer} w - Index in concatenation of t1 and t2 for lane w
-    * @return {int32x4} New instance of int32x4 with lanes shuffled.
+    * @return {Int32x4} New instance of Int32x4 with lanes shuffled.
     */
-  SIMD.int32x4.shuffle = function(t1, t2, x, y, z, w) {
-    t1 = SIMD.int32x4.check(t1);
-    t2 = SIMD.int32x4.check(t2);
+  SIMD.Int32x4.shuffle = function(t1, t2, x, y, z, w) {
+    t1 = SIMD.Int32x4.check(t1);
+    t2 = SIMD.Int32x4.check(t2);
     check8(x);
     check8(y);
     check8(z);
     check8(w);
     var storage = _i32x8;
-    storage[0] = SIMD.int32x4.extractLane(t1, 0);
-    storage[1] = SIMD.int32x4.extractLane(t1, 1);
-    storage[2] = SIMD.int32x4.extractLane(t1, 2);
-    storage[3] = SIMD.int32x4.extractLane(t1, 3);
-    storage[4] = SIMD.int32x4.extractLane(t2, 0);
-    storage[5] = SIMD.int32x4.extractLane(t2, 1);
-    storage[6] = SIMD.int32x4.extractLane(t2, 2);
-    storage[7] = SIMD.int32x4.extractLane(t2, 3);
-    return SIMD.int32x4(storage[x], storage[y], storage[z], storage[w]);
+    storage[0] = SIMD.Int32x4.extractLane(t1, 0);
+    storage[1] = SIMD.Int32x4.extractLane(t1, 1);
+    storage[2] = SIMD.Int32x4.extractLane(t1, 2);
+    storage[3] = SIMD.Int32x4.extractLane(t1, 3);
+    storage[4] = SIMD.Int32x4.extractLane(t2, 0);
+    storage[5] = SIMD.Int32x4.extractLane(t2, 1);
+    storage[6] = SIMD.Int32x4.extractLane(t2, 2);
+    storage[7] = SIMD.Int32x4.extractLane(t2, 3);
+    return SIMD.Int32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.int32x4.select === "undefined") {
+if (typeof SIMD.Int32x4.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {int32x4} trueValue Pick lane from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Int32x4} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {int32x4} falseValue Pick lane from here if corresponding
+    * @param {Int32x4} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {int32x4} Mix of lanes from trueValue or falseValue as
+    * @return {Int32x4} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int32x4.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.int32x4.check(trueValue);
-    falseValue = SIMD.int32x4.check(falseValue);
-    return SIMD.int32x4(
-        SIMD.int32x4.extractLaneAsBool(t, 0) ?
-            SIMD.int32x4.extractLane(trueValue, 0) :
-                SIMD.int32x4.extractLane(falseValue, 0),
-        SIMD.int32x4.extractLaneAsBool(t, 1) ?
-            SIMD.int32x4.extractLane(trueValue, 1) :
-                SIMD.int32x4.extractLane(falseValue, 1),
-        SIMD.int32x4.extractLaneAsBool(t, 2) ?
-            SIMD.int32x4.extractLane(trueValue, 2) :
-                SIMD.int32x4.extractLane(falseValue, 2),
-        SIMD.int32x4.extractLaneAsBool(t, 3) ?
-            SIMD.int32x4.extractLane(trueValue, 3) :
-                SIMD.int32x4.extractLane(falseValue, 3));
+  SIMD.Int32x4.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Int32x4.check(trueValue);
+    falseValue = SIMD.Int32x4.check(falseValue);
+    return SIMD.Int32x4(
+        SIMD.Int32x4.extractLaneAsBool(t, 0) ?
+            SIMD.Int32x4.extractLane(trueValue, 0) :
+                SIMD.Int32x4.extractLane(falseValue, 0),
+        SIMD.Int32x4.extractLaneAsBool(t, 1) ?
+            SIMD.Int32x4.extractLane(trueValue, 1) :
+                SIMD.Int32x4.extractLane(falseValue, 1),
+        SIMD.Int32x4.extractLaneAsBool(t, 2) ?
+            SIMD.Int32x4.extractLane(trueValue, 2) :
+                SIMD.Int32x4.extractLane(falseValue, 2),
+        SIMD.Int32x4.extractLaneAsBool(t, 3) ?
+            SIMD.Int32x4.extractLane(trueValue, 3) :
+                SIMD.Int32x4.extractLane(falseValue, 3));
   }
 }
 
-if (typeof SIMD.int32x4.selectBits === "undefined") {
+if (typeof SIMD.Int32x4.selectBits === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {int32x4} trueValue Pick bit from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Int32x4} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {int32x4} falseValue Pick bit from here if corresponding
+    * @param {Int32x4} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {int32x4} Mix of bits from trueValue or falseValue as
+    * @return {Int32x4} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.int32x4.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.int32x4.check(trueValue);
-    falseValue = SIMD.int32x4.check(falseValue);
-    var tr = SIMD.int32x4.and(t, trueValue);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), falseValue);
-    return SIMD.int32x4.or(tr, fr);
+  SIMD.Int32x4.selectBits = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Int32x4.check(trueValue);
+    falseValue = SIMD.Int32x4.check(falseValue);
+    var tr = SIMD.Int32x4.and(t, trueValue);
+    var fr = SIMD.Int32x4.and(SIMD.Int32x4.not(t), falseValue);
+    return SIMD.Int32x4.or(tr, fr);
   }
 }
 
-if (typeof SIMD.int32x4.equal === "undefined") {
+if (typeof SIMD.Int32x4.equal === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.int32x4.equal = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.equal = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) == SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) == SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) == SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) == SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) == SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) == SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) == SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) == SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.notEqual === "undefined") {
+if (typeof SIMD.Int32x4.notEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.int32x4.notEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.notEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) != SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) != SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) != SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) != SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) != SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) != SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) != SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) != SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.greaterThan === "undefined") {
+if (typeof SIMD.Int32x4.greaterThan === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.int32x4.greaterThan = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.greaterThan = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) > SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) > SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) > SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) > SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) > SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) > SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) > SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) > SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Int32x4.greaterThanOrEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.int32x4.greaterThanOrEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) >= SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) >= SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) >= SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) >= SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) >= SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) >= SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) >= SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) >= SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.lessThan === "undefined") {
+if (typeof SIMD.Int32x4.lessThan === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.int32x4.lessThan = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.lessThan = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) < SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) < SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) < SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) < SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) < SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) < SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) < SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) < SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Int32x4.lessThanOrEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.int32x4.lessThanOrEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.lessThanOrEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx =
-        SIMD.int32x4.extractLane(t, 0) <= SIMD.int32x4.extractLane(other, 0);
+        SIMD.Int32x4.extractLane(t, 0) <= SIMD.Int32x4.extractLane(other, 0);
     var cy =
-        SIMD.int32x4.extractLane(t, 1) <= SIMD.int32x4.extractLane(other, 1);
+        SIMD.Int32x4.extractLane(t, 1) <= SIMD.Int32x4.extractLane(other, 1);
     var cz =
-        SIMD.int32x4.extractLane(t, 2) <= SIMD.int32x4.extractLane(other, 2);
+        SIMD.Int32x4.extractLane(t, 2) <= SIMD.Int32x4.extractLane(other, 2);
     var cw =
-        SIMD.int32x4.extractLane(t, 3) <= SIMD.int32x4.extractLane(other, 3);
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+        SIMD.Int32x4.extractLane(t, 3) <= SIMD.Int32x4.extractLane(other, 3);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.shiftLeftByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftLeftByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftLeftByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftLeftByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     if (bits>>>0 >= 32)
-      return SIMD.int32x4.splat(0.0);
-    var x = SIMD.int32x4.extractLane(a, 0) << bits;
-    var y = SIMD.int32x4.extractLane(a, 1) << bits;
-    var z = SIMD.int32x4.extractLane(a, 2) << bits;
-    var w = SIMD.int32x4.extractLane(a, 3) << bits;
-    return SIMD.int32x4(x, y, z, w);
+      return SIMD.Int32x4.splat(0.0);
+    var x = SIMD.Int32x4.extractLane(a, 0) << bits;
+    var y = SIMD.Int32x4.extractLane(a, 1) << bits;
+    var z = SIMD.Int32x4.extractLane(a, 2) << bits;
+    var w = SIMD.Int32x4.extractLane(a, 3) << bits;
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.shiftRightLogicalByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftRightLogicalByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftRightLogicalByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftRightLogicalByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     if (bits>>>0 >= 32)
-      return SIMD.int32x4.splat(0.0);
-    var x = SIMD.int32x4.extractLane(a, 0) >>> bits;
-    var y = SIMD.int32x4.extractLane(a, 1) >>> bits;
-    var z = SIMD.int32x4.extractLane(a, 2) >>> bits;
-    var w = SIMD.int32x4.extractLane(a, 3) >>> bits;
-    return SIMD.int32x4(x, y, z, w);
+      return SIMD.Int32x4.splat(0.0);
+    var x = SIMD.Int32x4.extractLane(a, 0) >>> bits;
+    var y = SIMD.Int32x4.extractLane(a, 1) >>> bits;
+    var z = SIMD.Int32x4.extractLane(a, 2) >>> bits;
+    var w = SIMD.Int32x4.extractLane(a, 3) >>> bits;
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.shiftRightArithmeticByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftRightArithmeticByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftRightArithmeticByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftRightArithmeticByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     if (bits>>>0 >= 32)
       bits = 31;
-    var x = SIMD.int32x4.extractLane(a, 0) >> bits;
-    var y = SIMD.int32x4.extractLane(a, 1) >> bits;
-    var z = SIMD.int32x4.extractLane(a, 2) >> bits;
-    var w = SIMD.int32x4.extractLane(a, 3) >> bits;
-    return SIMD.int32x4(x, y, z, w);
+    var x = SIMD.Int32x4.extractLane(a, 0) >> bits;
+    var y = SIMD.Int32x4.extractLane(a, 1) >> bits;
+    var z = SIMD.Int32x4.extractLane(a, 2) >> bits;
+    var w = SIMD.Int32x4.extractLane(a, 3) >> bits;
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.load === "undefined") {
+if (typeof SIMD.Int32x4.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.load = function(tarray, index) {
+  SIMD.Int32x4.load = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3398,17 +3398,17 @@ if (typeof SIMD.int32x4.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int32x4(i32temp[0], i32temp[1], i32temp[2], i32temp[3]);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], i32temp[2], i32temp[3]);
   }
 }
 
-if (typeof SIMD.int32x4.load1 === "undefined") {
+if (typeof SIMD.Int32x4.load1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.load1 = function(tarray, index) {
+  SIMD.Int32x4.load1 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3424,17 +3424,17 @@ if (typeof SIMD.int32x4.load1 === "undefined") {
     var n = 4 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int32x4(i32temp[0], 0, 0, 0);
+    return SIMD.Int32x4(i32temp[0], 0, 0, 0);
   }
 }
 
-if (typeof SIMD.int32x4.load2 === "undefined") {
+if (typeof SIMD.Int32x4.load2 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.load2 = function(tarray, index) {
+  SIMD.Int32x4.load2 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3450,17 +3450,17 @@ if (typeof SIMD.int32x4.load2 === "undefined") {
     var n = 8 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int32x4(i32temp[0], i32temp[1], 0, 0);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], 0, 0);
   }
 }
 
-if (typeof SIMD.int32x4.load3 === "undefined") {
+if (typeof SIMD.Int32x4.load3 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.load3 = function(tarray, index) {
+  SIMD.Int32x4.load3 = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3476,18 +3476,18 @@ if (typeof SIMD.int32x4.load3 === "undefined") {
     var n = 12 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int32x4(i32temp[0], i32temp[1], i32temp[2], 0);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], i32temp[2], 0);
   }
 }
 
-if (typeof SIMD.int32x4.store === "undefined") {
+if (typeof SIMD.Int32x4.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
-    * @return {int32x4} value
+    * @param {Int32x4} value An instance of Int32x4.
+    * @return {Int32x4} value
     */
-  SIMD.int32x4.store = function(tarray, index, value) {
+  SIMD.Int32x4.store = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3495,11 +3495,11 @@ if (typeof SIMD.int32x4.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
-    _i32x4[0] = SIMD.int32x4.extractLane(value, 0);
-    _i32x4[1] = SIMD.int32x4.extractLane(value, 1);
-    _i32x4[2] = SIMD.int32x4.extractLane(value, 2);
-    _i32x4[3] = SIMD.int32x4.extractLane(value, 3);
+    value = SIMD.Int32x4.check(value);
+    _i32x4[0] = SIMD.Int32x4.extractLane(value, 0);
+    _i32x4[1] = SIMD.Int32x4.extractLane(value, 1);
+    _i32x4[2] = SIMD.Int32x4.extractLane(value, 2);
+    _i32x4[3] = SIMD.Int32x4.extractLane(value, 3);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -3511,14 +3511,14 @@ if (typeof SIMD.int32x4.store === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.store1 === "undefined") {
+if (typeof SIMD.Int32x4.store1 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
-    * @return {int32x4} value
+    * @param {Int32x4} value An instance of Int32x4.
+    * @return {Int32x4} value
     */
-  SIMD.int32x4.store1 = function(tarray, index, value) {
+  SIMD.Int32x4.store1 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3526,14 +3526,14 @@ if (typeof SIMD.int32x4.store1 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 4) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Int32Array(tarray.buffer,
                                 tarray.byteOffset + index * 8, 1);
-      view[0] = SIMD.int32x4.extractLane(value, 0);
+      view[0] = SIMD.Int32x4.extractLane(value, 0);
     } else {
-      _i32x4[0] = SIMD.int32x4.extractLane(value, 0);
+      _i32x4[0] = SIMD.Int32x4.extractLane(value, 0);
       var array = bpe == 1 ? _i8x16 :
                   bpe == 2 ? _i16x8 :
                   (tarray instanceof Float32Array ? _f32x4 : _i32x4);
@@ -3545,14 +3545,14 @@ if (typeof SIMD.int32x4.store1 === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.store2 === "undefined") {
+if (typeof SIMD.Int32x4.store2 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
-    * @return {int32x4} value
+    * @param {Int32x4} value An instance of Int32x4.
+    * @return {Int32x4} value
     */
-  SIMD.int32x4.store2 = function(tarray, index, value) {
+  SIMD.Int32x4.store2 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3560,9 +3560,9 @@ if (typeof SIMD.int32x4.store2 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
-    _i32x4[0] = SIMD.int32x4.extractLane(value, 0);
-    _i32x4[1] = SIMD.int32x4.extractLane(value, 1);
+    value = SIMD.Int32x4.check(value);
+    _i32x4[0] = SIMD.Int32x4.extractLane(value, 0);
+    _i32x4[1] = SIMD.Int32x4.extractLane(value, 1);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -3574,14 +3574,14 @@ if (typeof SIMD.int32x4.store2 === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.store3 === "undefined") {
+if (typeof SIMD.Int32x4.store3 === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
-    * @return {int32x4} value
+    * @param {Int32x4} value An instance of Int32x4.
+    * @return {Int32x4} value
     */
-  SIMD.int32x4.store3 = function(tarray, index, value) {
+  SIMD.Int32x4.store3 = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -3589,18 +3589,18 @@ if (typeof SIMD.int32x4.store3 === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 12) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Int32Array(tarray.buffer,
                                 tarray.byteOffset + index * 8, 3);
-      view[0] = SIMD.int32x4.extractLane(value, 0);
-      view[1] = SIMD.int32x4.extractLane(value, 1);
-      view[2] = SIMD.int32x4.extractLane(value, 2);
+      view[0] = SIMD.Int32x4.extractLane(value, 0);
+      view[1] = SIMD.Int32x4.extractLane(value, 1);
+      view[2] = SIMD.Int32x4.extractLane(value, 2);
     } else {
-      _i32x4[0] = SIMD.int32x4.extractLane(value, 0);
-      _i32x4[1] = SIMD.int32x4.extractLane(value, 1);
-      _i32x4[2] = SIMD.int32x4.extractLane(value, 2);
+      _i32x4[0] = SIMD.Int32x4.extractLane(value, 0);
+      _i32x4[1] = SIMD.Int32x4.extractLane(value, 1);
+      _i32x4[2] = SIMD.Int32x4.extractLane(value, 2);
       var array = bpe == 1 ? _i8x16 :
                   bpe == 2 ? _i16x8 :
                   (tarray instanceof Float32Array ? _f32x4 : _i32x4);
@@ -3612,178 +3612,178 @@ if (typeof SIMD.int32x4.store3 === "undefined") {
   }
 }
 
-if (typeof SIMD.int16x8.and === "undefined") {
+if (typeof SIMD.Int16x8.and === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a & b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a & b.
     */
-  SIMD.int16x8.and = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLane(a, 0) & SIMD.int16x8.extractLane(b, 0),
-        SIMD.int16x8.extractLane(a, 1) & SIMD.int16x8.extractLane(b, 1),
-        SIMD.int16x8.extractLane(a, 2) & SIMD.int16x8.extractLane(b, 2),
-        SIMD.int16x8.extractLane(a, 3) & SIMD.int16x8.extractLane(b, 3),
-        SIMD.int16x8.extractLane(a, 4) & SIMD.int16x8.extractLane(b, 4),
-        SIMD.int16x8.extractLane(a, 5) & SIMD.int16x8.extractLane(b, 5),
-        SIMD.int16x8.extractLane(a, 6) & SIMD.int16x8.extractLane(b, 6),
-        SIMD.int16x8.extractLane(a, 7) & SIMD.int16x8.extractLane(b, 7));
+  SIMD.Int16x8.and = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLane(a, 0) & SIMD.Int16x8.extractLane(b, 0),
+        SIMD.Int16x8.extractLane(a, 1) & SIMD.Int16x8.extractLane(b, 1),
+        SIMD.Int16x8.extractLane(a, 2) & SIMD.Int16x8.extractLane(b, 2),
+        SIMD.Int16x8.extractLane(a, 3) & SIMD.Int16x8.extractLane(b, 3),
+        SIMD.Int16x8.extractLane(a, 4) & SIMD.Int16x8.extractLane(b, 4),
+        SIMD.Int16x8.extractLane(a, 5) & SIMD.Int16x8.extractLane(b, 5),
+        SIMD.Int16x8.extractLane(a, 6) & SIMD.Int16x8.extractLane(b, 6),
+        SIMD.Int16x8.extractLane(a, 7) & SIMD.Int16x8.extractLane(b, 7));
   }
 }
 
-if (typeof SIMD.int16x8.or === "undefined") {
+if (typeof SIMD.Int16x8.or === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a | b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a | b.
     */
-  SIMD.int16x8.or = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLane(a, 0) | SIMD.int16x8.extractLane(b, 0),
-        SIMD.int16x8.extractLane(a, 1) | SIMD.int16x8.extractLane(b, 1),
-        SIMD.int16x8.extractLane(a, 2) | SIMD.int16x8.extractLane(b, 2),
-        SIMD.int16x8.extractLane(a, 3) | SIMD.int16x8.extractLane(b, 3),
-        SIMD.int16x8.extractLane(a, 4) | SIMD.int16x8.extractLane(b, 4),
-        SIMD.int16x8.extractLane(a, 5) | SIMD.int16x8.extractLane(b, 5),
-        SIMD.int16x8.extractLane(a, 6) | SIMD.int16x8.extractLane(b, 6),
-        SIMD.int16x8.extractLane(a, 7) | SIMD.int16x8.extractLane(b, 7));
+  SIMD.Int16x8.or = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLane(a, 0) | SIMD.Int16x8.extractLane(b, 0),
+        SIMD.Int16x8.extractLane(a, 1) | SIMD.Int16x8.extractLane(b, 1),
+        SIMD.Int16x8.extractLane(a, 2) | SIMD.Int16x8.extractLane(b, 2),
+        SIMD.Int16x8.extractLane(a, 3) | SIMD.Int16x8.extractLane(b, 3),
+        SIMD.Int16x8.extractLane(a, 4) | SIMD.Int16x8.extractLane(b, 4),
+        SIMD.Int16x8.extractLane(a, 5) | SIMD.Int16x8.extractLane(b, 5),
+        SIMD.Int16x8.extractLane(a, 6) | SIMD.Int16x8.extractLane(b, 6),
+        SIMD.Int16x8.extractLane(a, 7) | SIMD.Int16x8.extractLane(b, 7));
   }
 }
 
-if (typeof SIMD.int16x8.xor === "undefined") {
+if (typeof SIMD.Int16x8.xor === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a ^ b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a ^ b.
     */
-  SIMD.int16x8.xor = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLane(a, 0) ^ SIMD.int16x8.extractLane(b, 0),
-        SIMD.int16x8.extractLane(a, 1) ^ SIMD.int16x8.extractLane(b, 1),
-        SIMD.int16x8.extractLane(a, 2) ^ SIMD.int16x8.extractLane(b, 2),
-        SIMD.int16x8.extractLane(a, 3) ^ SIMD.int16x8.extractLane(b, 3),
-        SIMD.int16x8.extractLane(a, 4) ^ SIMD.int16x8.extractLane(b, 4),
-        SIMD.int16x8.extractLane(a, 5) ^ SIMD.int16x8.extractLane(b, 5),
-        SIMD.int16x8.extractLane(a, 6) ^ SIMD.int16x8.extractLane(b, 6),
-        SIMD.int16x8.extractLane(a, 7) ^ SIMD.int16x8.extractLane(b, 7));
+  SIMD.Int16x8.xor = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLane(a, 0) ^ SIMD.Int16x8.extractLane(b, 0),
+        SIMD.Int16x8.extractLane(a, 1) ^ SIMD.Int16x8.extractLane(b, 1),
+        SIMD.Int16x8.extractLane(a, 2) ^ SIMD.Int16x8.extractLane(b, 2),
+        SIMD.Int16x8.extractLane(a, 3) ^ SIMD.Int16x8.extractLane(b, 3),
+        SIMD.Int16x8.extractLane(a, 4) ^ SIMD.Int16x8.extractLane(b, 4),
+        SIMD.Int16x8.extractLane(a, 5) ^ SIMD.Int16x8.extractLane(b, 5),
+        SIMD.Int16x8.extractLane(a, 6) ^ SIMD.Int16x8.extractLane(b, 6),
+        SIMD.Int16x8.extractLane(a, 7) ^ SIMD.Int16x8.extractLane(b, 7));
   }
 }
 
-if (typeof SIMD.int16x8.not === "undefined") {
+if (typeof SIMD.Int16x8.not === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of ~t
+    * @param {Int16x8} t An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of ~t
     */
-  SIMD.int16x8.not = function(t) {
-    t = SIMD.int16x8.check(t);
-    return SIMD.int16x8(~SIMD.int16x8.extractLane(t, 0),
-                        ~SIMD.int16x8.extractLane(t, 1),
-                        ~SIMD.int16x8.extractLane(t, 2),
-                        ~SIMD.int16x8.extractLane(t, 3),
-                        ~SIMD.int16x8.extractLane(t, 4),
-                        ~SIMD.int16x8.extractLane(t, 5),
-                        ~SIMD.int16x8.extractLane(t, 6),
-                        ~SIMD.int16x8.extractLane(t, 7));
+  SIMD.Int16x8.not = function(t) {
+    t = SIMD.Int16x8.check(t);
+    return SIMD.Int16x8(~SIMD.Int16x8.extractLane(t, 0),
+                        ~SIMD.Int16x8.extractLane(t, 1),
+                        ~SIMD.Int16x8.extractLane(t, 2),
+                        ~SIMD.Int16x8.extractLane(t, 3),
+                        ~SIMD.Int16x8.extractLane(t, 4),
+                        ~SIMD.Int16x8.extractLane(t, 5),
+                        ~SIMD.Int16x8.extractLane(t, 6),
+                        ~SIMD.Int16x8.extractLane(t, 7));
   }
 }
 
-if (typeof SIMD.int16x8.neg === "undefined") {
+if (typeof SIMD.Int16x8.neg === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of -t
+    * @param {Int16x8} t An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of -t
     */
-  SIMD.int16x8.neg = function(t) {
-    t = SIMD.int16x8.check(t);
-    return SIMD.int16x8(-SIMD.int16x8.extractLane(t, 0),
-                        -SIMD.int16x8.extractLane(t, 1),
-                        -SIMD.int16x8.extractLane(t, 2),
-                        -SIMD.int16x8.extractLane(t, 3),
-                        -SIMD.int16x8.extractLane(t, 4),
-                        -SIMD.int16x8.extractLane(t, 5),
-                        -SIMD.int16x8.extractLane(t, 6),
-                        -SIMD.int16x8.extractLane(t, 7));
+  SIMD.Int16x8.neg = function(t) {
+    t = SIMD.Int16x8.check(t);
+    return SIMD.Int16x8(-SIMD.Int16x8.extractLane(t, 0),
+                        -SIMD.Int16x8.extractLane(t, 1),
+                        -SIMD.Int16x8.extractLane(t, 2),
+                        -SIMD.Int16x8.extractLane(t, 3),
+                        -SIMD.Int16x8.extractLane(t, 4),
+                        -SIMD.Int16x8.extractLane(t, 5),
+                        -SIMD.Int16x8.extractLane(t, 6),
+                        -SIMD.Int16x8.extractLane(t, 7));
   }
 }
 
-if (typeof SIMD.int16x8.add === "undefined") {
+if (typeof SIMD.Int16x8.add === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a + b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a + b.
     */
-  SIMD.int16x8.add = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLane(a, 0) + SIMD.int16x8.extractLane(b, 0),
-        SIMD.int16x8.extractLane(a, 1) + SIMD.int16x8.extractLane(b, 1),
-        SIMD.int16x8.extractLane(a, 2) + SIMD.int16x8.extractLane(b, 2),
-        SIMD.int16x8.extractLane(a, 3) + SIMD.int16x8.extractLane(b, 3),
-        SIMD.int16x8.extractLane(a, 4) + SIMD.int16x8.extractLane(b, 4),
-        SIMD.int16x8.extractLane(a, 5) + SIMD.int16x8.extractLane(b, 5),
-        SIMD.int16x8.extractLane(a, 6) + SIMD.int16x8.extractLane(b, 6),
-        SIMD.int16x8.extractLane(a, 7) + SIMD.int16x8.extractLane(b, 7));
+  SIMD.Int16x8.add = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLane(a, 0) + SIMD.Int16x8.extractLane(b, 0),
+        SIMD.Int16x8.extractLane(a, 1) + SIMD.Int16x8.extractLane(b, 1),
+        SIMD.Int16x8.extractLane(a, 2) + SIMD.Int16x8.extractLane(b, 2),
+        SIMD.Int16x8.extractLane(a, 3) + SIMD.Int16x8.extractLane(b, 3),
+        SIMD.Int16x8.extractLane(a, 4) + SIMD.Int16x8.extractLane(b, 4),
+        SIMD.Int16x8.extractLane(a, 5) + SIMD.Int16x8.extractLane(b, 5),
+        SIMD.Int16x8.extractLane(a, 6) + SIMD.Int16x8.extractLane(b, 6),
+        SIMD.Int16x8.extractLane(a, 7) + SIMD.Int16x8.extractLane(b, 7));
   }
 }
 
-if (typeof SIMD.int16x8.sub === "undefined") {
+if (typeof SIMD.Int16x8.sub === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a - b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a - b.
     */
-  SIMD.int16x8.sub = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLane(a, 0) - SIMD.int16x8.extractLane(b, 0),
-        SIMD.int16x8.extractLane(a, 1) - SIMD.int16x8.extractLane(b, 1),
-        SIMD.int16x8.extractLane(a, 2) - SIMD.int16x8.extractLane(b, 2),
-        SIMD.int16x8.extractLane(a, 3) - SIMD.int16x8.extractLane(b, 3),
-        SIMD.int16x8.extractLane(a, 4) - SIMD.int16x8.extractLane(b, 4),
-        SIMD.int16x8.extractLane(a, 5) - SIMD.int16x8.extractLane(b, 5),
-        SIMD.int16x8.extractLane(a, 6) - SIMD.int16x8.extractLane(b, 6),
-        SIMD.int16x8.extractLane(a, 7) - SIMD.int16x8.extractLane(b, 7));
+  SIMD.Int16x8.sub = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLane(a, 0) - SIMD.Int16x8.extractLane(b, 0),
+        SIMD.Int16x8.extractLane(a, 1) - SIMD.Int16x8.extractLane(b, 1),
+        SIMD.Int16x8.extractLane(a, 2) - SIMD.Int16x8.extractLane(b, 2),
+        SIMD.Int16x8.extractLane(a, 3) - SIMD.Int16x8.extractLane(b, 3),
+        SIMD.Int16x8.extractLane(a, 4) - SIMD.Int16x8.extractLane(b, 4),
+        SIMD.Int16x8.extractLane(a, 5) - SIMD.Int16x8.extractLane(b, 5),
+        SIMD.Int16x8.extractLane(a, 6) - SIMD.Int16x8.extractLane(b, 6),
+        SIMD.Int16x8.extractLane(a, 7) - SIMD.Int16x8.extractLane(b, 7));
   }
 }
 
-if (typeof SIMD.int16x8.mul === "undefined") {
+if (typeof SIMD.Int16x8.mul === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a * b.
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a * b.
     */
-  SIMD.int16x8.mul = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    return SIMD.int16x8(Math.imul(SIMD.int16x8.extractLane(a, 0),
-                                  SIMD.int16x8.extractLane(b, 0)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 1),
-                                  SIMD.int16x8.extractLane(b, 1)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 2),
-                                  SIMD.int16x8.extractLane(b, 2)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 3),
-                                  SIMD.int16x8.extractLane(b, 3)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 4),
-                                  SIMD.int16x8.extractLane(b, 4)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 5),
-                                  SIMD.int16x8.extractLane(b, 5)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 6),
-                                  SIMD.int16x8.extractLane(b, 6)),
-                        Math.imul(SIMD.int16x8.extractLane(a, 7),
-                                  SIMD.int16x8.extractLane(b, 7)));
+  SIMD.Int16x8.mul = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int16x8(Math.imul(SIMD.Int16x8.extractLane(a, 0),
+                                  SIMD.Int16x8.extractLane(b, 0)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 1),
+                                  SIMD.Int16x8.extractLane(b, 1)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 2),
+                                  SIMD.Int16x8.extractLane(b, 2)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 3),
+                                  SIMD.Int16x8.extractLane(b, 3)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 4),
+                                  SIMD.Int16x8.extractLane(b, 4)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 5),
+                                  SIMD.Int16x8.extractLane(b, 5)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 6),
+                                  SIMD.Int16x8.extractLane(b, 6)),
+                        Math.imul(SIMD.Int16x8.extractLane(a, 7),
+                                  SIMD.Int16x8.extractLane(b, 7)));
   }
 }
 
-if (typeof SIMD.int16x8.swizzle === "undefined") {
+if (typeof SIMD.Int16x8.swizzle === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8 to be swizzled.
+    * @param {Int16x8} t An instance of Int16x8 to be swizzled.
     * @param {integer} s0 - Index in t for lane s0
     * @param {integer} s1 - Index in t for lane s1
     * @param {integer} s2 - Index in t for lane s2
@@ -3792,10 +3792,10 @@ if (typeof SIMD.int16x8.swizzle === "undefined") {
     * @param {integer} s5 - Index in t for lane s5
     * @param {integer} s6 - Index in t for lane s6
     * @param {integer} s7 - Index in t for lane s7
-    * @return {int16x8} New instance of int16x8 with lanes swizzled.
+    * @return {Int16x8} New instance of Int16x8 with lanes swizzled.
     */
-  SIMD.int16x8.swizzle = function(t, s0, s1, s2, s3, s4, s5, s6, s7) {
-    t = SIMD.int16x8.check(t);
+  SIMD.Int16x8.swizzle = function(t, s0, s1, s2, s3, s4, s5, s6, s7) {
+    t = SIMD.Int16x8.check(t);
     check8(s0);
     check8(s1);
     check8(s2);
@@ -3805,26 +3805,26 @@ if (typeof SIMD.int16x8.swizzle === "undefined") {
     check8(s6);
     check8(s7);
     var storage = _i16x8;
-    storage[0] = SIMD.int16x8.extractLane(t, 0);
-    storage[1] = SIMD.int16x8.extractLane(t, 1);
-    storage[2] = SIMD.int16x8.extractLane(t, 2);
-    storage[3] = SIMD.int16x8.extractLane(t, 3);
-    storage[4] = SIMD.int16x8.extractLane(t, 4);
-    storage[5] = SIMD.int16x8.extractLane(t, 5);
-    storage[6] = SIMD.int16x8.extractLane(t, 6);
-    storage[7] = SIMD.int16x8.extractLane(t, 7);
-    return SIMD.int16x8(storage[s0], storage[s1], storage[s2], storage[s3],
+    storage[0] = SIMD.Int16x8.extractLane(t, 0);
+    storage[1] = SIMD.Int16x8.extractLane(t, 1);
+    storage[2] = SIMD.Int16x8.extractLane(t, 2);
+    storage[3] = SIMD.Int16x8.extractLane(t, 3);
+    storage[4] = SIMD.Int16x8.extractLane(t, 4);
+    storage[5] = SIMD.Int16x8.extractLane(t, 5);
+    storage[6] = SIMD.Int16x8.extractLane(t, 6);
+    storage[7] = SIMD.Int16x8.extractLane(t, 7);
+    return SIMD.Int16x8(storage[s0], storage[s1], storage[s2], storage[s3],
                         storage[s4], storage[s5], storage[s6], storage[s7]);
   }
 }
 
-if (typeof SIMD.int16x8.shuffle === "undefined") {
+if (typeof SIMD.Int16x8.shuffle === "undefined") {
 
   _i16x16 = new Int16Array(16);
 
   /**
-    * @param {int16x8} t0 An instance of int16x8 to be shuffled.
-    * @param {int16x8} t1 An instance of int16x8 to be shuffled.
+    * @param {Int16x8} t0 An instance of Int16x8 to be shuffled.
+    * @param {Int16x8} t1 An instance of Int16x8 to be shuffled.
     * @param {integer} s0 - Index in concatenation of t0 and t1 for lane s0
     * @param {integer} s1 - Index in concatenation of t0 and t1 for lane s1
     * @param {integer} s2 - Index in concatenation of t0 and t1 for lane s2
@@ -3833,11 +3833,11 @@ if (typeof SIMD.int16x8.shuffle === "undefined") {
     * @param {integer} s5 - Index in concatenation of t0 and t1 for lane s5
     * @param {integer} s6 - Index in concatenation of t0 and t1 for lane s6
     * @param {integer} s7 - Index in concatenation of t0 and t1 for lane s7
-    * @return {int16x8} New instance of int16x8 with lanes shuffled.
+    * @return {Int16x8} New instance of Int16x8 with lanes shuffled.
     */
-  SIMD.int16x8.shuffle = function(t0, t1, s0, s1, s2, s3, s4, s5, s6, s7) {
-    t0 = SIMD.int16x8.check(t0);
-    t1 = SIMD.int16x8.check(t1);
+  SIMD.Int16x8.shuffle = function(t0, t1, s0, s1, s2, s3, s4, s5, s6, s7) {
+    t0 = SIMD.Int16x8.check(t0);
+    t1 = SIMD.Int16x8.check(t1);
     check16(s0);
     check16(s1);
     check16(s2);
@@ -3847,382 +3847,382 @@ if (typeof SIMD.int16x8.shuffle === "undefined") {
     check16(s6);
     check16(s7);
     var storage = _i16x16;
-    storage[0] = SIMD.int16x8.extractLane(t0, 0);
-    storage[1] = SIMD.int16x8.extractLane(t0, 1);
-    storage[2] = SIMD.int16x8.extractLane(t0, 2);
-    storage[3] = SIMD.int16x8.extractLane(t0, 3);
-    storage[4] = SIMD.int16x8.extractLane(t0, 4);
-    storage[5] = SIMD.int16x8.extractLane(t0, 5);
-    storage[6] = SIMD.int16x8.extractLane(t0, 6);
-    storage[7] = SIMD.int16x8.extractLane(t0, 7);
-    storage[8] = SIMD.int16x8.extractLane(t1, 0);
-    storage[9] = SIMD.int16x8.extractLane(t1, 1);
-    storage[10] = SIMD.int16x8.extractLane(t1, 2);
-    storage[11] = SIMD.int16x8.extractLane(t1, 3);
-    storage[12] = SIMD.int16x8.extractLane(t1, 4);
-    storage[13] = SIMD.int16x8.extractLane(t1, 5);
-    storage[14] = SIMD.int16x8.extractLane(t1, 6);
-    storage[15] = SIMD.int16x8.extractLane(t1, 7);
-    return SIMD.int16x8(storage[s0], storage[s1], storage[s2], storage[s3],
+    storage[0] = SIMD.Int16x8.extractLane(t0, 0);
+    storage[1] = SIMD.Int16x8.extractLane(t0, 1);
+    storage[2] = SIMD.Int16x8.extractLane(t0, 2);
+    storage[3] = SIMD.Int16x8.extractLane(t0, 3);
+    storage[4] = SIMD.Int16x8.extractLane(t0, 4);
+    storage[5] = SIMD.Int16x8.extractLane(t0, 5);
+    storage[6] = SIMD.Int16x8.extractLane(t0, 6);
+    storage[7] = SIMD.Int16x8.extractLane(t0, 7);
+    storage[8] = SIMD.Int16x8.extractLane(t1, 0);
+    storage[9] = SIMD.Int16x8.extractLane(t1, 1);
+    storage[10] = SIMD.Int16x8.extractLane(t1, 2);
+    storage[11] = SIMD.Int16x8.extractLane(t1, 3);
+    storage[12] = SIMD.Int16x8.extractLane(t1, 4);
+    storage[13] = SIMD.Int16x8.extractLane(t1, 5);
+    storage[14] = SIMD.Int16x8.extractLane(t1, 6);
+    storage[15] = SIMD.Int16x8.extractLane(t1, 7);
+    return SIMD.Int16x8(storage[s0], storage[s1], storage[s2], storage[s3],
                         storage[s4], storage[s5], storage[s6], storage[s7]);
   }
 }
 
-if (typeof SIMD.int16x8.addSaturate === "undefined") {
+if (typeof SIMD.Int16x8.addSaturate === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a + b with
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a + b with
     * signed saturating behavior on overflow.
     */
-  SIMD.int16x8.addSaturate = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    var c = SIMD.int16x8.add(a, b);
-    var max = SIMD.int16x8.splat(0x7fff);
-    var min = SIMD.int16x8.splat(0x8000);
-    var mask = SIMD.int16x8.lessThan(c, a);
-    return SIMD.int16x8.select(SIMD.int16x8.and(mask, SIMD.int16x8.not(b)), max,
-             SIMD.int16x8.select(SIMD.int16x8.and(SIMD.int16x8.not(mask), b), min,
+  SIMD.Int16x8.addSaturate = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    var c = SIMD.Int16x8.add(a, b);
+    var max = SIMD.Int16x8.splat(0x7fff);
+    var min = SIMD.Int16x8.splat(0x8000);
+    var mask = SIMD.Int16x8.lessThan(c, a);
+    return SIMD.Int16x8.select(SIMD.Int16x8.and(mask, SIMD.Int16x8.not(b)), max,
+             SIMD.Int16x8.select(SIMD.Int16x8.and(SIMD.Int16x8.not(mask), b), min,
                c));
   }
 }
 
-if (typeof SIMD.int16x8.subSaturate === "undefined") {
+if (typeof SIMD.Int16x8.subSaturate === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
-    * @param {int16x8} b An instance of int16x8.
-    * @return {int16x8} New instance of int16x8 with values of a - b with
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a - b with
     * signed saturating behavior on overflow.
     */
-  SIMD.int16x8.subSaturate = function(a, b) {
-    a = SIMD.int16x8.check(a);
-    b = SIMD.int16x8.check(b);
-    var c = SIMD.int16x8.sub(a, b);
-    var max = SIMD.int16x8.splat(0x7fff);
-    var min = SIMD.int16x8.splat(0x8000);
-    var mask = SIMD.int16x8.greaterThan(c, a);
-    return SIMD.int16x8.select(SIMD.int16x8.and(mask, SIMD.int16x8.not(b)), min,
-             SIMD.int16x8.select(SIMD.int16x8.and(SIMD.int16x8.not(mask), b), max,
+  SIMD.Int16x8.subSaturate = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    var c = SIMD.Int16x8.sub(a, b);
+    var max = SIMD.Int16x8.splat(0x7fff);
+    var min = SIMD.Int16x8.splat(0x8000);
+    var mask = SIMD.Int16x8.greaterThan(c, a);
+    return SIMD.Int16x8.select(SIMD.Int16x8.and(mask, SIMD.Int16x8.not(b)), min,
+             SIMD.Int16x8.select(SIMD.Int16x8.and(SIMD.Int16x8.not(mask), b), max,
                c));
   }
 }
 
-if (typeof SIMD.int16x8.select === "undefined") {
+if (typeof SIMD.Int16x8.select === "undefined") {
   /**
-    * @param {int16x8} t Selector mask. An instance of int16x8
-    * @param {int16x8} trueValue Pick lane from here if corresponding
+    * @param {Int16x8} t Selector mask. An instance of Int16x8
+    * @param {Int16x8} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {int16x8} falseValue Pick lane from here if corresponding
+    * @param {Int16x8} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {int16x8} Mix of lanes from trueValue or falseValue as
+    * @return {Int16x8} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int16x8.select = function(t, trueValue, falseValue) {
-    t = SIMD.int16x8.check(t);
-    trueValue = SIMD.int16x8.check(trueValue);
-    falseValue = SIMD.int16x8.check(falseValue);
-    return SIMD.int16x8(
-        SIMD.int16x8.extractLaneAsBool(t, 0) ?
-            SIMD.int16x8.extractLane(trueValue, 0) :
-                SIMD.int16x8.extractLane(falseValue, 0),
-        SIMD.int16x8.extractLaneAsBool(t, 1) ?
-            SIMD.int16x8.extractLane(trueValue, 1) :
-                SIMD.int16x8.extractLane(falseValue, 1),
-        SIMD.int16x8.extractLaneAsBool(t, 2) ?
-            SIMD.int16x8.extractLane(trueValue, 2) :
-                SIMD.int16x8.extractLane(falseValue, 2),
-        SIMD.int16x8.extractLaneAsBool(t, 3) ?
-            SIMD.int16x8.extractLane(trueValue, 3) :
-                SIMD.int16x8.extractLane(falseValue, 3),
-        SIMD.int16x8.extractLaneAsBool(t, 4) ?
-            SIMD.int16x8.extractLane(trueValue, 4) :
-                SIMD.int16x8.extractLane(falseValue, 4),
-        SIMD.int16x8.extractLaneAsBool(t, 5) ?
-            SIMD.int16x8.extractLane(trueValue, 5) :
-                SIMD.int16x8.extractLane(falseValue, 5),
-        SIMD.int16x8.extractLaneAsBool(t, 6) ?
-            SIMD.int16x8.extractLane(trueValue, 6) :
-                SIMD.int16x8.extractLane(falseValue, 6),
-        SIMD.int16x8.extractLaneAsBool(t, 7) ?
-            SIMD.int16x8.extractLane(trueValue, 7) :
-                SIMD.int16x8.extractLane(falseValue, 7));
+  SIMD.Int16x8.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int16x8.check(t);
+    trueValue = SIMD.Int16x8.check(trueValue);
+    falseValue = SIMD.Int16x8.check(falseValue);
+    return SIMD.Int16x8(
+        SIMD.Int16x8.extractLaneAsBool(t, 0) ?
+            SIMD.Int16x8.extractLane(trueValue, 0) :
+                SIMD.Int16x8.extractLane(falseValue, 0),
+        SIMD.Int16x8.extractLaneAsBool(t, 1) ?
+            SIMD.Int16x8.extractLane(trueValue, 1) :
+                SIMD.Int16x8.extractLane(falseValue, 1),
+        SIMD.Int16x8.extractLaneAsBool(t, 2) ?
+            SIMD.Int16x8.extractLane(trueValue, 2) :
+                SIMD.Int16x8.extractLane(falseValue, 2),
+        SIMD.Int16x8.extractLaneAsBool(t, 3) ?
+            SIMD.Int16x8.extractLane(trueValue, 3) :
+                SIMD.Int16x8.extractLane(falseValue, 3),
+        SIMD.Int16x8.extractLaneAsBool(t, 4) ?
+            SIMD.Int16x8.extractLane(trueValue, 4) :
+                SIMD.Int16x8.extractLane(falseValue, 4),
+        SIMD.Int16x8.extractLaneAsBool(t, 5) ?
+            SIMD.Int16x8.extractLane(trueValue, 5) :
+                SIMD.Int16x8.extractLane(falseValue, 5),
+        SIMD.Int16x8.extractLaneAsBool(t, 6) ?
+            SIMD.Int16x8.extractLane(trueValue, 6) :
+                SIMD.Int16x8.extractLane(falseValue, 6),
+        SIMD.Int16x8.extractLaneAsBool(t, 7) ?
+            SIMD.Int16x8.extractLane(trueValue, 7) :
+                SIMD.Int16x8.extractLane(falseValue, 7));
   }
 }
 
-if (typeof SIMD.int16x8.selectBits === "undefined") {
+if (typeof SIMD.Int16x8.selectBits === "undefined") {
   /**
-    * @param {int16x8} t Selector mask. An instance of int16x8
-    * @param {int16x8} trueValue Pick lane from here if corresponding
+    * @param {Int16x8} t Selector mask. An instance of Int16x8
+    * @param {Int16x8} trueValue Pick lane from here if corresponding
     * selector bit is 1
-    * @param {int16x8} falseValue Pick lane from here if corresponding
+    * @param {Int16x8} falseValue Pick lane from here if corresponding
     * selector bit is 0
-    * @return {int16x8} Mix of lanes from trueValue or falseValue as
+    * @return {Int16x8} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int16x8.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int16x8.check(t);
-    trueValue = SIMD.int16x8.check(trueValue);
-    falseValue = SIMD.int16x8.check(falseValue);
-    var tr = SIMD.int16x8.and(t, trueValue);
-    var fr = SIMD.int16x8.and(SIMD.int16x8.not(t), falseValue);
-    return SIMD.int16x8.or(tr, fr);
+  SIMD.Int16x8.selectBits = function(t, trueValue, falseValue) {
+    t = SIMD.Int16x8.check(t);
+    trueValue = SIMD.Int16x8.check(trueValue);
+    falseValue = SIMD.Int16x8.check(falseValue);
+    var tr = SIMD.Int16x8.and(t, trueValue);
+    var fr = SIMD.Int16x8.and(SIMD.Int16x8.not(t), falseValue);
+    return SIMD.Int16x8.or(tr, fr);
   }
 }
 
-if (typeof SIMD.int16x8.equal === "undefined") {
+if (typeof SIMD.Int16x8.equal === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.int16x8.equal = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.equal = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) == SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) == SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) == SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) == SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) == SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) == SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) == SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) == SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) == SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) == SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) == SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) == SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) == SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) == SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) == SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) == SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.notEqual === "undefined") {
+if (typeof SIMD.Int16x8.notEqual === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.int16x8.notEqual = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.notEqual = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) != SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) != SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) != SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) != SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) != SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) != SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) != SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) != SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) != SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) != SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) != SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) != SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) != SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) != SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) != SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) != SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.greaterThan === "undefined") {
+if (typeof SIMD.Int16x8.greaterThan === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.int16x8.greaterThan = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.greaterThan = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) > SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) > SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) > SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) > SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) > SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) > SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) > SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) > SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) > SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) > SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) > SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) > SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) > SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) > SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) > SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) > SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Int16x8.greaterThanOrEqual === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.int16x8.greaterThanOrEqual = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) >= SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) >= SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) >= SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) >= SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) >= SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) >= SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) >= SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) >= SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) >= SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) >= SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) >= SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) >= SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) >= SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) >= SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) >= SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) >= SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.lessThan === "undefined") {
+if (typeof SIMD.Int16x8.lessThan === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.int16x8.lessThan = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.lessThan = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) < SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) < SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) < SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) < SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) < SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) < SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) < SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) < SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) < SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) < SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) < SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) < SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) < SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) < SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) < SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) < SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Int16x8.lessThanOrEqual === "undefined") {
   /**
-    * @param {int16x8} t An instance of int16x8.
-    * @param {int16x8} other An instance of int16x8.
-    * @return {int16x8} true or false in each lane depending on
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Int16x8} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.int16x8.lessThanOrEqual = function(t, other) {
-    t = SIMD.int16x8.check(t);
-    other = SIMD.int16x8.check(other);
+  SIMD.Int16x8.lessThanOrEqual = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
     var cs0 =
-        SIMD.int16x8.extractLane(t, 0) <= SIMD.int16x8.extractLane(other, 0);
+        SIMD.Int16x8.extractLane(t, 0) <= SIMD.Int16x8.extractLane(other, 0);
     var cs1 =
-        SIMD.int16x8.extractLane(t, 1) <= SIMD.int16x8.extractLane(other, 1);
+        SIMD.Int16x8.extractLane(t, 1) <= SIMD.Int16x8.extractLane(other, 1);
     var cs2 =
-        SIMD.int16x8.extractLane(t, 2) <= SIMD.int16x8.extractLane(other, 2);
+        SIMD.Int16x8.extractLane(t, 2) <= SIMD.Int16x8.extractLane(other, 2);
     var cs3 =
-        SIMD.int16x8.extractLane(t, 3) <= SIMD.int16x8.extractLane(other, 3);
+        SIMD.Int16x8.extractLane(t, 3) <= SIMD.Int16x8.extractLane(other, 3);
     var cs4 =
-        SIMD.int16x8.extractLane(t, 4) <= SIMD.int16x8.extractLane(other, 4);
+        SIMD.Int16x8.extractLane(t, 4) <= SIMD.Int16x8.extractLane(other, 4);
     var cs5 =
-        SIMD.int16x8.extractLane(t, 5) <= SIMD.int16x8.extractLane(other, 5);
+        SIMD.Int16x8.extractLane(t, 5) <= SIMD.Int16x8.extractLane(other, 5);
     var cs6 =
-        SIMD.int16x8.extractLane(t, 6) <= SIMD.int16x8.extractLane(other, 6);
+        SIMD.Int16x8.extractLane(t, 6) <= SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
-        SIMD.int16x8.extractLane(t, 7) <= SIMD.int16x8.extractLane(other, 7);
-    return SIMD.int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+        SIMD.Int16x8.extractLane(t, 7) <= SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Int16x8.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
 
-if (typeof SIMD.int16x8.shiftLeftByScalar === "undefined") {
+if (typeof SIMD.Int16x8.shiftLeftByScalar === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
+    * @param {Int16x8} a An instance of Int16x8.
     * @param {integer} bits Bit count to shift by.
-    * @return {int16x8} lanes in a shifted by bits.
+    * @return {Int16x8} lanes in a shifted by bits.
     */
-  SIMD.int16x8.shiftLeftByScalar = function(a, bits) {
-    a = SIMD.int16x8.check(a);
+  SIMD.Int16x8.shiftLeftByScalar = function(a, bits) {
+    a = SIMD.Int16x8.check(a);
     if (bits>>>0 > 16)
       bits = 16;
-    var s0 = SIMD.int16x8.extractLane(a, 0) << bits;
-    var s1 = SIMD.int16x8.extractLane(a, 1) << bits;
-    var s2 = SIMD.int16x8.extractLane(a, 2) << bits;
-    var s3 = SIMD.int16x8.extractLane(a, 3) << bits;
-    var s4 = SIMD.int16x8.extractLane(a, 4) << bits;
-    var s5 = SIMD.int16x8.extractLane(a, 5) << bits;
-    var s6 = SIMD.int16x8.extractLane(a, 6) << bits;
-    var s7 = SIMD.int16x8.extractLane(a, 7) << bits;
-    return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+    var s0 = SIMD.Int16x8.extractLane(a, 0) << bits;
+    var s1 = SIMD.Int16x8.extractLane(a, 1) << bits;
+    var s2 = SIMD.Int16x8.extractLane(a, 2) << bits;
+    var s3 = SIMD.Int16x8.extractLane(a, 3) << bits;
+    var s4 = SIMD.Int16x8.extractLane(a, 4) << bits;
+    var s5 = SIMD.Int16x8.extractLane(a, 5) << bits;
+    var s6 = SIMD.Int16x8.extractLane(a, 6) << bits;
+    var s7 = SIMD.Int16x8.extractLane(a, 7) << bits;
+    return SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
   }
 }
 
-if (typeof SIMD.int16x8.shiftRightLogicalByScalar === "undefined") {
+if (typeof SIMD.Int16x8.shiftRightLogicalByScalar === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
+    * @param {Int16x8} a An instance of Int16x8.
     * @param {integer} bits Bit count to shift by.
-    * @return {int16x8} lanes in a shifted by bits.
+    * @return {Int16x8} lanes in a shifted by bits.
     */
-  SIMD.int16x8.shiftRightLogicalByScalar = function(a, bits) {
-    a = SIMD.int16x8.check(a);
+  SIMD.Int16x8.shiftRightLogicalByScalar = function(a, bits) {
+    a = SIMD.Int16x8.check(a);
     if (bits>>>0 > 16)
       bits = 16;
-    var s0 = (SIMD.int16x8.extractLane(a, 0) & 0xffff) >>> bits;
-    var s1 = (SIMD.int16x8.extractLane(a, 1) & 0xffff) >>> bits;
-    var s2 = (SIMD.int16x8.extractLane(a, 2) & 0xffff) >>> bits;
-    var s3 = (SIMD.int16x8.extractLane(a, 3) & 0xffff) >>> bits;
-    var s4 = (SIMD.int16x8.extractLane(a, 4) & 0xffff) >>> bits;
-    var s5 = (SIMD.int16x8.extractLane(a, 5) & 0xffff) >>> bits;
-    var s6 = (SIMD.int16x8.extractLane(a, 6) & 0xffff) >>> bits;
-    var s7 = (SIMD.int16x8.extractLane(a, 7) & 0xffff) >>> bits;
-    return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+    var s0 = (SIMD.Int16x8.extractLane(a, 0) & 0xffff) >>> bits;
+    var s1 = (SIMD.Int16x8.extractLane(a, 1) & 0xffff) >>> bits;
+    var s2 = (SIMD.Int16x8.extractLane(a, 2) & 0xffff) >>> bits;
+    var s3 = (SIMD.Int16x8.extractLane(a, 3) & 0xffff) >>> bits;
+    var s4 = (SIMD.Int16x8.extractLane(a, 4) & 0xffff) >>> bits;
+    var s5 = (SIMD.Int16x8.extractLane(a, 5) & 0xffff) >>> bits;
+    var s6 = (SIMD.Int16x8.extractLane(a, 6) & 0xffff) >>> bits;
+    var s7 = (SIMD.Int16x8.extractLane(a, 7) & 0xffff) >>> bits;
+    return SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
   }
 }
 
-if (typeof SIMD.int16x8.shiftRightArithmeticByScalar === "undefined") {
+if (typeof SIMD.Int16x8.shiftRightArithmeticByScalar === "undefined") {
   /**
-    * @param {int16x8} a An instance of int16x8.
+    * @param {Int16x8} a An instance of Int16x8.
     * @param {integer} bits Bit count to shift by.
-    * @return {int16x8} lanes in a shifted by bits.
+    * @return {Int16x8} lanes in a shifted by bits.
     */
-  SIMD.int16x8.shiftRightArithmeticByScalar = function(a, bits) {
-    a = SIMD.int16x8.check(a);
+  SIMD.Int16x8.shiftRightArithmeticByScalar = function(a, bits) {
+    a = SIMD.Int16x8.check(a);
     if (bits>>>0 > 16)
       bits = 16;
-    var s0 = SIMD.int16x8.extractLane(a, 0) >> bits;
-    var s1 = SIMD.int16x8.extractLane(a, 1) >> bits;
-    var s2 = SIMD.int16x8.extractLane(a, 2) >> bits;
-    var s3 = SIMD.int16x8.extractLane(a, 3) >> bits;
-    var s4 = SIMD.int16x8.extractLane(a, 4) >> bits;
-    var s5 = SIMD.int16x8.extractLane(a, 5) >> bits;
-    var s6 = SIMD.int16x8.extractLane(a, 6) >> bits;
-    var s7 = SIMD.int16x8.extractLane(a, 7) >> bits;
-    return SIMD.int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
+    var s0 = SIMD.Int16x8.extractLane(a, 0) >> bits;
+    var s1 = SIMD.Int16x8.extractLane(a, 1) >> bits;
+    var s2 = SIMD.Int16x8.extractLane(a, 2) >> bits;
+    var s3 = SIMD.Int16x8.extractLane(a, 3) >> bits;
+    var s4 = SIMD.Int16x8.extractLane(a, 4) >> bits;
+    var s5 = SIMD.Int16x8.extractLane(a, 5) >> bits;
+    var s6 = SIMD.Int16x8.extractLane(a, 6) >> bits;
+    var s7 = SIMD.Int16x8.extractLane(a, 7) >> bits;
+    return SIMD.Int16x8(s0, s1, s2, s3, s4, s5, s6, s7);
   }
 }
 
-if (typeof SIMD.int16x8.load === "undefined") {
+if (typeof SIMD.Int16x8.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int16x8} New instance of int16x8.
+    * @return {Int16x8} New instance of Int16x8.
     */
-  SIMD.int16x8.load = function(tarray, index) {
+  SIMD.Int16x8.load = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -4238,19 +4238,19 @@ if (typeof SIMD.int16x8.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int16x8(i16temp[0], i16temp[1], i16temp[2], i16temp[3],
+    return SIMD.Int16x8(i16temp[0], i16temp[1], i16temp[2], i16temp[3],
                         i16temp[4], i16temp[5], i16temp[6], i16temp[7]);
   }
 }
 
-if (typeof SIMD.int16x8.store === "undefined") {
+if (typeof SIMD.Int16x8.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int16x8} value An instance of int16x8.
-    * @return {int16x8} value
+    * @param {Int16x8} value An instance of Int16x8.
+    * @return {Int16x8} value
     */
-  SIMD.int16x8.store = function(tarray, index, value) {
+  SIMD.Int16x8.store = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -4258,15 +4258,15 @@ if (typeof SIMD.int16x8.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int16x8.check(value);
-    _i16x8[0] = SIMD.int16x8.extractLane(value, 0);
-    _i16x8[1] = SIMD.int16x8.extractLane(value, 1);
-    _i16x8[2] = SIMD.int16x8.extractLane(value, 2);
-    _i16x8[3] = SIMD.int16x8.extractLane(value, 3);
-    _i16x8[4] = SIMD.int16x8.extractLane(value, 4);
-    _i16x8[5] = SIMD.int16x8.extractLane(value, 5);
-    _i16x8[6] = SIMD.int16x8.extractLane(value, 6);
-    _i16x8[7] = SIMD.int16x8.extractLane(value, 7);
+    value = SIMD.Int16x8.check(value);
+    _i16x8[0] = SIMD.Int16x8.extractLane(value, 0);
+    _i16x8[1] = SIMD.Int16x8.extractLane(value, 1);
+    _i16x8[2] = SIMD.Int16x8.extractLane(value, 2);
+    _i16x8[3] = SIMD.Int16x8.extractLane(value, 3);
+    _i16x8[4] = SIMD.Int16x8.extractLane(value, 4);
+    _i16x8[5] = SIMD.Int16x8.extractLane(value, 5);
+    _i16x8[6] = SIMD.Int16x8.extractLane(value, 6);
+    _i16x8[7] = SIMD.Int16x8.extractLane(value, 7);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :
@@ -4278,250 +4278,250 @@ if (typeof SIMD.int16x8.store === "undefined") {
   }
 }
 
-if (typeof SIMD.int8x16.and === "undefined") {
+if (typeof SIMD.Int8x16.and === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a & b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a & b.
     */
-  SIMD.int8x16.and = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLane(a, 0) & SIMD.int8x16.extractLane(b, 0),
-        SIMD.int8x16.extractLane(a, 1) & SIMD.int8x16.extractLane(b, 1),
-        SIMD.int8x16.extractLane(a, 2) & SIMD.int8x16.extractLane(b, 2),
-        SIMD.int8x16.extractLane(a, 3) & SIMD.int8x16.extractLane(b, 3),
-        SIMD.int8x16.extractLane(a, 4) & SIMD.int8x16.extractLane(b, 4),
-        SIMD.int8x16.extractLane(a, 5) & SIMD.int8x16.extractLane(b, 5),
-        SIMD.int8x16.extractLane(a, 6) & SIMD.int8x16.extractLane(b, 6),
-        SIMD.int8x16.extractLane(a, 7) & SIMD.int8x16.extractLane(b, 7),
-        SIMD.int8x16.extractLane(a, 8) & SIMD.int8x16.extractLane(b, 8),
-        SIMD.int8x16.extractLane(a, 9) & SIMD.int8x16.extractLane(b, 9),
-        SIMD.int8x16.extractLane(a, 10) & SIMD.int8x16.extractLane(b, 10),
-        SIMD.int8x16.extractLane(a, 11) & SIMD.int8x16.extractLane(b, 11),
-        SIMD.int8x16.extractLane(a, 12) & SIMD.int8x16.extractLane(b, 12),
-        SIMD.int8x16.extractLane(a, 13) & SIMD.int8x16.extractLane(b, 13),
-        SIMD.int8x16.extractLane(a, 14) & SIMD.int8x16.extractLane(b, 14),
-        SIMD.int8x16.extractLane(a, 15) & SIMD.int8x16.extractLane(b, 15));
+  SIMD.Int8x16.and = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLane(a, 0) & SIMD.Int8x16.extractLane(b, 0),
+        SIMD.Int8x16.extractLane(a, 1) & SIMD.Int8x16.extractLane(b, 1),
+        SIMD.Int8x16.extractLane(a, 2) & SIMD.Int8x16.extractLane(b, 2),
+        SIMD.Int8x16.extractLane(a, 3) & SIMD.Int8x16.extractLane(b, 3),
+        SIMD.Int8x16.extractLane(a, 4) & SIMD.Int8x16.extractLane(b, 4),
+        SIMD.Int8x16.extractLane(a, 5) & SIMD.Int8x16.extractLane(b, 5),
+        SIMD.Int8x16.extractLane(a, 6) & SIMD.Int8x16.extractLane(b, 6),
+        SIMD.Int8x16.extractLane(a, 7) & SIMD.Int8x16.extractLane(b, 7),
+        SIMD.Int8x16.extractLane(a, 8) & SIMD.Int8x16.extractLane(b, 8),
+        SIMD.Int8x16.extractLane(a, 9) & SIMD.Int8x16.extractLane(b, 9),
+        SIMD.Int8x16.extractLane(a, 10) & SIMD.Int8x16.extractLane(b, 10),
+        SIMD.Int8x16.extractLane(a, 11) & SIMD.Int8x16.extractLane(b, 11),
+        SIMD.Int8x16.extractLane(a, 12) & SIMD.Int8x16.extractLane(b, 12),
+        SIMD.Int8x16.extractLane(a, 13) & SIMD.Int8x16.extractLane(b, 13),
+        SIMD.Int8x16.extractLane(a, 14) & SIMD.Int8x16.extractLane(b, 14),
+        SIMD.Int8x16.extractLane(a, 15) & SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.or === "undefined") {
+if (typeof SIMD.Int8x16.or === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a | b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a | b.
     */
-  SIMD.int8x16.or = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLane(a, 0) | SIMD.int8x16.extractLane(b, 0),
-        SIMD.int8x16.extractLane(a, 1) | SIMD.int8x16.extractLane(b, 1),
-        SIMD.int8x16.extractLane(a, 2) | SIMD.int8x16.extractLane(b, 2),
-        SIMD.int8x16.extractLane(a, 3) | SIMD.int8x16.extractLane(b, 3),
-        SIMD.int8x16.extractLane(a, 4) | SIMD.int8x16.extractLane(b, 4),
-        SIMD.int8x16.extractLane(a, 5) | SIMD.int8x16.extractLane(b, 5),
-        SIMD.int8x16.extractLane(a, 6) | SIMD.int8x16.extractLane(b, 6),
-        SIMD.int8x16.extractLane(a, 7) | SIMD.int8x16.extractLane(b, 7),
-        SIMD.int8x16.extractLane(a, 8) | SIMD.int8x16.extractLane(b, 8),
-        SIMD.int8x16.extractLane(a, 9) | SIMD.int8x16.extractLane(b, 9),
-        SIMD.int8x16.extractLane(a, 10) | SIMD.int8x16.extractLane(b, 10),
-        SIMD.int8x16.extractLane(a, 11) | SIMD.int8x16.extractLane(b, 11),
-        SIMD.int8x16.extractLane(a, 12) | SIMD.int8x16.extractLane(b, 12),
-        SIMD.int8x16.extractLane(a, 13) | SIMD.int8x16.extractLane(b, 13),
-        SIMD.int8x16.extractLane(a, 14) | SIMD.int8x16.extractLane(b, 14),
-        SIMD.int8x16.extractLane(a, 15) | SIMD.int8x16.extractLane(b, 15));
+  SIMD.Int8x16.or = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLane(a, 0) | SIMD.Int8x16.extractLane(b, 0),
+        SIMD.Int8x16.extractLane(a, 1) | SIMD.Int8x16.extractLane(b, 1),
+        SIMD.Int8x16.extractLane(a, 2) | SIMD.Int8x16.extractLane(b, 2),
+        SIMD.Int8x16.extractLane(a, 3) | SIMD.Int8x16.extractLane(b, 3),
+        SIMD.Int8x16.extractLane(a, 4) | SIMD.Int8x16.extractLane(b, 4),
+        SIMD.Int8x16.extractLane(a, 5) | SIMD.Int8x16.extractLane(b, 5),
+        SIMD.Int8x16.extractLane(a, 6) | SIMD.Int8x16.extractLane(b, 6),
+        SIMD.Int8x16.extractLane(a, 7) | SIMD.Int8x16.extractLane(b, 7),
+        SIMD.Int8x16.extractLane(a, 8) | SIMD.Int8x16.extractLane(b, 8),
+        SIMD.Int8x16.extractLane(a, 9) | SIMD.Int8x16.extractLane(b, 9),
+        SIMD.Int8x16.extractLane(a, 10) | SIMD.Int8x16.extractLane(b, 10),
+        SIMD.Int8x16.extractLane(a, 11) | SIMD.Int8x16.extractLane(b, 11),
+        SIMD.Int8x16.extractLane(a, 12) | SIMD.Int8x16.extractLane(b, 12),
+        SIMD.Int8x16.extractLane(a, 13) | SIMD.Int8x16.extractLane(b, 13),
+        SIMD.Int8x16.extractLane(a, 14) | SIMD.Int8x16.extractLane(b, 14),
+        SIMD.Int8x16.extractLane(a, 15) | SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.xor === "undefined") {
+if (typeof SIMD.Int8x16.xor === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a ^ b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a ^ b.
     */
-  SIMD.int8x16.xor = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLane(a, 0) ^ SIMD.int8x16.extractLane(b, 0),
-        SIMD.int8x16.extractLane(a, 1) ^ SIMD.int8x16.extractLane(b, 1),
-        SIMD.int8x16.extractLane(a, 2) ^ SIMD.int8x16.extractLane(b, 2),
-        SIMD.int8x16.extractLane(a, 3) ^ SIMD.int8x16.extractLane(b, 3),
-        SIMD.int8x16.extractLane(a, 4) ^ SIMD.int8x16.extractLane(b, 4),
-        SIMD.int8x16.extractLane(a, 5) ^ SIMD.int8x16.extractLane(b, 5),
-        SIMD.int8x16.extractLane(a, 6) ^ SIMD.int8x16.extractLane(b, 6),
-        SIMD.int8x16.extractLane(a, 7) ^ SIMD.int8x16.extractLane(b, 7),
-        SIMD.int8x16.extractLane(a, 8) ^ SIMD.int8x16.extractLane(b, 8),
-        SIMD.int8x16.extractLane(a, 9) ^ SIMD.int8x16.extractLane(b, 9),
-        SIMD.int8x16.extractLane(a, 10) ^ SIMD.int8x16.extractLane(b, 10),
-        SIMD.int8x16.extractLane(a, 11) ^ SIMD.int8x16.extractLane(b, 11),
-        SIMD.int8x16.extractLane(a, 12) ^ SIMD.int8x16.extractLane(b, 12),
-        SIMD.int8x16.extractLane(a, 13) ^ SIMD.int8x16.extractLane(b, 13),
-        SIMD.int8x16.extractLane(a, 14) ^ SIMD.int8x16.extractLane(b, 14),
-        SIMD.int8x16.extractLane(a, 15) ^ SIMD.int8x16.extractLane(b, 15));
+  SIMD.Int8x16.xor = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLane(a, 0) ^ SIMD.Int8x16.extractLane(b, 0),
+        SIMD.Int8x16.extractLane(a, 1) ^ SIMD.Int8x16.extractLane(b, 1),
+        SIMD.Int8x16.extractLane(a, 2) ^ SIMD.Int8x16.extractLane(b, 2),
+        SIMD.Int8x16.extractLane(a, 3) ^ SIMD.Int8x16.extractLane(b, 3),
+        SIMD.Int8x16.extractLane(a, 4) ^ SIMD.Int8x16.extractLane(b, 4),
+        SIMD.Int8x16.extractLane(a, 5) ^ SIMD.Int8x16.extractLane(b, 5),
+        SIMD.Int8x16.extractLane(a, 6) ^ SIMD.Int8x16.extractLane(b, 6),
+        SIMD.Int8x16.extractLane(a, 7) ^ SIMD.Int8x16.extractLane(b, 7),
+        SIMD.Int8x16.extractLane(a, 8) ^ SIMD.Int8x16.extractLane(b, 8),
+        SIMD.Int8x16.extractLane(a, 9) ^ SIMD.Int8x16.extractLane(b, 9),
+        SIMD.Int8x16.extractLane(a, 10) ^ SIMD.Int8x16.extractLane(b, 10),
+        SIMD.Int8x16.extractLane(a, 11) ^ SIMD.Int8x16.extractLane(b, 11),
+        SIMD.Int8x16.extractLane(a, 12) ^ SIMD.Int8x16.extractLane(b, 12),
+        SIMD.Int8x16.extractLane(a, 13) ^ SIMD.Int8x16.extractLane(b, 13),
+        SIMD.Int8x16.extractLane(a, 14) ^ SIMD.Int8x16.extractLane(b, 14),
+        SIMD.Int8x16.extractLane(a, 15) ^ SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.not === "undefined") {
+if (typeof SIMD.Int8x16.not === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of ~t
+    * @param {Int8x16} t An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of ~t
     */
-  SIMD.int8x16.not = function(t) {
-    t = SIMD.int8x16.check(t);
-    return SIMD.int8x16(~SIMD.int8x16.extractLane(t, 0),
-                        ~SIMD.int8x16.extractLane(t, 1),
-                        ~SIMD.int8x16.extractLane(t, 2),
-                        ~SIMD.int8x16.extractLane(t, 3),
-                        ~SIMD.int8x16.extractLane(t, 4),
-                        ~SIMD.int8x16.extractLane(t, 5),
-                        ~SIMD.int8x16.extractLane(t, 6),
-                        ~SIMD.int8x16.extractLane(t, 7),
-                        ~SIMD.int8x16.extractLane(t, 8),
-                        ~SIMD.int8x16.extractLane(t, 9),
-                        ~SIMD.int8x16.extractLane(t, 10),
-                        ~SIMD.int8x16.extractLane(t, 11),
-                        ~SIMD.int8x16.extractLane(t, 12),
-                        ~SIMD.int8x16.extractLane(t, 13),
-                        ~SIMD.int8x16.extractLane(t, 14),
-                        ~SIMD.int8x16.extractLane(t, 15));
+  SIMD.Int8x16.not = function(t) {
+    t = SIMD.Int8x16.check(t);
+    return SIMD.Int8x16(~SIMD.Int8x16.extractLane(t, 0),
+                        ~SIMD.Int8x16.extractLane(t, 1),
+                        ~SIMD.Int8x16.extractLane(t, 2),
+                        ~SIMD.Int8x16.extractLane(t, 3),
+                        ~SIMD.Int8x16.extractLane(t, 4),
+                        ~SIMD.Int8x16.extractLane(t, 5),
+                        ~SIMD.Int8x16.extractLane(t, 6),
+                        ~SIMD.Int8x16.extractLane(t, 7),
+                        ~SIMD.Int8x16.extractLane(t, 8),
+                        ~SIMD.Int8x16.extractLane(t, 9),
+                        ~SIMD.Int8x16.extractLane(t, 10),
+                        ~SIMD.Int8x16.extractLane(t, 11),
+                        ~SIMD.Int8x16.extractLane(t, 12),
+                        ~SIMD.Int8x16.extractLane(t, 13),
+                        ~SIMD.Int8x16.extractLane(t, 14),
+                        ~SIMD.Int8x16.extractLane(t, 15));
   }
 }
 
-if (typeof SIMD.int8x16.neg === "undefined") {
+if (typeof SIMD.Int8x16.neg === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of -t
+    * @param {Int8x16} t An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of -t
     */
-  SIMD.int8x16.neg = function(t) {
-    t = SIMD.int8x16.check(t);
-    return SIMD.int8x16(-SIMD.int8x16.extractLane(t, 0),
-                        -SIMD.int8x16.extractLane(t, 1),
-                        -SIMD.int8x16.extractLane(t, 2),
-                        -SIMD.int8x16.extractLane(t, 3),
-                        -SIMD.int8x16.extractLane(t, 4),
-                        -SIMD.int8x16.extractLane(t, 5),
-                        -SIMD.int8x16.extractLane(t, 6),
-                        -SIMD.int8x16.extractLane(t, 7),
-                        -SIMD.int8x16.extractLane(t, 8),
-                        -SIMD.int8x16.extractLane(t, 9),
-                        -SIMD.int8x16.extractLane(t, 10),
-                        -SIMD.int8x16.extractLane(t, 11),
-                        -SIMD.int8x16.extractLane(t, 12),
-                        -SIMD.int8x16.extractLane(t, 13),
-                        -SIMD.int8x16.extractLane(t, 14),
-                        -SIMD.int8x16.extractLane(t, 15));
+  SIMD.Int8x16.neg = function(t) {
+    t = SIMD.Int8x16.check(t);
+    return SIMD.Int8x16(-SIMD.Int8x16.extractLane(t, 0),
+                        -SIMD.Int8x16.extractLane(t, 1),
+                        -SIMD.Int8x16.extractLane(t, 2),
+                        -SIMD.Int8x16.extractLane(t, 3),
+                        -SIMD.Int8x16.extractLane(t, 4),
+                        -SIMD.Int8x16.extractLane(t, 5),
+                        -SIMD.Int8x16.extractLane(t, 6),
+                        -SIMD.Int8x16.extractLane(t, 7),
+                        -SIMD.Int8x16.extractLane(t, 8),
+                        -SIMD.Int8x16.extractLane(t, 9),
+                        -SIMD.Int8x16.extractLane(t, 10),
+                        -SIMD.Int8x16.extractLane(t, 11),
+                        -SIMD.Int8x16.extractLane(t, 12),
+                        -SIMD.Int8x16.extractLane(t, 13),
+                        -SIMD.Int8x16.extractLane(t, 14),
+                        -SIMD.Int8x16.extractLane(t, 15));
   }
 }
 
-if (typeof SIMD.int8x16.add === "undefined") {
+if (typeof SIMD.Int8x16.add === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a + b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a + b.
     */
-  SIMD.int8x16.add = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLane(a, 0) + SIMD.int8x16.extractLane(b, 0),
-        SIMD.int8x16.extractLane(a, 1) + SIMD.int8x16.extractLane(b, 1),
-        SIMD.int8x16.extractLane(a, 2) + SIMD.int8x16.extractLane(b, 2),
-        SIMD.int8x16.extractLane(a, 3) + SIMD.int8x16.extractLane(b, 3),
-        SIMD.int8x16.extractLane(a, 4) + SIMD.int8x16.extractLane(b, 4),
-        SIMD.int8x16.extractLane(a, 5) + SIMD.int8x16.extractLane(b, 5),
-        SIMD.int8x16.extractLane(a, 6) + SIMD.int8x16.extractLane(b, 6),
-        SIMD.int8x16.extractLane(a, 7) + SIMD.int8x16.extractLane(b, 7),
-        SIMD.int8x16.extractLane(a, 8) + SIMD.int8x16.extractLane(b, 8),
-        SIMD.int8x16.extractLane(a, 9) + SIMD.int8x16.extractLane(b, 9),
-        SIMD.int8x16.extractLane(a, 10) + SIMD.int8x16.extractLane(b, 10),
-        SIMD.int8x16.extractLane(a, 11) + SIMD.int8x16.extractLane(b, 11),
-        SIMD.int8x16.extractLane(a, 12) + SIMD.int8x16.extractLane(b, 12),
-        SIMD.int8x16.extractLane(a, 13) + SIMD.int8x16.extractLane(b, 13),
-        SIMD.int8x16.extractLane(a, 14) + SIMD.int8x16.extractLane(b, 14),
-        SIMD.int8x16.extractLane(a, 15) + SIMD.int8x16.extractLane(b, 15));
+  SIMD.Int8x16.add = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLane(a, 0) + SIMD.Int8x16.extractLane(b, 0),
+        SIMD.Int8x16.extractLane(a, 1) + SIMD.Int8x16.extractLane(b, 1),
+        SIMD.Int8x16.extractLane(a, 2) + SIMD.Int8x16.extractLane(b, 2),
+        SIMD.Int8x16.extractLane(a, 3) + SIMD.Int8x16.extractLane(b, 3),
+        SIMD.Int8x16.extractLane(a, 4) + SIMD.Int8x16.extractLane(b, 4),
+        SIMD.Int8x16.extractLane(a, 5) + SIMD.Int8x16.extractLane(b, 5),
+        SIMD.Int8x16.extractLane(a, 6) + SIMD.Int8x16.extractLane(b, 6),
+        SIMD.Int8x16.extractLane(a, 7) + SIMD.Int8x16.extractLane(b, 7),
+        SIMD.Int8x16.extractLane(a, 8) + SIMD.Int8x16.extractLane(b, 8),
+        SIMD.Int8x16.extractLane(a, 9) + SIMD.Int8x16.extractLane(b, 9),
+        SIMD.Int8x16.extractLane(a, 10) + SIMD.Int8x16.extractLane(b, 10),
+        SIMD.Int8x16.extractLane(a, 11) + SIMD.Int8x16.extractLane(b, 11),
+        SIMD.Int8x16.extractLane(a, 12) + SIMD.Int8x16.extractLane(b, 12),
+        SIMD.Int8x16.extractLane(a, 13) + SIMD.Int8x16.extractLane(b, 13),
+        SIMD.Int8x16.extractLane(a, 14) + SIMD.Int8x16.extractLane(b, 14),
+        SIMD.Int8x16.extractLane(a, 15) + SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.sub === "undefined") {
+if (typeof SIMD.Int8x16.sub === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a - b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a - b.
     */
-  SIMD.int8x16.sub = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLane(a, 0) - SIMD.int8x16.extractLane(b, 0),
-        SIMD.int8x16.extractLane(a, 1) - SIMD.int8x16.extractLane(b, 1),
-        SIMD.int8x16.extractLane(a, 2) - SIMD.int8x16.extractLane(b, 2),
-        SIMD.int8x16.extractLane(a, 3) - SIMD.int8x16.extractLane(b, 3),
-        SIMD.int8x16.extractLane(a, 4) - SIMD.int8x16.extractLane(b, 4),
-        SIMD.int8x16.extractLane(a, 5) - SIMD.int8x16.extractLane(b, 5),
-        SIMD.int8x16.extractLane(a, 6) - SIMD.int8x16.extractLane(b, 6),
-        SIMD.int8x16.extractLane(a, 7) - SIMD.int8x16.extractLane(b, 7),
-        SIMD.int8x16.extractLane(a, 8) - SIMD.int8x16.extractLane(b, 8),
-        SIMD.int8x16.extractLane(a, 9) - SIMD.int8x16.extractLane(b, 9),
-        SIMD.int8x16.extractLane(a, 10) - SIMD.int8x16.extractLane(b, 10),
-        SIMD.int8x16.extractLane(a, 11) - SIMD.int8x16.extractLane(b, 11),
-        SIMD.int8x16.extractLane(a, 12) - SIMD.int8x16.extractLane(b, 12),
-        SIMD.int8x16.extractLane(a, 13) - SIMD.int8x16.extractLane(b, 13),
-        SIMD.int8x16.extractLane(a, 14) - SIMD.int8x16.extractLane(b, 14),
-        SIMD.int8x16.extractLane(a, 15) - SIMD.int8x16.extractLane(b, 15));
+  SIMD.Int8x16.sub = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLane(a, 0) - SIMD.Int8x16.extractLane(b, 0),
+        SIMD.Int8x16.extractLane(a, 1) - SIMD.Int8x16.extractLane(b, 1),
+        SIMD.Int8x16.extractLane(a, 2) - SIMD.Int8x16.extractLane(b, 2),
+        SIMD.Int8x16.extractLane(a, 3) - SIMD.Int8x16.extractLane(b, 3),
+        SIMD.Int8x16.extractLane(a, 4) - SIMD.Int8x16.extractLane(b, 4),
+        SIMD.Int8x16.extractLane(a, 5) - SIMD.Int8x16.extractLane(b, 5),
+        SIMD.Int8x16.extractLane(a, 6) - SIMD.Int8x16.extractLane(b, 6),
+        SIMD.Int8x16.extractLane(a, 7) - SIMD.Int8x16.extractLane(b, 7),
+        SIMD.Int8x16.extractLane(a, 8) - SIMD.Int8x16.extractLane(b, 8),
+        SIMD.Int8x16.extractLane(a, 9) - SIMD.Int8x16.extractLane(b, 9),
+        SIMD.Int8x16.extractLane(a, 10) - SIMD.Int8x16.extractLane(b, 10),
+        SIMD.Int8x16.extractLane(a, 11) - SIMD.Int8x16.extractLane(b, 11),
+        SIMD.Int8x16.extractLane(a, 12) - SIMD.Int8x16.extractLane(b, 12),
+        SIMD.Int8x16.extractLane(a, 13) - SIMD.Int8x16.extractLane(b, 13),
+        SIMD.Int8x16.extractLane(a, 14) - SIMD.Int8x16.extractLane(b, 14),
+        SIMD.Int8x16.extractLane(a, 15) - SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.mul === "undefined") {
+if (typeof SIMD.Int8x16.mul === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a * b.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a * b.
     */
-  SIMD.int8x16.mul = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    return SIMD.int8x16(Math.imul(SIMD.int8x16.extractLane(a, 0),
-                                  SIMD.int8x16.extractLane(b, 0)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 1),
-                                  SIMD.int8x16.extractLane(b, 1)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 2),
-                                  SIMD.int8x16.extractLane(b, 2)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 3),
-                                  SIMD.int8x16.extractLane(b, 3)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 4),
-                                  SIMD.int8x16.extractLane(b, 4)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 5),
-                                  SIMD.int8x16.extractLane(b, 5)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 6),
-                                  SIMD.int8x16.extractLane(b, 6)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 7),
-                                  SIMD.int8x16.extractLane(b, 7)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 8),
-                                  SIMD.int8x16.extractLane(b, 8)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 9),
-                                  SIMD.int8x16.extractLane(b, 9)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 10),
-                                  SIMD.int8x16.extractLane(b, 10)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 11),
-                                  SIMD.int8x16.extractLane(b, 11)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 12),
-                                  SIMD.int8x16.extractLane(b, 12)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 13),
-                                  SIMD.int8x16.extractLane(b, 13)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 14),
-                                  SIMD.int8x16.extractLane(b, 14)),
-                        Math.imul(SIMD.int8x16.extractLane(a, 15),
-                                  SIMD.int8x16.extractLane(b, 15)));
+  SIMD.Int8x16.mul = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int8x16(Math.imul(SIMD.Int8x16.extractLane(a, 0),
+                                  SIMD.Int8x16.extractLane(b, 0)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 1),
+                                  SIMD.Int8x16.extractLane(b, 1)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 2),
+                                  SIMD.Int8x16.extractLane(b, 2)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 3),
+                                  SIMD.Int8x16.extractLane(b, 3)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 4),
+                                  SIMD.Int8x16.extractLane(b, 4)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 5),
+                                  SIMD.Int8x16.extractLane(b, 5)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 6),
+                                  SIMD.Int8x16.extractLane(b, 6)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 7),
+                                  SIMD.Int8x16.extractLane(b, 7)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 8),
+                                  SIMD.Int8x16.extractLane(b, 8)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 9),
+                                  SIMD.Int8x16.extractLane(b, 9)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 10),
+                                  SIMD.Int8x16.extractLane(b, 10)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 11),
+                                  SIMD.Int8x16.extractLane(b, 11)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 12),
+                                  SIMD.Int8x16.extractLane(b, 12)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 13),
+                                  SIMD.Int8x16.extractLane(b, 13)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 14),
+                                  SIMD.Int8x16.extractLane(b, 14)),
+                        Math.imul(SIMD.Int8x16.extractLane(a, 15),
+                                  SIMD.Int8x16.extractLane(b, 15)));
   }
 }
 
-if (typeof SIMD.int8x16.swizzle === "undefined") {
+if (typeof SIMD.Int8x16.swizzle === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16 to be swizzled.
+    * @param {Int8x16} t An instance of Int8x16 to be swizzled.
     * @param {integer} s0 - Index in t for lane s0
     * @param {integer} s1 - Index in t for lane s1
     * @param {integer} s2 - Index in t for lane s2
@@ -4538,11 +4538,11 @@ if (typeof SIMD.int8x16.swizzle === "undefined") {
     * @param {integer} s13 - Index in t for lane s13
     * @param {integer} s14 - Index in t for lane s14
     * @param {integer} s15 - Index in t for lane s15
-    * @return {int8x16} New instance of int8x16 with lanes swizzled.
+    * @return {Int8x16} New instance of Int8x16 with lanes swizzled.
     */
-  SIMD.int8x16.swizzle = function(t, s0, s1, s2, s3, s4, s5, s6, s7,
+  SIMD.Int8x16.swizzle = function(t, s0, s1, s2, s3, s4, s5, s6, s7,
                                      s8, s9, s10, s11, s12, s13, s14, s15) {
-    t = SIMD.int8x16.check(t);
+    t = SIMD.Int8x16.check(t);
     check16(s0);
     check16(s1);
     check16(s2);
@@ -4560,36 +4560,36 @@ if (typeof SIMD.int8x16.swizzle === "undefined") {
     check16(s14);
     check16(s15);
     var storage = _i8x16;
-    storage[0] = SIMD.int8x16.extractLane(t, 0);
-    storage[1] = SIMD.int8x16.extractLane(t, 1);
-    storage[2] = SIMD.int8x16.extractLane(t, 2);
-    storage[3] = SIMD.int8x16.extractLane(t, 3);
-    storage[4] = SIMD.int8x16.extractLane(t, 4);
-    storage[5] = SIMD.int8x16.extractLane(t, 5);
-    storage[6] = SIMD.int8x16.extractLane(t, 6);
-    storage[7] = SIMD.int8x16.extractLane(t, 7);
-    storage[8] = SIMD.int8x16.extractLane(t, 8);
-    storage[9] = SIMD.int8x16.extractLane(t, 9);
-    storage[10] = SIMD.int8x16.extractLane(t, 10);
-    storage[11] = SIMD.int8x16.extractLane(t, 11);
-    storage[12] = SIMD.int8x16.extractLane(t, 12);
-    storage[13] = SIMD.int8x16.extractLane(t, 13);
-    storage[14] = SIMD.int8x16.extractLane(t, 14);
-    storage[15] = SIMD.int8x16.extractLane(t, 15);
-    return SIMD.int8x16(storage[s0], storage[s1], storage[s2], storage[s3],
+    storage[0] = SIMD.Int8x16.extractLane(t, 0);
+    storage[1] = SIMD.Int8x16.extractLane(t, 1);
+    storage[2] = SIMD.Int8x16.extractLane(t, 2);
+    storage[3] = SIMD.Int8x16.extractLane(t, 3);
+    storage[4] = SIMD.Int8x16.extractLane(t, 4);
+    storage[5] = SIMD.Int8x16.extractLane(t, 5);
+    storage[6] = SIMD.Int8x16.extractLane(t, 6);
+    storage[7] = SIMD.Int8x16.extractLane(t, 7);
+    storage[8] = SIMD.Int8x16.extractLane(t, 8);
+    storage[9] = SIMD.Int8x16.extractLane(t, 9);
+    storage[10] = SIMD.Int8x16.extractLane(t, 10);
+    storage[11] = SIMD.Int8x16.extractLane(t, 11);
+    storage[12] = SIMD.Int8x16.extractLane(t, 12);
+    storage[13] = SIMD.Int8x16.extractLane(t, 13);
+    storage[14] = SIMD.Int8x16.extractLane(t, 14);
+    storage[15] = SIMD.Int8x16.extractLane(t, 15);
+    return SIMD.Int8x16(storage[s0], storage[s1], storage[s2], storage[s3],
                         storage[s4], storage[s5], storage[s6], storage[s7],
                         storage[s8], storage[s9], storage[s10], storage[s11],
                         storage[s12], storage[s13], storage[s14], storage[s15]);
   }
 }
 
-if (typeof SIMD.int8x16.shuffle === "undefined") {
+if (typeof SIMD.Int8x16.shuffle === "undefined") {
 
   _i8x32 = new Int8Array(32);
 
   /**
-    * @param {int8x16} t0 An instance of int8x16 to be shuffled.
-    * @param {int8x16} t1 An instance of int8x16 to be shuffled.
+    * @param {Int8x16} t0 An instance of Int8x16 to be shuffled.
+    * @param {Int8x16} t1 An instance of Int8x16 to be shuffled.
     * @param {integer} s0 - Index in concatenation of t0 and t1 for lane s0
     * @param {integer} s1 - Index in concatenation of t0 and t1 for lane s1
     * @param {integer} s2 - Index in concatenation of t0 and t1 for lane s2
@@ -4606,12 +4606,12 @@ if (typeof SIMD.int8x16.shuffle === "undefined") {
     * @param {integer} s13 - Index in concatenation of t0 and t1 for lane s13
     * @param {integer} s14 - Index in concatenation of t0 and t1 for lane s14
     * @param {integer} s15 - Index in concatenation of t0 and t1 for lane s15
-    * @return {int8x16} New instance of int8x16 with lanes shuffled.
+    * @return {Int8x16} New instance of Int8x16 with lanes shuffled.
     */
-  SIMD.int8x16.shuffle = function(t0, t1, s0, s1, s2, s3, s4, s5, s6, s7,
+  SIMD.Int8x16.shuffle = function(t0, t1, s0, s1, s2, s3, s4, s5, s6, s7,
                                           s8, s9, s10, s11, s12, s13, s14, s15) {
-    t0 = SIMD.int8x16.check(t0);
-    t1 = SIMD.int8x16.check(t1);
+    t0 = SIMD.Int8x16.check(t0);
+    t1 = SIMD.Int8x16.check(t1);
     check32(s0);
     check32(s1);
     check32(s2);
@@ -4629,598 +4629,598 @@ if (typeof SIMD.int8x16.shuffle === "undefined") {
     check32(s14);
     check32(s15);
     var storage = _i8x32;
-    storage[0] = SIMD.int8x16.extractLane(t0, 0);
-    storage[1] = SIMD.int8x16.extractLane(t0, 1);
-    storage[2] = SIMD.int8x16.extractLane(t0, 2);
-    storage[3] = SIMD.int8x16.extractLane(t0, 3);
-    storage[4] = SIMD.int8x16.extractLane(t0, 4);
-    storage[5] = SIMD.int8x16.extractLane(t0, 5);
-    storage[6] = SIMD.int8x16.extractLane(t0, 6);
-    storage[7] = SIMD.int8x16.extractLane(t0, 7);
-    storage[8] = SIMD.int8x16.extractLane(t0, 8);
-    storage[9] = SIMD.int8x16.extractLane(t0, 9);
-    storage[10] = SIMD.int8x16.extractLane(t0, 10);
-    storage[11] = SIMD.int8x16.extractLane(t0, 11);
-    storage[12] = SIMD.int8x16.extractLane(t0, 12);
-    storage[13] = SIMD.int8x16.extractLane(t0, 13);
-    storage[14] = SIMD.int8x16.extractLane(t0, 14);
-    storage[15] = SIMD.int8x16.extractLane(t0, 15);
-    storage[16] = SIMD.int8x16.extractLane(t1, 0);
-    storage[17] = SIMD.int8x16.extractLane(t1, 1);
-    storage[18] = SIMD.int8x16.extractLane(t1, 2);
-    storage[19] = SIMD.int8x16.extractLane(t1, 3);
-    storage[20] = SIMD.int8x16.extractLane(t1, 4);
-    storage[21] = SIMD.int8x16.extractLane(t1, 5);
-    storage[22] = SIMD.int8x16.extractLane(t1, 6);
-    storage[23] = SIMD.int8x16.extractLane(t1, 7);
-    storage[24] = SIMD.int8x16.extractLane(t1, 8);
-    storage[25] = SIMD.int8x16.extractLane(t1, 9);
-    storage[26] = SIMD.int8x16.extractLane(t1, 10);
-    storage[27] = SIMD.int8x16.extractLane(t1, 11);
-    storage[28] = SIMD.int8x16.extractLane(t1, 12);
-    storage[29] = SIMD.int8x16.extractLane(t1, 13);
-    storage[30] = SIMD.int8x16.extractLane(t1, 14);
-    storage[31] = SIMD.int8x16.extractLane(t1, 15);
-    return SIMD.int8x16(storage[s0], storage[s1], storage[s2], storage[s3],
+    storage[0] = SIMD.Int8x16.extractLane(t0, 0);
+    storage[1] = SIMD.Int8x16.extractLane(t0, 1);
+    storage[2] = SIMD.Int8x16.extractLane(t0, 2);
+    storage[3] = SIMD.Int8x16.extractLane(t0, 3);
+    storage[4] = SIMD.Int8x16.extractLane(t0, 4);
+    storage[5] = SIMD.Int8x16.extractLane(t0, 5);
+    storage[6] = SIMD.Int8x16.extractLane(t0, 6);
+    storage[7] = SIMD.Int8x16.extractLane(t0, 7);
+    storage[8] = SIMD.Int8x16.extractLane(t0, 8);
+    storage[9] = SIMD.Int8x16.extractLane(t0, 9);
+    storage[10] = SIMD.Int8x16.extractLane(t0, 10);
+    storage[11] = SIMD.Int8x16.extractLane(t0, 11);
+    storage[12] = SIMD.Int8x16.extractLane(t0, 12);
+    storage[13] = SIMD.Int8x16.extractLane(t0, 13);
+    storage[14] = SIMD.Int8x16.extractLane(t0, 14);
+    storage[15] = SIMD.Int8x16.extractLane(t0, 15);
+    storage[16] = SIMD.Int8x16.extractLane(t1, 0);
+    storage[17] = SIMD.Int8x16.extractLane(t1, 1);
+    storage[18] = SIMD.Int8x16.extractLane(t1, 2);
+    storage[19] = SIMD.Int8x16.extractLane(t1, 3);
+    storage[20] = SIMD.Int8x16.extractLane(t1, 4);
+    storage[21] = SIMD.Int8x16.extractLane(t1, 5);
+    storage[22] = SIMD.Int8x16.extractLane(t1, 6);
+    storage[23] = SIMD.Int8x16.extractLane(t1, 7);
+    storage[24] = SIMD.Int8x16.extractLane(t1, 8);
+    storage[25] = SIMD.Int8x16.extractLane(t1, 9);
+    storage[26] = SIMD.Int8x16.extractLane(t1, 10);
+    storage[27] = SIMD.Int8x16.extractLane(t1, 11);
+    storage[28] = SIMD.Int8x16.extractLane(t1, 12);
+    storage[29] = SIMD.Int8x16.extractLane(t1, 13);
+    storage[30] = SIMD.Int8x16.extractLane(t1, 14);
+    storage[31] = SIMD.Int8x16.extractLane(t1, 15);
+    return SIMD.Int8x16(storage[s0], storage[s1], storage[s2], storage[s3],
                         storage[s4], storage[s5], storage[s6], storage[s7],
                         storage[s8], storage[s9], storage[s10], storage[s11],
                         storage[s12], storage[s13], storage[s14], storage[s15]);
   }
 }
 
-if (typeof SIMD.int8x16.addSaturate === "undefined") {
+if (typeof SIMD.Int8x16.addSaturate === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a + b with
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a + b with
     * signed saturating behavior on overflow.
     */
-  SIMD.int8x16.addSaturate = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    var c = SIMD.int8x16.add(a, b);
-    var max = SIMD.int8x16.splat(0x7f);
-    var min = SIMD.int8x16.splat(0x80);
-    var mask = SIMD.int8x16.lessThan(c, a);
-    return SIMD.int8x16.select(SIMD.int8x16.and(mask, SIMD.int8x16.not(b)), max,
-             SIMD.int8x16.select(SIMD.int8x16.and(SIMD.int8x16.not(mask), b), min,
+  SIMD.Int8x16.addSaturate = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    var c = SIMD.Int8x16.add(a, b);
+    var max = SIMD.Int8x16.splat(0x7f);
+    var min = SIMD.Int8x16.splat(0x80);
+    var mask = SIMD.Int8x16.lessThan(c, a);
+    return SIMD.Int8x16.select(SIMD.Int8x16.and(mask, SIMD.Int8x16.not(b)), max,
+             SIMD.Int8x16.select(SIMD.Int8x16.and(SIMD.Int8x16.not(mask), b), min,
                c));
   }
 }
 
-if (typeof SIMD.int8x16.subSaturate === "undefined") {
+if (typeof SIMD.Int8x16.subSaturate === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
-    * @return {int8x16} New instance of int8x16 with values of a - b with
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a - b with
     * signed saturating behavior on overflow.
     */
-  SIMD.int8x16.subSaturate = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
-    var c = SIMD.int8x16.sub(a, b);
-    var max = SIMD.int8x16.splat(0x7f);
-    var min = SIMD.int8x16.splat(0x80);
-    var mask = SIMD.int8x16.greaterThan(c, a);
-    return SIMD.int8x16.select(SIMD.int8x16.and(mask, SIMD.int8x16.not(b)), min,
-             SIMD.int8x16.select(SIMD.int8x16.and(SIMD.int8x16.not(mask), b), max,
+  SIMD.Int8x16.subSaturate = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    var c = SIMD.Int8x16.sub(a, b);
+    var max = SIMD.Int8x16.splat(0x7f);
+    var min = SIMD.Int8x16.splat(0x80);
+    var mask = SIMD.Int8x16.greaterThan(c, a);
+    return SIMD.Int8x16.select(SIMD.Int8x16.and(mask, SIMD.Int8x16.not(b)), min,
+             SIMD.Int8x16.select(SIMD.Int8x16.and(SIMD.Int8x16.not(mask), b), max,
                c));
   }
 }
 
-if (typeof SIMD.int8x16.sumOfAbsoluteDifferences === "undefined") {
+if (typeof SIMD.Int8x16.sumOfAbsoluteDifferences === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
-    * @param {int8x16} b An instance of int8x16.
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
     * @return {Number} The sum of the absolute differences (SAD) of the
     * corresponding elements of a and b.
     */
-  SIMD.int8x16.sumOfAbsoluteDifferences = function(a, b) {
-    a = SIMD.int8x16.check(a);
-    b = SIMD.int8x16.check(b);
+  SIMD.Int8x16.sumOfAbsoluteDifferences = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
     return Math.abs(
-        SIMD.int8x16.extractLane(a, 0) - SIMD.int8x16.extractLane(b, 0)) +
+        SIMD.Int8x16.extractLane(a, 0) - SIMD.Int8x16.extractLane(b, 0)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 1) - SIMD.int8x16.extractLane(b, 1)) +
+            SIMD.Int8x16.extractLane(a, 1) - SIMD.Int8x16.extractLane(b, 1)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 2) - SIMD.int8x16.extractLane(b, 2)) +
+            SIMD.Int8x16.extractLane(a, 2) - SIMD.Int8x16.extractLane(b, 2)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 3) - SIMD.int8x16.extractLane(b, 3)) +
+            SIMD.Int8x16.extractLane(a, 3) - SIMD.Int8x16.extractLane(b, 3)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 4) - SIMD.int8x16.extractLane(b, 4)) +
+            SIMD.Int8x16.extractLane(a, 4) - SIMD.Int8x16.extractLane(b, 4)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 5) - SIMD.int8x16.extractLane(b, 5)) +
+            SIMD.Int8x16.extractLane(a, 5) - SIMD.Int8x16.extractLane(b, 5)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 6) - SIMD.int8x16.extractLane(b, 6)) +
+            SIMD.Int8x16.extractLane(a, 6) - SIMD.Int8x16.extractLane(b, 6)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 7) - SIMD.int8x16.extractLane(b, 7)) +
+            SIMD.Int8x16.extractLane(a, 7) - SIMD.Int8x16.extractLane(b, 7)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 8) - SIMD.int8x16.extractLane(b, 8)) +
+            SIMD.Int8x16.extractLane(a, 8) - SIMD.Int8x16.extractLane(b, 8)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 9) - SIMD.int8x16.extractLane(b, 9)) +
+            SIMD.Int8x16.extractLane(a, 9) - SIMD.Int8x16.extractLane(b, 9)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 10) - SIMD.int8x16.extractLane(b, 10)) +
+            SIMD.Int8x16.extractLane(a, 10) - SIMD.Int8x16.extractLane(b, 10)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 11) - SIMD.int8x16.extractLane(b, 11)) +
+            SIMD.Int8x16.extractLane(a, 11) - SIMD.Int8x16.extractLane(b, 11)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 12) - SIMD.int8x16.extractLane(b, 12)) +
+            SIMD.Int8x16.extractLane(a, 12) - SIMD.Int8x16.extractLane(b, 12)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 13) - SIMD.int8x16.extractLane(b, 13)) +
+            SIMD.Int8x16.extractLane(a, 13) - SIMD.Int8x16.extractLane(b, 13)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 14) - SIMD.int8x16.extractLane(b, 14)) +
+            SIMD.Int8x16.extractLane(a, 14) - SIMD.Int8x16.extractLane(b, 14)) +
         Math.abs(
-            SIMD.int8x16.extractLane(a, 15) - SIMD.int8x16.extractLane(b, 15));
+            SIMD.Int8x16.extractLane(a, 15) - SIMD.Int8x16.extractLane(b, 15));
   }
 }
 
-if (typeof SIMD.int8x16.select === "undefined") {
+if (typeof SIMD.Int8x16.select === "undefined") {
   /**
-    * @param {int8x16} t Selector mask. An instance of int8x16
-    * @param {int8x16} trueValue Pick lane from here if corresponding
+    * @param {Int8x16} t Selector mask. An instance of Int8x16
+    * @param {Int8x16} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {int8x16} falseValue Pick lane from here if corresponding
+    * @param {Int8x16} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {int8x16} Mix of lanes from trueValue or falseValue as
+    * @return {Int8x16} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int8x16.select = function(t, trueValue, falseValue) {
-    t = SIMD.int8x16.check(t);
-    trueValue = SIMD.int8x16.check(trueValue);
-    falseValue = SIMD.int8x16.check(falseValue);
-    return SIMD.int8x16(
-        SIMD.int8x16.extractLaneAsBool(t, 0) ?
-            SIMD.int8x16.extractLane(trueValue, 0) :
-                SIMD.int8x16.extractLane(falseValue, 0),
-        SIMD.int8x16.extractLaneAsBool(t, 1) ?
-            SIMD.int8x16.extractLane(trueValue, 1) :
-                SIMD.int8x16.extractLane(falseValue, 1),
-        SIMD.int8x16.extractLaneAsBool(t, 2) ?
-            SIMD.int8x16.extractLane(trueValue, 2) :
-                SIMD.int8x16.extractLane(falseValue, 2),
-        SIMD.int8x16.extractLaneAsBool(t, 3) ?
-            SIMD.int8x16.extractLane(trueValue, 3) :
-                SIMD.int8x16.extractLane(falseValue, 3),
-        SIMD.int8x16.extractLaneAsBool(t, 4) ?
-            SIMD.int8x16.extractLane(trueValue, 4) :
-                SIMD.int8x16.extractLane(falseValue, 4),
-        SIMD.int8x16.extractLaneAsBool(t, 5) ?
-            SIMD.int8x16.extractLane(trueValue, 5) :
-                SIMD.int8x16.extractLane(falseValue, 5),
-        SIMD.int8x16.extractLaneAsBool(t, 6) ?
-            SIMD.int8x16.extractLane(trueValue, 6) :
-                SIMD.int8x16.extractLane(falseValue, 6),
-        SIMD.int8x16.extractLaneAsBool(t, 7) ?
-            SIMD.int8x16.extractLane(trueValue, 7) :
-                SIMD.int8x16.extractLane(falseValue, 7),
-        SIMD.int8x16.extractLaneAsBool(t, 8) ?
-            SIMD.int8x16.extractLane(trueValue, 8) :
-                SIMD.int8x16.extractLane(falseValue, 8),
-        SIMD.int8x16.extractLaneAsBool(t, 9) ?
-            SIMD.int8x16.extractLane(trueValue, 9) :
-                SIMD.int8x16.extractLane(falseValue, 9),
-        SIMD.int8x16.extractLaneAsBool(t, 10) ?
-            SIMD.int8x16.extractLane(trueValue, 10) :
-                SIMD.int8x16.extractLane(falseValue, 10),
-        SIMD.int8x16.extractLaneAsBool(t, 11) ?
-            SIMD.int8x16.extractLane(trueValue, 11) :
-                SIMD.int8x16.extractLane(falseValue, 11),
-        SIMD.int8x16.extractLaneAsBool(t, 12) ?
-            SIMD.int8x16.extractLane(trueValue, 12) :
-                SIMD.int8x16.extractLane(falseValue, 12),
-        SIMD.int8x16.extractLaneAsBool(t, 13) ?
-            SIMD.int8x16.extractLane(trueValue, 13) :
-                SIMD.int8x16.extractLane(falseValue, 13),
-        SIMD.int8x16.extractLaneAsBool(t, 14) ?
-            SIMD.int8x16.extractLane(trueValue, 14) :
-                SIMD.int8x16.extractLane(falseValue, 14),
-        SIMD.int8x16.extractLaneAsBool(t, 15) ?
-            SIMD.int8x16.extractLane(trueValue, 15) :
-                SIMD.int8x16.extractLane(falseValue, 15));
+  SIMD.Int8x16.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int8x16.check(t);
+    trueValue = SIMD.Int8x16.check(trueValue);
+    falseValue = SIMD.Int8x16.check(falseValue);
+    return SIMD.Int8x16(
+        SIMD.Int8x16.extractLaneAsBool(t, 0) ?
+            SIMD.Int8x16.extractLane(trueValue, 0) :
+                SIMD.Int8x16.extractLane(falseValue, 0),
+        SIMD.Int8x16.extractLaneAsBool(t, 1) ?
+            SIMD.Int8x16.extractLane(trueValue, 1) :
+                SIMD.Int8x16.extractLane(falseValue, 1),
+        SIMD.Int8x16.extractLaneAsBool(t, 2) ?
+            SIMD.Int8x16.extractLane(trueValue, 2) :
+                SIMD.Int8x16.extractLane(falseValue, 2),
+        SIMD.Int8x16.extractLaneAsBool(t, 3) ?
+            SIMD.Int8x16.extractLane(trueValue, 3) :
+                SIMD.Int8x16.extractLane(falseValue, 3),
+        SIMD.Int8x16.extractLaneAsBool(t, 4) ?
+            SIMD.Int8x16.extractLane(trueValue, 4) :
+                SIMD.Int8x16.extractLane(falseValue, 4),
+        SIMD.Int8x16.extractLaneAsBool(t, 5) ?
+            SIMD.Int8x16.extractLane(trueValue, 5) :
+                SIMD.Int8x16.extractLane(falseValue, 5),
+        SIMD.Int8x16.extractLaneAsBool(t, 6) ?
+            SIMD.Int8x16.extractLane(trueValue, 6) :
+                SIMD.Int8x16.extractLane(falseValue, 6),
+        SIMD.Int8x16.extractLaneAsBool(t, 7) ?
+            SIMD.Int8x16.extractLane(trueValue, 7) :
+                SIMD.Int8x16.extractLane(falseValue, 7),
+        SIMD.Int8x16.extractLaneAsBool(t, 8) ?
+            SIMD.Int8x16.extractLane(trueValue, 8) :
+                SIMD.Int8x16.extractLane(falseValue, 8),
+        SIMD.Int8x16.extractLaneAsBool(t, 9) ?
+            SIMD.Int8x16.extractLane(trueValue, 9) :
+                SIMD.Int8x16.extractLane(falseValue, 9),
+        SIMD.Int8x16.extractLaneAsBool(t, 10) ?
+            SIMD.Int8x16.extractLane(trueValue, 10) :
+                SIMD.Int8x16.extractLane(falseValue, 10),
+        SIMD.Int8x16.extractLaneAsBool(t, 11) ?
+            SIMD.Int8x16.extractLane(trueValue, 11) :
+                SIMD.Int8x16.extractLane(falseValue, 11),
+        SIMD.Int8x16.extractLaneAsBool(t, 12) ?
+            SIMD.Int8x16.extractLane(trueValue, 12) :
+                SIMD.Int8x16.extractLane(falseValue, 12),
+        SIMD.Int8x16.extractLaneAsBool(t, 13) ?
+            SIMD.Int8x16.extractLane(trueValue, 13) :
+                SIMD.Int8x16.extractLane(falseValue, 13),
+        SIMD.Int8x16.extractLaneAsBool(t, 14) ?
+            SIMD.Int8x16.extractLane(trueValue, 14) :
+                SIMD.Int8x16.extractLane(falseValue, 14),
+        SIMD.Int8x16.extractLaneAsBool(t, 15) ?
+            SIMD.Int8x16.extractLane(trueValue, 15) :
+                SIMD.Int8x16.extractLane(falseValue, 15));
   }
 }
 
-if (typeof SIMD.int8x16.selectBits === "undefined") {
+if (typeof SIMD.Int8x16.selectBits === "undefined") {
   /**
-    * @param {int8x16} t Selector mask. An instance of int8x16
-    * @param {int8x16} trueValue Pick lane from here if corresponding
+    * @param {Int8x16} t Selector mask. An instance of Int8x16
+    * @param {Int8x16} trueValue Pick lane from here if corresponding
     * selector bit is 1
-    * @param {int8x16} falseValue Pick lane from here if corresponding
+    * @param {Int8x16} falseValue Pick lane from here if corresponding
     * selector bit is 0
-    * @return {int8x16} Mix of lanes from trueValue or falseValue as
+    * @return {Int8x16} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int8x16.selectBits = function(t, trueValue, falseValue) {
-    t = SIMD.int8x16.check(t);
-    trueValue = SIMD.int8x16.check(trueValue);
-    falseValue = SIMD.int8x16.check(falseValue);
-    var tr = SIMD.int8x16.and(t, trueValue);
-    var fr = SIMD.int8x16.and(SIMD.int8x16.not(t), falseValue);
-    return SIMD.int8x16.or(tr, fr);
+  SIMD.Int8x16.selectBits = function(t, trueValue, falseValue) {
+    t = SIMD.Int8x16.check(t);
+    trueValue = SIMD.Int8x16.check(trueValue);
+    falseValue = SIMD.Int8x16.check(falseValue);
+    var tr = SIMD.Int8x16.and(t, trueValue);
+    var fr = SIMD.Int8x16.and(SIMD.Int8x16.not(t), falseValue);
+    return SIMD.Int8x16.or(tr, fr);
   }
 }
 
-if (typeof SIMD.int8x16.equal === "undefined") {
+if (typeof SIMD.Int8x16.equal === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.int8x16.equal = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.equal = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) == SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) == SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) == SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) == SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) == SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) == SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) == SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) == SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) == SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) == SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) == SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) == SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) == SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) == SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) == SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) == SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) == SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) == SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) == SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) == SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) == SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) == SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) == SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) == SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) == SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) == SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) == SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) == SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) == SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) == SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) == SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) == SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.notEqual === "undefined") {
+if (typeof SIMD.Int8x16.notEqual === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.int8x16.notEqual = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.notEqual = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) != SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) != SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) != SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) != SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) != SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) != SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) != SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) != SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) != SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) != SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) != SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) != SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) != SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) != SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) != SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) != SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) != SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) != SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) != SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) != SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) != SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) != SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) != SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) != SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) != SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) != SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) != SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) != SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) != SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) != SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) != SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) != SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.greaterThan === "undefined") {
+if (typeof SIMD.Int8x16.greaterThan === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.int8x16.greaterThan = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.greaterThan = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) > SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) > SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) > SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) > SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) > SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) > SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) > SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) > SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) > SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) > SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) > SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) > SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) > SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) > SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) > SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) > SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) > SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) > SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) > SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) > SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) > SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) > SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) > SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) > SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) > SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) > SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) > SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) > SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) > SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) > SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) > SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) > SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Int8x16.greaterThanOrEqual === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.int8x16.greaterThanOrEqual = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) >= SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) >= SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) >= SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) >= SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) >= SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) >= SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) >= SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) >= SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) >= SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) >= SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) >= SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) >= SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) >= SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) >= SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) >= SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) >= SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) >= SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) >= SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) >= SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) >= SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) >= SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) >= SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) >= SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) >= SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) >= SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) >= SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) >= SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) >= SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) >= SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) >= SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) >= SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) >= SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.lessThan === "undefined") {
+if (typeof SIMD.Int8x16.lessThan === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.int8x16.lessThan = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.lessThan = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) < SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) < SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) < SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) < SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) < SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) < SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) < SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) < SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) < SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) < SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) < SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) < SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) < SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) < SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) < SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) < SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) < SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) < SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) < SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) < SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) < SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) < SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) < SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) < SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) < SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) < SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) < SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) < SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) < SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) < SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) < SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) < SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Int8x16.lessThanOrEqual === "undefined") {
   /**
-    * @param {int8x16} t An instance of int8x16.
-    * @param {int8x16} other An instance of int8x16.
-    * @return {int8x16} true or false in each lane depending on
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Int8x16} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.int8x16.lessThanOrEqual = function(t, other) {
-    t = SIMD.int8x16.check(t);
-    other = SIMD.int8x16.check(other);
+  SIMD.Int8x16.lessThanOrEqual = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
     var cs0 =
-        SIMD.int8x16.extractLane(t, 0) <= SIMD.int8x16.extractLane(other, 0);
+        SIMD.Int8x16.extractLane(t, 0) <= SIMD.Int8x16.extractLane(other, 0);
     var cs1 =
-        SIMD.int8x16.extractLane(t, 1) <= SIMD.int8x16.extractLane(other, 1);
+        SIMD.Int8x16.extractLane(t, 1) <= SIMD.Int8x16.extractLane(other, 1);
     var cs2 =
-        SIMD.int8x16.extractLane(t, 2) <= SIMD.int8x16.extractLane(other, 2);
+        SIMD.Int8x16.extractLane(t, 2) <= SIMD.Int8x16.extractLane(other, 2);
     var cs3 =
-        SIMD.int8x16.extractLane(t, 3) <= SIMD.int8x16.extractLane(other, 3);
+        SIMD.Int8x16.extractLane(t, 3) <= SIMD.Int8x16.extractLane(other, 3);
     var cs4 =
-        SIMD.int8x16.extractLane(t, 4) <= SIMD.int8x16.extractLane(other, 4);
+        SIMD.Int8x16.extractLane(t, 4) <= SIMD.Int8x16.extractLane(other, 4);
     var cs5 =
-        SIMD.int8x16.extractLane(t, 5) <= SIMD.int8x16.extractLane(other, 5);
+        SIMD.Int8x16.extractLane(t, 5) <= SIMD.Int8x16.extractLane(other, 5);
     var cs6 =
-        SIMD.int8x16.extractLane(t, 6) <= SIMD.int8x16.extractLane(other, 6);
+        SIMD.Int8x16.extractLane(t, 6) <= SIMD.Int8x16.extractLane(other, 6);
     var cs7 =
-        SIMD.int8x16.extractLane(t, 7) <= SIMD.int8x16.extractLane(other, 7);
+        SIMD.Int8x16.extractLane(t, 7) <= SIMD.Int8x16.extractLane(other, 7);
     var cs8 =
-        SIMD.int8x16.extractLane(t, 8) <= SIMD.int8x16.extractLane(other, 8);
+        SIMD.Int8x16.extractLane(t, 8) <= SIMD.Int8x16.extractLane(other, 8);
     var cs9 =
-        SIMD.int8x16.extractLane(t, 9) <= SIMD.int8x16.extractLane(other, 9);
+        SIMD.Int8x16.extractLane(t, 9) <= SIMD.Int8x16.extractLane(other, 9);
     var cs10 =
-        SIMD.int8x16.extractLane(t, 10) <= SIMD.int8x16.extractLane(other, 10);
+        SIMD.Int8x16.extractLane(t, 10) <= SIMD.Int8x16.extractLane(other, 10);
     var cs11 =
-        SIMD.int8x16.extractLane(t, 11) <= SIMD.int8x16.extractLane(other, 11);
+        SIMD.Int8x16.extractLane(t, 11) <= SIMD.Int8x16.extractLane(other, 11);
     var cs12 =
-        SIMD.int8x16.extractLane(t, 12) <= SIMD.int8x16.extractLane(other, 12);
+        SIMD.Int8x16.extractLane(t, 12) <= SIMD.Int8x16.extractLane(other, 12);
     var cs13 =
-        SIMD.int8x16.extractLane(t, 13) <= SIMD.int8x16.extractLane(other, 13);
+        SIMD.Int8x16.extractLane(t, 13) <= SIMD.Int8x16.extractLane(other, 13);
     var cs14 =
-        SIMD.int8x16.extractLane(t, 14) <= SIMD.int8x16.extractLane(other, 14);
+        SIMD.Int8x16.extractLane(t, 14) <= SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
-        SIMD.int8x16.extractLane(t, 15) <= SIMD.int8x16.extractLane(other, 15);
-    return SIMD.int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+        SIMD.Int8x16.extractLane(t, 15) <= SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Int8x16.bool(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                              cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
 }
 
-if (typeof SIMD.int8x16.shiftLeftByScalar === "undefined") {
+if (typeof SIMD.Int8x16.shiftLeftByScalar === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
+    * @param {Int8x16} a An instance of Int8x16.
     * @param {integer} bits Bit count to shift by.
-    * @return {int8x16} lanes in a shifted by bits.
+    * @return {Int8x16} lanes in a shifted by bits.
     */
-  SIMD.int8x16.shiftLeftByScalar = function(a, bits) {
-    a = SIMD.int8x16.check(a);
+  SIMD.Int8x16.shiftLeftByScalar = function(a, bits) {
+    a = SIMD.Int8x16.check(a);
     if (bits>>>0 > 8)
       bits = 8;
-    var s0 = SIMD.int8x16.extractLane(a, 0) << bits;
-    var s1 = SIMD.int8x16.extractLane(a, 1) << bits;
-    var s2 = SIMD.int8x16.extractLane(a, 2) << bits;
-    var s3 = SIMD.int8x16.extractLane(a, 3) << bits;
-    var s4 = SIMD.int8x16.extractLane(a, 4) << bits;
-    var s5 = SIMD.int8x16.extractLane(a, 5) << bits;
-    var s6 = SIMD.int8x16.extractLane(a, 6) << bits;
-    var s7 = SIMD.int8x16.extractLane(a, 7) << bits;
-    var s8 = SIMD.int8x16.extractLane(a, 8) << bits;
-    var s9 = SIMD.int8x16.extractLane(a, 9) << bits;
-    var s10 = SIMD.int8x16.extractLane(a, 10) << bits;
-    var s11 = SIMD.int8x16.extractLane(a, 11) << bits;
-    var s12 = SIMD.int8x16.extractLane(a, 12) << bits;
-    var s13 = SIMD.int8x16.extractLane(a, 13) << bits;
-    var s14 = SIMD.int8x16.extractLane(a, 14) << bits;
-    var s15 = SIMD.int8x16.extractLane(a, 15) << bits;
-    return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+    var s0 = SIMD.Int8x16.extractLane(a, 0) << bits;
+    var s1 = SIMD.Int8x16.extractLane(a, 1) << bits;
+    var s2 = SIMD.Int8x16.extractLane(a, 2) << bits;
+    var s3 = SIMD.Int8x16.extractLane(a, 3) << bits;
+    var s4 = SIMD.Int8x16.extractLane(a, 4) << bits;
+    var s5 = SIMD.Int8x16.extractLane(a, 5) << bits;
+    var s6 = SIMD.Int8x16.extractLane(a, 6) << bits;
+    var s7 = SIMD.Int8x16.extractLane(a, 7) << bits;
+    var s8 = SIMD.Int8x16.extractLane(a, 8) << bits;
+    var s9 = SIMD.Int8x16.extractLane(a, 9) << bits;
+    var s10 = SIMD.Int8x16.extractLane(a, 10) << bits;
+    var s11 = SIMD.Int8x16.extractLane(a, 11) << bits;
+    var s12 = SIMD.Int8x16.extractLane(a, 12) << bits;
+    var s13 = SIMD.Int8x16.extractLane(a, 13) << bits;
+    var s14 = SIMD.Int8x16.extractLane(a, 14) << bits;
+    var s15 = SIMD.Int8x16.extractLane(a, 15) << bits;
+    return SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
                         s8, s9, s10, s11, s12, s13, s14, s15);
   }
 }
 
-if (typeof SIMD.int8x16.shiftRightLogicalByScalar === "undefined") {
+if (typeof SIMD.Int8x16.shiftRightLogicalByScalar === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
+    * @param {Int8x16} a An instance of Int8x16.
     * @param {integer} bits Bit count to shift by.
-    * @return {int8x16} lanes in a shifted by bits.
+    * @return {Int8x16} lanes in a shifted by bits.
     */
-  SIMD.int8x16.shiftRightLogicalByScalar = function(a, bits) {
-    a = SIMD.int8x16.check(a);
+  SIMD.Int8x16.shiftRightLogicalByScalar = function(a, bits) {
+    a = SIMD.Int8x16.check(a);
     if (bits>>>0 > 8)
       bits = 8;
-    var s0 = (SIMD.int8x16.extractLane(a, 0) & 0xff) >>> bits;
-    var s1 = (SIMD.int8x16.extractLane(a, 1) & 0xff) >>> bits;
-    var s2 = (SIMD.int8x16.extractLane(a, 2) & 0xff) >>> bits;
-    var s3 = (SIMD.int8x16.extractLane(a, 3) & 0xff) >>> bits;
-    var s4 = (SIMD.int8x16.extractLane(a, 4) & 0xff) >>> bits;
-    var s5 = (SIMD.int8x16.extractLane(a, 5) & 0xff) >>> bits;
-    var s6 = (SIMD.int8x16.extractLane(a, 6) & 0xff) >>> bits;
-    var s7 = (SIMD.int8x16.extractLane(a, 7) & 0xff) >>> bits;
-    var s8 = (SIMD.int8x16.extractLane(a, 8) & 0xff) >>> bits;
-    var s9 = (SIMD.int8x16.extractLane(a, 9) & 0xff) >>> bits;
-    var s10 = (SIMD.int8x16.extractLane(a, 10) & 0xff) >>> bits;
-    var s11 = (SIMD.int8x16.extractLane(a, 11) & 0xff) >>> bits;
-    var s12 = (SIMD.int8x16.extractLane(a, 12) & 0xff) >>> bits;
-    var s13 = (SIMD.int8x16.extractLane(a, 13) & 0xff) >>> bits;
-    var s14 = (SIMD.int8x16.extractLane(a, 14) & 0xff) >>> bits;
-    var s15 = (SIMD.int8x16.extractLane(a, 15) & 0xff) >>> bits;
-    return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+    var s0 = (SIMD.Int8x16.extractLane(a, 0) & 0xff) >>> bits;
+    var s1 = (SIMD.Int8x16.extractLane(a, 1) & 0xff) >>> bits;
+    var s2 = (SIMD.Int8x16.extractLane(a, 2) & 0xff) >>> bits;
+    var s3 = (SIMD.Int8x16.extractLane(a, 3) & 0xff) >>> bits;
+    var s4 = (SIMD.Int8x16.extractLane(a, 4) & 0xff) >>> bits;
+    var s5 = (SIMD.Int8x16.extractLane(a, 5) & 0xff) >>> bits;
+    var s6 = (SIMD.Int8x16.extractLane(a, 6) & 0xff) >>> bits;
+    var s7 = (SIMD.Int8x16.extractLane(a, 7) & 0xff) >>> bits;
+    var s8 = (SIMD.Int8x16.extractLane(a, 8) & 0xff) >>> bits;
+    var s9 = (SIMD.Int8x16.extractLane(a, 9) & 0xff) >>> bits;
+    var s10 = (SIMD.Int8x16.extractLane(a, 10) & 0xff) >>> bits;
+    var s11 = (SIMD.Int8x16.extractLane(a, 11) & 0xff) >>> bits;
+    var s12 = (SIMD.Int8x16.extractLane(a, 12) & 0xff) >>> bits;
+    var s13 = (SIMD.Int8x16.extractLane(a, 13) & 0xff) >>> bits;
+    var s14 = (SIMD.Int8x16.extractLane(a, 14) & 0xff) >>> bits;
+    var s15 = (SIMD.Int8x16.extractLane(a, 15) & 0xff) >>> bits;
+    return SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
                         s8, s9, s10, s11, s12, s13, s14, s15);
   }
 }
 
-if (typeof SIMD.int8x16.shiftRightArithmeticByScalar === "undefined") {
+if (typeof SIMD.Int8x16.shiftRightArithmeticByScalar === "undefined") {
   /**
-    * @param {int8x16} a An instance of int8x16.
+    * @param {Int8x16} a An instance of Int8x16.
     * @param {integer} bits Bit count to shift by.
-    * @return {int8x16} lanes in a shifted by bits.
+    * @return {Int8x16} lanes in a shifted by bits.
     */
-  SIMD.int8x16.shiftRightArithmeticByScalar = function(a, bits) {
-    a = SIMD.int8x16.check(a);
+  SIMD.Int8x16.shiftRightArithmeticByScalar = function(a, bits) {
+    a = SIMD.Int8x16.check(a);
     if (bits>>>0 > 8)
       bits = 8;
-    var s0 = SIMD.int8x16.extractLane(a, 0) >> bits;
-    var s1 = SIMD.int8x16.extractLane(a, 1) >> bits;
-    var s2 = SIMD.int8x16.extractLane(a, 2) >> bits;
-    var s3 = SIMD.int8x16.extractLane(a, 3) >> bits;
-    var s4 = SIMD.int8x16.extractLane(a, 4) >> bits;
-    var s5 = SIMD.int8x16.extractLane(a, 5) >> bits;
-    var s6 = SIMD.int8x16.extractLane(a, 6) >> bits;
-    var s7 = SIMD.int8x16.extractLane(a, 7) >> bits;
-    var s8 = SIMD.int8x16.extractLane(a, 8) >> bits;
-    var s9 = SIMD.int8x16.extractLane(a, 9) >> bits;
-    var s10 = SIMD.int8x16.extractLane(a, 10) >> bits;
-    var s11 = SIMD.int8x16.extractLane(a, 11) >> bits;
-    var s12 = SIMD.int8x16.extractLane(a, 12) >> bits;
-    var s13 = SIMD.int8x16.extractLane(a, 13) >> bits;
-    var s14 = SIMD.int8x16.extractLane(a, 14) >> bits;
-    var s15 = SIMD.int8x16.extractLane(a, 15) >> bits;
-    return SIMD.int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
+    var s0 = SIMD.Int8x16.extractLane(a, 0) >> bits;
+    var s1 = SIMD.Int8x16.extractLane(a, 1) >> bits;
+    var s2 = SIMD.Int8x16.extractLane(a, 2) >> bits;
+    var s3 = SIMD.Int8x16.extractLane(a, 3) >> bits;
+    var s4 = SIMD.Int8x16.extractLane(a, 4) >> bits;
+    var s5 = SIMD.Int8x16.extractLane(a, 5) >> bits;
+    var s6 = SIMD.Int8x16.extractLane(a, 6) >> bits;
+    var s7 = SIMD.Int8x16.extractLane(a, 7) >> bits;
+    var s8 = SIMD.Int8x16.extractLane(a, 8) >> bits;
+    var s9 = SIMD.Int8x16.extractLane(a, 9) >> bits;
+    var s10 = SIMD.Int8x16.extractLane(a, 10) >> bits;
+    var s11 = SIMD.Int8x16.extractLane(a, 11) >> bits;
+    var s12 = SIMD.Int8x16.extractLane(a, 12) >> bits;
+    var s13 = SIMD.Int8x16.extractLane(a, 13) >> bits;
+    var s14 = SIMD.Int8x16.extractLane(a, 14) >> bits;
+    var s15 = SIMD.Int8x16.extractLane(a, 15) >> bits;
+    return SIMD.Int8x16(s0, s1, s2, s3, s4, s5, s6, s7,
                         s8, s9, s10, s11, s12, s13, s14, s15);
   }
 }
 
-if (typeof SIMD.int8x16.load === "undefined") {
+if (typeof SIMD.Int8x16.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int8x16} New instance of int8x16.
+    * @return {Int8x16} New instance of Int8x16.
     */
-  SIMD.int8x16.load = function(tarray, index) {
+  SIMD.Int8x16.load = function(tarray, index) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -5236,21 +5236,21 @@ if (typeof SIMD.int8x16.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.int8x16(i8temp[0], i8temp[1], i8temp[2], i8temp[3],
+    return SIMD.Int8x16(i8temp[0], i8temp[1], i8temp[2], i8temp[3],
                         i8temp[4], i8temp[5], i8temp[6], i8temp[7],
                         i8temp[8], i8temp[9], i8temp[10], i8temp[11],
                         i8temp[12], i8temp[13], i8temp[14], i8temp[15]);
   }
 }
 
-if (typeof SIMD.int8x16.store === "undefined") {
+if (typeof SIMD.Int8x16.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int8x16} value An instance of int8x16.
-    * @return {int8x16} value
+    * @param {Int8x16} value An instance of Int8x16.
+    * @return {Int8x16} value
     */
-  SIMD.int8x16.store = function(tarray, index, value) {
+  SIMD.Int8x16.store = function(tarray, index, value) {
     if (!isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!isInt32(index))
@@ -5258,23 +5258,23 @@ if (typeof SIMD.int8x16.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int8x16.check(value);
-    _i8x16[0] = SIMD.int8x16.extractLane(value, 0);
-    _i8x16[1] = SIMD.int8x16.extractLane(value, 1);
-    _i8x16[2] = SIMD.int8x16.extractLane(value, 2);
-    _i8x16[3] = SIMD.int8x16.extractLane(value, 3);
-    _i8x16[4] = SIMD.int8x16.extractLane(value, 4);
-    _i8x16[5] = SIMD.int8x16.extractLane(value, 5);
-    _i8x16[6] = SIMD.int8x16.extractLane(value, 6);
-    _i8x16[7] = SIMD.int8x16.extractLane(value, 7);
-    _i8x16[8] = SIMD.int8x16.extractLane(value, 8);
-    _i8x16[9] = SIMD.int8x16.extractLane(value, 9);
-    _i8x16[10] = SIMD.int8x16.extractLane(value, 10);
-    _i8x16[11] = SIMD.int8x16.extractLane(value, 11);
-    _i8x16[12] = SIMD.int8x16.extractLane(value, 12);
-    _i8x16[13] = SIMD.int8x16.extractLane(value, 13);
-    _i8x16[14] = SIMD.int8x16.extractLane(value, 14);
-    _i8x16[15] = SIMD.int8x16.extractLane(value, 15);
+    value = SIMD.Int8x16.check(value);
+    _i8x16[0] = SIMD.Int8x16.extractLane(value, 0);
+    _i8x16[1] = SIMD.Int8x16.extractLane(value, 1);
+    _i8x16[2] = SIMD.Int8x16.extractLane(value, 2);
+    _i8x16[3] = SIMD.Int8x16.extractLane(value, 3);
+    _i8x16[4] = SIMD.Int8x16.extractLane(value, 4);
+    _i8x16[5] = SIMD.Int8x16.extractLane(value, 5);
+    _i8x16[6] = SIMD.Int8x16.extractLane(value, 6);
+    _i8x16[7] = SIMD.Int8x16.extractLane(value, 7);
+    _i8x16[8] = SIMD.Int8x16.extractLane(value, 8);
+    _i8x16[9] = SIMD.Int8x16.extractLane(value, 9);
+    _i8x16[10] = SIMD.Int8x16.extractLane(value, 10);
+    _i8x16[11] = SIMD.Int8x16.extractLane(value, 11);
+    _i8x16[12] = SIMD.Int8x16.extractLane(value, 12);
+    _i8x16[13] = SIMD.Int8x16.extractLane(value, 13);
+    _i8x16[14] = SIMD.Int8x16.extractLane(value, 14);
+    _i8x16[15] = SIMD.Int8x16.extractLane(value, 15);
     var array = bpe == 1 ? _i8x16 :
                 bpe == 2 ? _i16x8 :
                 bpe == 4 ? (tarray instanceof Float32Array ? _f32x4 : _i32x4) :

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -38,648 +38,648 @@ function toBool(x) {
   return x < 0;
 }
 
-test('float32x4 operators', function() {
+test('Float32x4 operators', function() {
     // Not possible to implement properly in polyfill:
     //   ==, ===, !=, !==
-    throws(function() {Number(SIMD.float32x4(0, 1, 2, 3))});
-    throws(function() {+SIMD.float32x4(0, 1, 2, 3)});
-    throws(function() {-SIMD.float32x4(0, 1, 2, 3)});
-    throws(function() {~SIMD.float32x4(0, 1, 2, 3), -1});
-    throws(function() {Math.fround(SIMD.float32x4(0, 1, 2, 3))});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)|0});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)&0});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)^0});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)>>>0});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)>>0});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3)<<0});
-    throws(function() {(SIMD.float32x4(0, 1, 2, 3) + SIMD.float32x4(4, 5, 6, 7))});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) - SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) * SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) / SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) % SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) < SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) > SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) <= SIMD.float32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.float32x4(0, 1, 2, 3) >= SIMD.float32x4(4, 5, 6, 7)});
-    equal(SIMD.float32x4(0, 1, 2, 3).toString(), "float32x4(0, 1, 2, 3)");
-    equal(SIMD.float32x4(0, 1, 2, 3).toLocaleString(), "float32x4(0, 1, 2, 3)");
-    throws(function() { SIMD.float32x4(0, 1, 2, 3)(); });
-    equal(SIMD.float32x4(0, 1, 2, 3)[0], undefined);
-    equal(SIMD.float32x4(0, 1, 2, 3).a, undefined);
-    equal(!SIMD.float32x4(0, 1, 2, 3), false);
-    equal(!SIMD.float32x4(0, 0, 0, 0), false);
-    equal(SIMD.float32x4(0, 1, 2, 3) ? 1 : 2, 1);
-    equal(SIMD.float32x4(0, 0, 0, 0) ? 1 : 2, 1);
+    throws(function() {Number(SIMD.Float32x4(0, 1, 2, 3))});
+    throws(function() {+SIMD.Float32x4(0, 1, 2, 3)});
+    throws(function() {-SIMD.Float32x4(0, 1, 2, 3)});
+    throws(function() {~SIMD.Float32x4(0, 1, 2, 3), -1});
+    throws(function() {Math.fround(SIMD.Float32x4(0, 1, 2, 3))});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)|0});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)&0});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)^0});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)>>>0});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)>>0});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3)<<0});
+    throws(function() {(SIMD.Float32x4(0, 1, 2, 3) + SIMD.Float32x4(4, 5, 6, 7))});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) - SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) * SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) / SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) % SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) < SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) > SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) <= SIMD.Float32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Float32x4(0, 1, 2, 3) >= SIMD.Float32x4(4, 5, 6, 7)});
+    equal(SIMD.Float32x4(0, 1, 2, 3).toString(), "Float32x4(0, 1, 2, 3)");
+    equal(SIMD.Float32x4(0, 1, 2, 3).toLocaleString(), "Float32x4(0, 1, 2, 3)");
+    throws(function() { SIMD.Float32x4(0, 1, 2, 3)(); });
+    equal(SIMD.Float32x4(0, 1, 2, 3)[0], undefined);
+    equal(SIMD.Float32x4(0, 1, 2, 3).a, undefined);
+    equal(!SIMD.Float32x4(0, 1, 2, 3), false);
+    equal(!SIMD.Float32x4(0, 0, 0, 0), false);
+    equal(SIMD.Float32x4(0, 1, 2, 3) ? 1 : 2, 1);
+    equal(SIMD.Float32x4(0, 0, 0, 0) ? 1 : 2, 1);
 });
 
-test('int32x4 operators', function() {
+test('Int32x4 operators', function() {
     // Not possible to implement properly in polyfill:
     //   ==, ===, !=, !==
-    throws(function() {Number(SIMD.int32x4(0, 1, 2, 3))});
-    throws(function() {+SIMD.int32x4(0, 1, 2, 3)});
-    throws(function() {-SIMD.int32x4(0, 1, 2, 3)});
-    throws(function() {~SIMD.int32x4(0, 1, 2, 3), -1});
-    throws(function() {Math.fround(SIMD.int32x4(0, 1, 2, 3))});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)|0});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)&0});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)^0});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)>>>0});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)>>0});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3)<<0});
-    throws(function() {(SIMD.int32x4(0, 1, 2, 3) + SIMD.int32x4(4, 5, 6, 7))});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) - SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) * SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) / SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) % SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) < SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) > SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) <= SIMD.int32x4(4, 5, 6, 7)});
-    throws(function() {SIMD.int32x4(0, 1, 2, 3) >= SIMD.int32x4(4, 5, 6, 7)});
-    equal(SIMD.int32x4(0, 1, 2, 3).toString(), "int32x4(0, 1, 2, 3)");
-    equal(SIMD.int32x4(0, 1, 2, 3).toLocaleString(), "int32x4(0, 1, 2, 3)");
-    throws(function() { SIMD.int32x4(0, 1, 2, 3)(); });
-    equal(SIMD.int32x4(0, 1, 2, 3)[0], undefined);
-    equal(SIMD.int32x4(0, 1, 2, 3).a, undefined);
-    equal(!SIMD.int32x4(0, 1, 2, 3), false);
-    equal(!SIMD.int32x4(0, 0, 0, 0), false);
-    equal(SIMD.int32x4(0, 1, 2, 3) ? 1 : 2, 1);
-    equal(SIMD.int32x4(0, 0, 0, 0) ? 1 : 2, 1);
+    throws(function() {Number(SIMD.Int32x4(0, 1, 2, 3))});
+    throws(function() {+SIMD.Int32x4(0, 1, 2, 3)});
+    throws(function() {-SIMD.Int32x4(0, 1, 2, 3)});
+    throws(function() {~SIMD.Int32x4(0, 1, 2, 3), -1});
+    throws(function() {Math.fround(SIMD.Int32x4(0, 1, 2, 3))});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)|0});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)&0});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)^0});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)>>>0});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)>>0});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3)<<0});
+    throws(function() {(SIMD.Int32x4(0, 1, 2, 3) + SIMD.Int32x4(4, 5, 6, 7))});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) - SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) * SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) / SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) % SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) < SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) > SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) <= SIMD.Int32x4(4, 5, 6, 7)});
+    throws(function() {SIMD.Int32x4(0, 1, 2, 3) >= SIMD.Int32x4(4, 5, 6, 7)});
+    equal(SIMD.Int32x4(0, 1, 2, 3).toString(), "Int32x4(0, 1, 2, 3)");
+    equal(SIMD.Int32x4(0, 1, 2, 3).toLocaleString(), "Int32x4(0, 1, 2, 3)");
+    throws(function() { SIMD.Int32x4(0, 1, 2, 3)(); });
+    equal(SIMD.Int32x4(0, 1, 2, 3)[0], undefined);
+    equal(SIMD.Int32x4(0, 1, 2, 3).a, undefined);
+    equal(!SIMD.Int32x4(0, 1, 2, 3), false);
+    equal(!SIMD.Int32x4(0, 0, 0, 0), false);
+    equal(SIMD.Int32x4(0, 1, 2, 3) ? 1 : 2, 1);
+    equal(SIMD.Int32x4(0, 0, 0, 0) ? 1 : 2, 1);
 });
 
-test('float64x2 operators', function() {
+test('Float64x2 operators', function() {
     // Not possible to implement properly in polyfill:
     //   ==, ===, !=, !==
-    throws(function() {Number(SIMD.float64x2(0, 1))});
-    throws(function() {+SIMD.float64x2(0, 1)});
-    throws(function() {-SIMD.float64x2(0, 1)});
-    throws(function() {~SIMD.float64x2(0, 1), -1});
-    throws(function() {Math.fround(SIMD.float64x2(0, 1))});
-    throws(function() {SIMD.float64x2(0, 1)|0});
-    throws(function() {SIMD.float64x2(0, 1)&0});
-    throws(function() {SIMD.float64x2(0, 1)^0});
-    throws(function() {SIMD.float64x2(0, 1)>>>0});
-    throws(function() {SIMD.float64x2(0, 1)>>0});
-    throws(function() {SIMD.float64x2(0, 1)<<0});
-    throws(function() {(SIMD.float64x2(0, 1) + SIMD.float64x2(0, 1))});
-    throws(function() {SIMD.float64x2(0, 1) - SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) * SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) / SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) % SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) < SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) > SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) <= SIMD.float64x2(0, 1)});
-    throws(function() {SIMD.float64x2(0, 1) >= SIMD.float64x2(0, 1)});
-    equal(SIMD.float64x2(0, 1).toString(), "float64x2(0, 1)");
-    equal(SIMD.float64x2(0, 1).toLocaleString(), "float64x2(0, 1)");
-    throws(function() { SIMD.float64x2(0, 1)(); });
-    equal(SIMD.float64x2(0, 1)[0], undefined);
-    equal(SIMD.float64x2(0, 1).a, undefined);
-    equal(!SIMD.float64x2(0, 1), false);
-    equal(!SIMD.float64x2(0, 1), false);
-    equal(SIMD.float64x2(0, 1) ? 1 : 2, 1);
-    equal(SIMD.float64x2(0, 1) ? 1 : 2, 1);
+    throws(function() {Number(SIMD.Float64x2(0, 1))});
+    throws(function() {+SIMD.Float64x2(0, 1)});
+    throws(function() {-SIMD.Float64x2(0, 1)});
+    throws(function() {~SIMD.Float64x2(0, 1), -1});
+    throws(function() {Math.fround(SIMD.Float64x2(0, 1))});
+    throws(function() {SIMD.Float64x2(0, 1)|0});
+    throws(function() {SIMD.Float64x2(0, 1)&0});
+    throws(function() {SIMD.Float64x2(0, 1)^0});
+    throws(function() {SIMD.Float64x2(0, 1)>>>0});
+    throws(function() {SIMD.Float64x2(0, 1)>>0});
+    throws(function() {SIMD.Float64x2(0, 1)<<0});
+    throws(function() {(SIMD.Float64x2(0, 1) + SIMD.Float64x2(0, 1))});
+    throws(function() {SIMD.Float64x2(0, 1) - SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) * SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) / SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) % SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) < SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) > SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) <= SIMD.Float64x2(0, 1)});
+    throws(function() {SIMD.Float64x2(0, 1) >= SIMD.Float64x2(0, 1)});
+    equal(SIMD.Float64x2(0, 1).toString(), "Float64x2(0, 1)");
+    equal(SIMD.Float64x2(0, 1).toLocaleString(), "Float64x2(0, 1)");
+    throws(function() { SIMD.Float64x2(0, 1)(); });
+    equal(SIMD.Float64x2(0, 1)[0], undefined);
+    equal(SIMD.Float64x2(0, 1).a, undefined);
+    equal(!SIMD.Float64x2(0, 1), false);
+    equal(!SIMD.Float64x2(0, 1), false);
+    equal(SIMD.Float64x2(0, 1) ? 1 : 2, 1);
+    equal(SIMD.Float64x2(0, 1) ? 1 : 2, 1);
 });
 
-test('int8x16 operators', function() {
+test('Int8x16 operators', function() {
     // Not possible to implement properly in polyfill:
     //   ==, ===, !=, !==
-    throws(function() {Number(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {+SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {-SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {~SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), -1});
-    throws(function() {Math.fround(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)|0});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)&0});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)^0});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>>0});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>0});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)<<0});
-    throws(function() {(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) + SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) - SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) * SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) / SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) % SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) < SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) > SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) <= SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    throws(function() {SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) >= SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toString(), "int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toLocaleString(), "int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
-    throws(function() { SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)(); });
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)[0], undefined);
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).a, undefined);
-    equal(!SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
-    equal(!SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
-    equal(SIMD.int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
+    throws(function() {Number(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
+    throws(function() {+SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {-SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {~SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), -1});
+    throws(function() {Math.fround(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)|0});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)&0});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)^0});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>>0});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)>>0});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)<<0});
+    throws(function() {(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) + SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) - SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) * SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) / SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) % SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) < SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) > SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) <= SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    throws(function() {SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) >= SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)});
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toString(), "Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toLocaleString(), "Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)");
+    throws(function() { SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)(); });
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)[0], undefined);
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).a, undefined);
+    equal(!SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
+    equal(!SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), false);
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
+    equal(SIMD.Int8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) ? 1 : 2, 1);
 });
 
-test('int16x8 operators', function() {
+test('Int16x8 operators', function() {
     // Not possible to implement properly in polyfill:
     //   ==, ===, !=, !==
-    throws(function() {Number(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {+SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {-SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {~SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7), -1});
-    throws(function() {Math.fround(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)|0});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)&0});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)^0});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>>0});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>0});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)<<0});
-    throws(function() {(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) + SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) - SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) * SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) / SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) % SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) < SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) > SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) <= SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    throws(function() {SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) >= SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7).toString(), "int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7).toLocaleString(), "int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
-    throws(function() { SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)(); });
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7)[0], undefined);
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7).a, undefined);
-    equal(!SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
-    equal(!SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
-    equal(SIMD.int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
+    throws(function() {Number(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
+    throws(function() {+SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {-SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {~SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), -1});
+    throws(function() {Math.fround(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)|0});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)&0});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)^0});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>>0});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)>>0});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)<<0});
+    throws(function() {(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) + SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7))});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) - SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) * SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) / SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) % SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) < SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) > SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) <= SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    throws(function() {SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) >= SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)});
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).toString(), "Int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).toLocaleString(), "Int16x8(0, 1, 2, 3, 4, 5, 6, 7)");
+    throws(function() { SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)(); });
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7)[0], undefined);
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7).a, undefined);
+    equal(!SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
+    equal(!SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7), false);
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
+    equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
 });
 
-test('float32x4 constructor', function() {
-  notEqual(undefined, SIMD.float32x4);  // Type.
-  notEqual(undefined, SIMD.float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
+test('Float32x4 constructor', function() {
+  notEqual(undefined, SIMD.Float32x4);  // Type.
+  notEqual(undefined, SIMD.Float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
 });
 
 test('simd128 types check', function() {
-  var x = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var a = SIMD.float32x4.check(x);
-  equal(SIMD.float32x4.extractLane(a, 0), SIMD.float32x4.extractLane(x, 0));
-  equal(SIMD.float32x4.extractLane(a, 1), SIMD.float32x4.extractLane(x, 1));
-  equal(SIMD.float32x4.extractLane(a, 2), SIMD.float32x4.extractLane(x, 2));
-  equal(SIMD.float32x4.extractLane(a, 3), SIMD.float32x4.extractLane(x, 3));
-  throws(function() {SIMD.float32x4.check(1)});
-  throws(function() {SIMD.float32x4.check('hi')});
+  var x = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var a = SIMD.Float32x4.check(x);
+  equal(SIMD.Float32x4.extractLane(a, 0), SIMD.Float32x4.extractLane(x, 0));
+  equal(SIMD.Float32x4.extractLane(a, 1), SIMD.Float32x4.extractLane(x, 1));
+  equal(SIMD.Float32x4.extractLane(a, 2), SIMD.Float32x4.extractLane(x, 2));
+  equal(SIMD.Float32x4.extractLane(a, 3), SIMD.Float32x4.extractLane(x, 3));
+  throws(function() {SIMD.Float32x4.check(1)});
+  throws(function() {SIMD.Float32x4.check('hi')});
 
-  var y = SIMD.int32x4(1, 2, 3, 4);
-  var b = SIMD.int32x4.check(y);
-  equal(SIMD.int32x4.extractLane(b, 0), SIMD.int32x4.extractLane(y, 0));
-  equal(SIMD.int32x4.extractLane(b, 1), SIMD.int32x4.extractLane(y, 1));
-  equal(SIMD.int32x4.extractLane(b, 2), SIMD.int32x4.extractLane(y, 2));
-  equal(SIMD.int32x4.extractLane(b, 3), SIMD.int32x4.extractLane(y, 3));
-  throws(function() {SIMD.int32x4.check(1)});
-  throws(function() {SIMD.int32x4.check('hi')});
+  var y = SIMD.Int32x4(1, 2, 3, 4);
+  var b = SIMD.Int32x4.check(y);
+  equal(SIMD.Int32x4.extractLane(b, 0), SIMD.Int32x4.extractLane(y, 0));
+  equal(SIMD.Int32x4.extractLane(b, 1), SIMD.Int32x4.extractLane(y, 1));
+  equal(SIMD.Int32x4.extractLane(b, 2), SIMD.Int32x4.extractLane(y, 2));
+  equal(SIMD.Int32x4.extractLane(b, 3), SIMD.Int32x4.extractLane(y, 3));
+  throws(function() {SIMD.Int32x4.check(1)});
+  throws(function() {SIMD.Int32x4.check('hi')});
 
-  var z = SIMD.float64x2(1.0, 2.0);
-  var c = SIMD.float64x2.check(z);
-  equal(SIMD.float64x2.extractLane(c, 0), SIMD.float64x2.extractLane(z, 0));
-  equal(SIMD.float64x2.extractLane(c, 1), SIMD.float64x2.extractLane(z, 1));
-  throws(function() {SIMD.float64x2.check(1)});
-  throws(function() {SIMD.float64x2.check('hi')});
+  var z = SIMD.Float64x2(1.0, 2.0);
+  var c = SIMD.Float64x2.check(z);
+  equal(SIMD.Float64x2.extractLane(c, 0), SIMD.Float64x2.extractLane(z, 0));
+  equal(SIMD.Float64x2.extractLane(c, 1), SIMD.Float64x2.extractLane(z, 1));
+  throws(function() {SIMD.Float64x2.check(1)});
+  throws(function() {SIMD.Float64x2.check('hi')});
 
-  var u = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var d = SIMD.int16x8.check(u);
-  equal(SIMD.int16x8.extractLane(d, 0), SIMD.int16x8.extractLane(u, 0));
-  equal(SIMD.int16x8.extractLane(d, 1), SIMD.int16x8.extractLane(u, 1));
-  equal(SIMD.int16x8.extractLane(d, 2), SIMD.int16x8.extractLane(u, 2));
-  equal(SIMD.int16x8.extractLane(d, 3), SIMD.int16x8.extractLane(u, 3));
-  equal(SIMD.int16x8.extractLane(d, 4), SIMD.int16x8.extractLane(u, 4));
-  equal(SIMD.int16x8.extractLane(d, 5), SIMD.int16x8.extractLane(u, 5));
-  equal(SIMD.int16x8.extractLane(d, 6), SIMD.int16x8.extractLane(u, 6));
-  equal(SIMD.int16x8.extractLane(d, 7), SIMD.int16x8.extractLane(u, 7));
-  throws(function() {SIMD.int16x8.check(1)});
-  throws(function() {SIMD.int16x8.check('hi')});
+  var u = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var d = SIMD.Int16x8.check(u);
+  equal(SIMD.Int16x8.extractLane(d, 0), SIMD.Int16x8.extractLane(u, 0));
+  equal(SIMD.Int16x8.extractLane(d, 1), SIMD.Int16x8.extractLane(u, 1));
+  equal(SIMD.Int16x8.extractLane(d, 2), SIMD.Int16x8.extractLane(u, 2));
+  equal(SIMD.Int16x8.extractLane(d, 3), SIMD.Int16x8.extractLane(u, 3));
+  equal(SIMD.Int16x8.extractLane(d, 4), SIMD.Int16x8.extractLane(u, 4));
+  equal(SIMD.Int16x8.extractLane(d, 5), SIMD.Int16x8.extractLane(u, 5));
+  equal(SIMD.Int16x8.extractLane(d, 6), SIMD.Int16x8.extractLane(u, 6));
+  equal(SIMD.Int16x8.extractLane(d, 7), SIMD.Int16x8.extractLane(u, 7));
+  throws(function() {SIMD.Int16x8.check(1)});
+  throws(function() {SIMD.Int16x8.check('hi')});
 
-  var v = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var e = SIMD.int8x16.check(v);
-  equal(SIMD.int8x16.extractLane(e, 0), SIMD.int8x16.extractLane(v, 0));
-  equal(SIMD.int8x16.extractLane(e, 1), SIMD.int8x16.extractLane(v, 1));
-  equal(SIMD.int8x16.extractLane(e, 2), SIMD.int8x16.extractLane(v, 2));
-  equal(SIMD.int8x16.extractLane(e, 3), SIMD.int8x16.extractLane(v, 3));
-  equal(SIMD.int8x16.extractLane(e, 4), SIMD.int8x16.extractLane(v, 4));
-  equal(SIMD.int8x16.extractLane(e, 5), SIMD.int8x16.extractLane(v, 5));
-  equal(SIMD.int8x16.extractLane(e, 6), SIMD.int8x16.extractLane(v, 6));
-  equal(SIMD.int8x16.extractLane(e, 7), SIMD.int8x16.extractLane(v, 7));
-  equal(SIMD.int8x16.extractLane(e, 8), SIMD.int8x16.extractLane(v, 8));
-  equal(SIMD.int8x16.extractLane(e, 9), SIMD.int8x16.extractLane(v, 9));
-  equal(SIMD.int8x16.extractLane(e, 10), SIMD.int8x16.extractLane(v, 10));
-  equal(SIMD.int8x16.extractLane(e, 11), SIMD.int8x16.extractLane(v, 11));
-  equal(SIMD.int8x16.extractLane(e, 12), SIMD.int8x16.extractLane(v, 12));
-  equal(SIMD.int8x16.extractLane(e, 13), SIMD.int8x16.extractLane(v, 13));
-  equal(SIMD.int8x16.extractLane(e, 14), SIMD.int8x16.extractLane(v, 14));
-  equal(SIMD.int8x16.extractLane(e, 15), SIMD.int8x16.extractLane(v, 15));
-  throws(function() {SIMD.int8x16.check(1)});
-  throws(function() {SIMD.int8x16.check('hi')});
+  var v = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var e = SIMD.Int8x16.check(v);
+  equal(SIMD.Int8x16.extractLane(e, 0), SIMD.Int8x16.extractLane(v, 0));
+  equal(SIMD.Int8x16.extractLane(e, 1), SIMD.Int8x16.extractLane(v, 1));
+  equal(SIMD.Int8x16.extractLane(e, 2), SIMD.Int8x16.extractLane(v, 2));
+  equal(SIMD.Int8x16.extractLane(e, 3), SIMD.Int8x16.extractLane(v, 3));
+  equal(SIMD.Int8x16.extractLane(e, 4), SIMD.Int8x16.extractLane(v, 4));
+  equal(SIMD.Int8x16.extractLane(e, 5), SIMD.Int8x16.extractLane(v, 5));
+  equal(SIMD.Int8x16.extractLane(e, 6), SIMD.Int8x16.extractLane(v, 6));
+  equal(SIMD.Int8x16.extractLane(e, 7), SIMD.Int8x16.extractLane(v, 7));
+  equal(SIMD.Int8x16.extractLane(e, 8), SIMD.Int8x16.extractLane(v, 8));
+  equal(SIMD.Int8x16.extractLane(e, 9), SIMD.Int8x16.extractLane(v, 9));
+  equal(SIMD.Int8x16.extractLane(e, 10), SIMD.Int8x16.extractLane(v, 10));
+  equal(SIMD.Int8x16.extractLane(e, 11), SIMD.Int8x16.extractLane(v, 11));
+  equal(SIMD.Int8x16.extractLane(e, 12), SIMD.Int8x16.extractLane(v, 12));
+  equal(SIMD.Int8x16.extractLane(e, 13), SIMD.Int8x16.extractLane(v, 13));
+  equal(SIMD.Int8x16.extractLane(e, 14), SIMD.Int8x16.extractLane(v, 14));
+  equal(SIMD.Int8x16.extractLane(e, 15), SIMD.Int8x16.extractLane(v, 15));
+  throws(function() {SIMD.Int8x16.check(1)});
+  throws(function() {SIMD.Int8x16.check('hi')});
 });
 
-test('float32x4 fromFloat64x2 constructor', function() {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float32x4.fromFloat64x2(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  isPositiveZero(SIMD.float32x4.extractLane(n, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromFloat64x2 constructor', function() {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float32x4.fromFloat64x2(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 3));
 
-  m = SIMD.float64x2(3.402824e+38, 7.006492e-46);
-  n = SIMD.float32x4.fromFloat64x2(m);
-  equal(Infinity, SIMD.float32x4.extractLane(n, 0));
-  isPositiveZero(SIMD.float32x4.extractLane(n, 1));
-  isPositiveZero(SIMD.float32x4.extractLane(n, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(n, 3));
+  m = SIMD.Float64x2(3.402824e+38, 7.006492e-46);
+  n = SIMD.Float32x4.fromFloat64x2(m);
+  equal(Infinity, SIMD.Float32x4.extractLane(n, 0));
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 1));
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 fromInt32x4 constructor', function() {
-  var m = SIMD.int32x4(1, 2, 3, 4);
-  var n = SIMD.float32x4.fromInt32x4(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromInt32x4 constructor', function() {
+  var m = SIMD.Int32x4(1, 2, 3, 4);
+  var n = SIMD.Float32x4.fromInt32x4(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
 
-  m = SIMD.int32x4(0, 2147483647, -2147483648, -1);
-  n = SIMD.float32x4.fromInt32x4(m);
-  isPositiveZero(SIMD.float32x4.extractLane(n, 0));
-  equal(2147483648, SIMD.float32x4.extractLane(n, 1));
-  equal(-2147483648, SIMD.float32x4.extractLane(n, 2));
-  equal(-1, SIMD.float32x4.extractLane(n, 3));
+  m = SIMD.Int32x4(0, 2147483647, -2147483648, -1);
+  n = SIMD.Float32x4.fromInt32x4(m);
+  isPositiveZero(SIMD.Float32x4.extractLane(n, 0));
+  equal(2147483648, SIMD.Float32x4.extractLane(n, 1));
+  equal(-2147483648, SIMD.Float32x4.extractLane(n, 2));
+  equal(-1, SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 fromFloat64x2Bits constructor', function() {
-  var m = SIMD.float64x2.fromInt32x4Bits(SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000));
-  var n = SIMD.float32x4.fromFloat64x2Bits(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromFloat64x2Bits constructor', function() {
+  var m = SIMD.Float64x2.fromInt32x4Bits(SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000));
+  var n = SIMD.Float32x4.fromFloat64x2Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 fromInt32x4Bits constructor', function() {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var n = SIMD.float32x4.fromInt32x4Bits(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromInt32x4Bits constructor', function() {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var n = SIMD.Float32x4.fromInt32x4Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 fromInt16x8Bits constructor', function() {
-  var m = SIMD.int16x8(0x0000, 0x3F80, 0x0000, 0x4000, 0x0000, 0x4040, 0x0000, 0x4080);
-  var n = SIMD.float32x4.fromInt16x8Bits(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromInt16x8Bits constructor', function() {
+  var m = SIMD.Int16x8(0x0000, 0x3F80, 0x0000, 0x4000, 0x0000, 0x4040, 0x0000, 0x4080);
+  var n = SIMD.Float32x4.fromInt16x8Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 fromInt8x16Bits constructor', function() {
-  var m = SIMD.int8x16(0x0, 0x0, 0x80, 0x3F, 0x0, 0x0, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40, 0x00, 0x00, 0x80, 0x40);
-  var n = SIMD.float32x4.fromInt8x16Bits(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
+test('Float32x4 fromInt8x16Bits constructor', function() {
+  var m = SIMD.Int8x16(0x0, 0x0, 0x80, 0x3F, 0x0, 0x0, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40, 0x00, 0x00, 0x80, 0x40);
+  var n = SIMD.Float32x4.fromInt8x16Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
 });
 
-test('float32x4 extract lane', function() {
-  var a = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  equal(1.0, SIMD.float32x4.extractLane(a, 0));
-  equal(2.0, SIMD.float32x4.extractLane(a, 1));
-  equal(3.0, SIMD.float32x4.extractLane(a, 2));
-  equal(4.0, SIMD.float32x4.extractLane(a, 3));
+test('Float32x4 extract lane', function() {
+  var a = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  equal(1.0, SIMD.Float32x4.extractLane(a, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(a, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(a, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(a, 3));
 });
 
-test('float32x4 vector getters', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var xxxx = SIMD.float32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.float32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.float32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.float32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.float32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4.0, SIMD.float32x4.extractLane(xxxx, 0));
-  equal(4.0, SIMD.float32x4.extractLane(xxxx, 1));
-  equal(4.0, SIMD.float32x4.extractLane(xxxx, 2));
-  equal(4.0, SIMD.float32x4.extractLane(xxxx, 3));
-  equal(3.0, SIMD.float32x4.extractLane(yyyy, 0));
-  equal(3.0, SIMD.float32x4.extractLane(yyyy, 1));
-  equal(3.0, SIMD.float32x4.extractLane(yyyy, 2));
-  equal(3.0, SIMD.float32x4.extractLane(yyyy, 3));
-  equal(2.0, SIMD.float32x4.extractLane(zzzz, 0));
-  equal(2.0, SIMD.float32x4.extractLane(zzzz, 1));
-  equal(2.0, SIMD.float32x4.extractLane(zzzz, 2));
-  equal(2.0, SIMD.float32x4.extractLane(zzzz, 3));
-  equal(1.0, SIMD.float32x4.extractLane(wwww, 0));
-  equal(1.0, SIMD.float32x4.extractLane(wwww, 1));
-  equal(1.0, SIMD.float32x4.extractLane(wwww, 2));
-  equal(1.0, SIMD.float32x4.extractLane(wwww, 3));
-  equal(1.0, SIMD.float32x4.extractLane(wzyx, 0));
-  equal(2.0, SIMD.float32x4.extractLane(wzyx, 1));
-  equal(3.0, SIMD.float32x4.extractLane(wzyx, 2));
-  equal(4.0, SIMD.float32x4.extractLane(wzyx, 3));
+test('Float32x4 vector getters', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var xxxx = SIMD.Float32x4.swizzle(a, 0, 0, 0, 0);
+  var yyyy = SIMD.Float32x4.swizzle(a, 1, 1, 1, 1);
+  var zzzz = SIMD.Float32x4.swizzle(a, 2, 2, 2, 2);
+  var wwww = SIMD.Float32x4.swizzle(a, 3, 3, 3, 3);
+  var wzyx = SIMD.Float32x4.swizzle(a, 3, 2, 1, 0);
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 0));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 1));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 2));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 3));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 1));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(wzyx, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(wzyx, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(wzyx, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(wzyx, 3));
 });
 
-test('float32x4 abs', function() {
-  var a = SIMD.float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.float32x4.abs(a);
-  equal(4.0, SIMD.float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
-  c = SIMD.float32x4.abs(SIMD.float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(4.0, SIMD.float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 abs', function() {
+  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
+  var c = SIMD.Float32x4.abs(a);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+  c = SIMD.Float32x4.abs(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 
-  var d = SIMD.float32x4(NaN, Infinity, 0.0, 1.0);
-  var e = SIMD.float32x4.abs(d);
-  var f = SIMD.float32x4(-NaN, -Infinity, -0.0, -1.0);
-  var g = SIMD.float32x4.abs(f);
-  isNaN(SIMD.float32x4.extractLane(e, 0))
-  equal(SIMD.float32x4.extractLane(e, 1), Infinity);
-  isPositiveZero(SIMD.float32x4.extractLane(e, 2));
-  equal(SIMD.float32x4.extractLane(e, 3), 1.0);
-  isNaN(SIMD.float32x4.extractLane(g, 0))
-  equal(SIMD.float32x4.extractLane(g, 1), Infinity);
-  isPositiveZero(SIMD.float32x4.extractLane(g, 2));
-  equal(SIMD.float32x4.extractLane(g, 3), 1.0);
+  var d = SIMD.Float32x4(NaN, Infinity, 0.0, 1.0);
+  var e = SIMD.Float32x4.abs(d);
+  var f = SIMD.Float32x4(-NaN, -Infinity, -0.0, -1.0);
+  var g = SIMD.Float32x4.abs(f);
+  isNaN(SIMD.Float32x4.extractLane(e, 0))
+  equal(SIMD.Float32x4.extractLane(e, 1), Infinity);
+  isPositiveZero(SIMD.Float32x4.extractLane(e, 2));
+  equal(SIMD.Float32x4.extractLane(e, 3), 1.0);
+  isNaN(SIMD.Float32x4.extractLane(g, 0))
+  equal(SIMD.Float32x4.extractLane(g, 1), Infinity);
+  isPositiveZero(SIMD.Float32x4.extractLane(g, 2));
+  equal(SIMD.Float32x4.extractLane(g, 3), 1.0);
 });
 
-test('float32x4 neg', function() {
-  var a = SIMD.float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.float32x4.neg(a);
-  equal(4.0, SIMD.float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
-  c = SIMD.float32x4.neg(SIMD.float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(-4.0, SIMD.float32x4.extractLane(c, 0));
-  equal(-3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(-2.0, SIMD.float32x4.extractLane(c, 2));
-  equal(-1.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 neg', function() {
+  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
+  var c = SIMD.Float32x4.neg(a);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+  c = SIMD.Float32x4.neg(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
+  equal(-4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(-3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(-2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(-1.0, SIMD.Float32x4.extractLane(c, 3));
 
-  var d = SIMD.float32x4(Infinity, -Infinity, 0.0, -0.0);
-  var f = SIMD.float32x4.neg(d);
-  equal(-Infinity, SIMD.float32x4.extractLane(f, 0));
-  equal(Infinity, SIMD.float32x4.extractLane(f, 1));
-  isNegativeZero(SIMD.float32x4.extractLane(f, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(f, 3));
+  var d = SIMD.Float32x4(Infinity, -Infinity, 0.0, -0.0);
+  var f = SIMD.Float32x4.neg(d);
+  equal(-Infinity, SIMD.Float32x4.extractLane(f, 0));
+  equal(Infinity, SIMD.Float32x4.extractLane(f, 1));
+  isNegativeZero(SIMD.Float32x4.extractLane(f, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(f, 3));
 
-  var g = SIMD.float32x4.neg(SIMD.float32x4.splat(NaN));
-  isNaN(SIMD.float32x4.extractLane(g, 0))
+  var g = SIMD.Float32x4.neg(SIMD.Float32x4.splat(NaN));
+  isNaN(SIMD.Float32x4.extractLane(g, 0))
 });
 
-test('float32x4 add', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.add(a, b);
-  equal(14.0, SIMD.float32x4.extractLane(c, 0));
-  equal(23.0, SIMD.float32x4.extractLane(c, 1));
-  equal(32.0, SIMD.float32x4.extractLane(c, 2));
-  equal(41.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 add', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.add(a, b);
+  equal(14.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(23.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(32.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(41.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 sub', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.sub(a, b);
-  equal(-6.0, SIMD.float32x4.extractLane(c, 0));
-  equal(-17.0, SIMD.float32x4.extractLane(c, 1));
-  equal(-28.0, SIMD.float32x4.extractLane(c, 2));
-  equal(-39.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 sub', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.sub(a, b);
+  equal(-6.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(-17.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(-28.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(-39.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 mul', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.mul(a, b);
-  equal(40.0, SIMD.float32x4.extractLane(c, 0));
-  equal(60.0, SIMD.float32x4.extractLane(c, 1));
-  equal(60.0, SIMD.float32x4.extractLane(c, 2));
-  equal(40.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 mul', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.mul(a, b);
+  equal(40.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(60.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(60.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(40.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 div', function() {
-  var a = SIMD.float32x4(4.0, 9.0, 8.0, 1.0);
-  var b = SIMD.float32x4(2.0, 3.0, 1.0, 0.5);
-  var c = SIMD.float32x4.div(a, b);
-  equal(2.0, SIMD.float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(8.0, SIMD.float32x4.extractLane(c, 2));
-  equal(2.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 div', function() {
+  var a = SIMD.Float32x4(4.0, 9.0, 8.0, 1.0);
+  var b = SIMD.Float32x4(2.0, 3.0, 1.0, 0.5);
+  var c = SIMD.Float32x4.div(a, b);
+  equal(2.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(8.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
 
-  var d = SIMD.float32x4(1.0, 0.0, Infinity, NaN);
-  var e = SIMD.float32x4(Infinity, 0.0, Infinity, 1.0);
-  var f = SIMD.float32x4.div(d, e);
-  isPositiveZero(SIMD.float32x4.extractLane(f, 0));
-  isNaN(SIMD.float32x4.extractLane(f, 1))
-  isNaN(SIMD.float32x4.extractLane(f, 2))
-  isNaN(SIMD.float32x4.extractLane(f, 3))
+  var d = SIMD.Float32x4(1.0, 0.0, Infinity, NaN);
+  var e = SIMD.Float32x4(Infinity, 0.0, Infinity, 1.0);
+  var f = SIMD.Float32x4.div(d, e);
+  isPositiveZero(SIMD.Float32x4.extractLane(f, 0));
+  isNaN(SIMD.Float32x4.extractLane(f, 1))
+  isNaN(SIMD.Float32x4.extractLane(f, 2))
+  isNaN(SIMD.Float32x4.extractLane(f, 3))
 
-  var g = SIMD.float32x4(1.0, 1.0, -1.0, -1.0);
-  var h = SIMD.float32x4(0.0, -0.0, 0.0, -0.0);
-  var i = SIMD.float32x4.div(g, h);
-  equal(SIMD.float32x4.extractLane(i, 0), Infinity);
-  equal(SIMD.float32x4.extractLane(i, 1), -Infinity);
-  equal(SIMD.float32x4.extractLane(i, 2), -Infinity);
-  equal(SIMD.float32x4.extractLane(i, 3), Infinity);
+  var g = SIMD.Float32x4(1.0, 1.0, -1.0, -1.0);
+  var h = SIMD.Float32x4(0.0, -0.0, 0.0, -0.0);
+  var i = SIMD.Float32x4.div(g, h);
+  equal(SIMD.Float32x4.extractLane(i, 0), Infinity);
+  equal(SIMD.Float32x4.extractLane(i, 1), -Infinity);
+  equal(SIMD.Float32x4.extractLane(i, 2), -Infinity);
+  equal(SIMD.Float32x4.extractLane(i, 3), Infinity);
 });
 
-test('float32x4 min', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.float32x4.min(a, lower);
-  equal(-20.0, SIMD.float32x4.extractLane(c, 0));
-  equal(1.0, SIMD.float32x4.extractLane(c, 1));
-  equal(30.0, SIMD.float32x4.extractLane(c, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 min', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
+  var c = SIMD.Float32x4.min(a, lower);
+  equal(-20.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(30.0, SIMD.Float32x4.extractLane(c, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(c, 3));
 
-  var x = SIMD.float32x4(-0, 0, NaN, 0);
-  var y = SIMD.float32x4(0, -0, 0, NaN);
-  var z = SIMD.float32x4.min(x, y);
-  isNegativeZero(SIMD.float32x4.extractLane(z, 0));
-  isNegativeZero(SIMD.float32x4.extractLane(z, 1));
-  isNaN(SIMD.float32x4.extractLane(z, 2))
-  isNaN(SIMD.float32x4.extractLane(z, 3))
+  var x = SIMD.Float32x4(-0, 0, NaN, 0);
+  var y = SIMD.Float32x4(0, -0, 0, NaN);
+  var z = SIMD.Float32x4.min(x, y);
+  isNegativeZero(SIMD.Float32x4.extractLane(z, 0));
+  isNegativeZero(SIMD.Float32x4.extractLane(z, 1));
+  isNaN(SIMD.Float32x4.extractLane(z, 2))
+  isNaN(SIMD.Float32x4.extractLane(z, 3))
 });
 
-test('float32x4 minNum', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.float32x4.minNum(a, lower);
-  equal(-20.0, SIMD.float32x4.extractLane(c, 0));
-  equal(1.0, SIMD.float32x4.extractLane(c, 1));
-  equal(30.0, SIMD.float32x4.extractLane(c, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 minNum', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
+  var c = SIMD.Float32x4.minNum(a, lower);
+  equal(-20.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(30.0, SIMD.Float32x4.extractLane(c, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(c, 3));
 
-  var x = SIMD.float32x4(-0, 0, NaN, 0);
-  var y = SIMD.float32x4(0, -0, 0, NaN);
-  var z = SIMD.float32x4.minNum(x, y);
-  isNegativeZero(SIMD.float32x4.extractLane(z, 0));
-  isNegativeZero(SIMD.float32x4.extractLane(z, 1));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 3));
+  var x = SIMD.Float32x4(-0, 0, NaN, 0);
+  var y = SIMD.Float32x4(0, -0, 0, NaN);
+  var z = SIMD.Float32x4.minNum(x, y);
+  isNegativeZero(SIMD.Float32x4.extractLane(z, 0));
+  isNegativeZero(SIMD.Float32x4.extractLane(z, 1));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 3));
 });
 
-test('float32x4 min exceptions', function() {
-  var ok    = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+test('Float32x4 min exceptions', function() {
+  var ok    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   var notOk = 1;
   throws(function () {
-    SIMD.float32x4.min(ok, notOk);
+    SIMD.Float32x4.min(ok, notOk);
   });
   throws(function () {
-    SIMD.float32x4.min(notOk, ok);
+    SIMD.Float32x4.min(notOk, ok);
   });
 });
 
-test('float32x4 max', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.max(a, upper);
-  equal(2.5, SIMD.float32x4.extractLane(c, 0));
-  equal(10.0, SIMD.float32x4.extractLane(c, 1));
-  equal(55.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 max', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
+  var c = SIMD.Float32x4.max(a, upper);
+  equal(2.5, SIMD.Float32x4.extractLane(c, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(55.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 
-  var x = SIMD.float32x4(-0, 0, NaN, 0);
-  var y = SIMD.float32x4(0, -0, 0, NaN);
-  var z = SIMD.float32x4.max(x, y);
-  isPositiveZero(SIMD.float32x4.extractLane(z, 0));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 1));
-  isNaN(SIMD.float32x4.extractLane(z, 2))
-  isNaN(SIMD.float32x4.extractLane(z, 3))
+  var x = SIMD.Float32x4(-0, 0, NaN, 0);
+  var y = SIMD.Float32x4(0, -0, 0, NaN);
+  var z = SIMD.Float32x4.max(x, y);
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 0));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 1));
+  isNaN(SIMD.Float32x4.extractLane(z, 2))
+  isNaN(SIMD.Float32x4.extractLane(z, 3))
 });
 
-test('float32x4 maxNum', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.maxNum(a, upper);
-  equal(2.5, SIMD.float32x4.extractLane(c, 0));
-  equal(10.0, SIMD.float32x4.extractLane(c, 1));
-  equal(55.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 maxNum', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
+  var c = SIMD.Float32x4.maxNum(a, upper);
+  equal(2.5, SIMD.Float32x4.extractLane(c, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(55.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 
-  var x = SIMD.float32x4(-0, 0, NaN, 0);
-  var y = SIMD.float32x4(0, -0, 0, NaN);
-  var z = SIMD.float32x4.maxNum(x, y);
-  isPositiveZero(SIMD.float32x4.extractLane(z, 0));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 1));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 2));
-  isPositiveZero(SIMD.float32x4.extractLane(z, 3));
+  var x = SIMD.Float32x4(-0, 0, NaN, 0);
+  var y = SIMD.Float32x4(0, -0, 0, NaN);
+  var z = SIMD.Float32x4.maxNum(x, y);
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 0));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 1));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 2));
+  isPositiveZero(SIMD.Float32x4.extractLane(z, 3));
 });
 
-test('float32x4 max exceptions', function() {
-  var ok    = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+test('Float32x4 max exceptions', function() {
+  var ok    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   var notOk = 1;
   throws(function () {
-    SIMD.float32x4.max(ok, notOk);
+    SIMD.Float32x4.max(ok, notOk);
   });
   throws(function () {
-    SIMD.float32x4.max(notOk, ok);
+    SIMD.Float32x4.max(notOk, ok);
   });
 });
 
-test('float32x4 reciprocal approximation', function() {
-  var a = SIMD.float32x4(8.0, 4.0, 2.0, -2.0);
-  var c = SIMD.float32x4.reciprocalApproximation(a);
-  almostEqual(0.125, SIMD.float32x4.extractLane(c, 0));
-  almostEqual(0.250, SIMD.float32x4.extractLane(c, 1));
-  almostEqual(0.5, SIMD.float32x4.extractLane(c, 2));
-  almostEqual(-0.5, SIMD.float32x4.extractLane(c, 3));
-  a = SIMD.float32x4(NaN, Infinity, -Infinity, -0);
-  c = SIMD.float32x4.reciprocalApproximation(a);
-  isNaN(SIMD.float32x4.extractLane(c, 0))
-  isPositiveZero(SIMD.float32x4.extractLane(c, 1));
-  isNegativeZero(SIMD.float32x4.extractLane(c, 2));
-  equal(-Infinity, SIMD.float32x4.extractLane(c, 3));
-  a = SIMD.float32x4(0, 2.3, -4.5, 7.8);
-  c = SIMD.float32x4.reciprocalApproximation(a);
-  equal(Infinity, SIMD.float32x4.extractLane(c, 0));
-  almostEqual(1/SIMD.float32x4.extractLane(a, 1), SIMD.float32x4.extractLane(c, 1));
-  almostEqual(1/SIMD.float32x4.extractLane(a, 2), SIMD.float32x4.extractLane(c, 2));
-  almostEqual(1/SIMD.float32x4.extractLane(a, 3), SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 reciprocal approximation', function() {
+  var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
+  var c = SIMD.Float32x4.reciprocalApproximation(a);
+  almostEqual(0.125, SIMD.Float32x4.extractLane(c, 0));
+  almostEqual(0.250, SIMD.Float32x4.extractLane(c, 1));
+  almostEqual(0.5, SIMD.Float32x4.extractLane(c, 2));
+  almostEqual(-0.5, SIMD.Float32x4.extractLane(c, 3));
+  a = SIMD.Float32x4(NaN, Infinity, -Infinity, -0);
+  c = SIMD.Float32x4.reciprocalApproximation(a);
+  isNaN(SIMD.Float32x4.extractLane(c, 0))
+  isPositiveZero(SIMD.Float32x4.extractLane(c, 1));
+  isNegativeZero(SIMD.Float32x4.extractLane(c, 2));
+  equal(-Infinity, SIMD.Float32x4.extractLane(c, 3));
+  a = SIMD.Float32x4(0, 2.3, -4.5, 7.8);
+  c = SIMD.Float32x4.reciprocalApproximation(a);
+  equal(Infinity, SIMD.Float32x4.extractLane(c, 0));
+  almostEqual(1/SIMD.Float32x4.extractLane(a, 1), SIMD.Float32x4.extractLane(c, 1));
+  almostEqual(1/SIMD.Float32x4.extractLane(a, 2), SIMD.Float32x4.extractLane(c, 2));
+  almostEqual(1/SIMD.Float32x4.extractLane(a, 3), SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 reciprocal sqrt approximation', function() {
-  var a = SIMD.float32x4(1.0, 0.25, 0.111111, 0.0625);
-  var c = SIMD.float32x4.reciprocalSqrtApproximation(a);
-  almostEqual(1.0, SIMD.float32x4.extractLane(c, 0));
-  almostEqual(2.0, SIMD.float32x4.extractLane(c, 1));
-  almostEqual(3.0, SIMD.float32x4.extractLane(c, 2));
-  almostEqual(4.0, SIMD.float32x4.extractLane(c, 3));
-  a = SIMD.float32x4(-Infinity, Infinity, NaN, 0);
-  c = SIMD.float32x4.reciprocalSqrtApproximation(a);
-  isNaN(SIMD.float32x4.extractLane(c, 0))
-  isPositiveZero(SIMD.float32x4.extractLane(c, 1));
-  isNaN(SIMD.float32x4.extractLane(c, 2))
-  equal(Infinity, SIMD.float32x4.extractLane(c, 3));
-  a = SIMD.float32x4(-0, -1, 121, 144);
-  c = SIMD.float32x4.reciprocalSqrtApproximation(a);
-  equal(-Infinity, SIMD.float32x4.extractLane(c, 0));
-  isNaN(SIMD.float32x4.extractLane(c, 1))
-  almostEqual(1/11, SIMD.float32x4.extractLane(c, 2));
-  almostEqual(1/12, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 reciprocal sqrt approximation', function() {
+  var a = SIMD.Float32x4(1.0, 0.25, 0.111111, 0.0625);
+  var c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
+  almostEqual(1.0, SIMD.Float32x4.extractLane(c, 0));
+  almostEqual(2.0, SIMD.Float32x4.extractLane(c, 1));
+  almostEqual(3.0, SIMD.Float32x4.extractLane(c, 2));
+  almostEqual(4.0, SIMD.Float32x4.extractLane(c, 3));
+  a = SIMD.Float32x4(-Infinity, Infinity, NaN, 0);
+  c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
+  isNaN(SIMD.Float32x4.extractLane(c, 0))
+  isPositiveZero(SIMD.Float32x4.extractLane(c, 1));
+  isNaN(SIMD.Float32x4.extractLane(c, 2))
+  equal(Infinity, SIMD.Float32x4.extractLane(c, 3));
+  a = SIMD.Float32x4(-0, -1, 121, 144);
+  c = SIMD.Float32x4.reciprocalSqrtApproximation(a);
+  equal(-Infinity, SIMD.Float32x4.extractLane(c, 0));
+  isNaN(SIMD.Float32x4.extractLane(c, 1))
+  almostEqual(1/11, SIMD.Float32x4.extractLane(c, 2));
+  almostEqual(1/12, SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 sqrt', function() {
-  var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-  var c = SIMD.float32x4.sqrt(a);
-  equal(4.0, SIMD.float32x4.extractLane(c, 0));
-  equal(3.0, SIMD.float32x4.extractLane(c, 1));
-  equal(2.0, SIMD.float32x4.extractLane(c, 2));
-  equal(1.0, SIMD.float32x4.extractLane(c, 3));
-  a = SIMD.float32x4(0.0, -0.0, Infinity, -Infinity);
-  c = SIMD.float32x4.sqrt(a);
-  isPositiveZero(SIMD.float32x4.extractLane(c, 0));
-  isNegativeZero(SIMD.float32x4.extractLane(c, 1));
-  equal(Infinity, SIMD.float32x4.extractLane(c, 2));
-  isNaN(SIMD.float32x4.extractLane(c, 3))
-  a = SIMD.float32x4(NaN, 2.0, 0.5, 121.0);
-  c = SIMD.float32x4.sqrt(a);
-  isNaN(SIMD.float32x4.extractLane(c, 0))
-  equal(Math.fround(Math.SQRT2), SIMD.float32x4.extractLane(c, 1));
-  equal(Math.fround(Math.SQRT1_2), SIMD.float32x4.extractLane(c, 2));
-  equal(11.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 sqrt', function() {
+  var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+  var c = SIMD.Float32x4.sqrt(a);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+  a = SIMD.Float32x4(0.0, -0.0, Infinity, -Infinity);
+  c = SIMD.Float32x4.sqrt(a);
+  isPositiveZero(SIMD.Float32x4.extractLane(c, 0));
+  isNegativeZero(SIMD.Float32x4.extractLane(c, 1));
+  equal(Infinity, SIMD.Float32x4.extractLane(c, 2));
+  isNaN(SIMD.Float32x4.extractLane(c, 3))
+  a = SIMD.Float32x4(NaN, 2.0, 0.5, 121.0);
+  c = SIMD.Float32x4.sqrt(a);
+  isNaN(SIMD.Float32x4.extractLane(c, 0))
+  equal(Math.fround(Math.SQRT2), SIMD.Float32x4.extractLane(c, 1));
+  equal(Math.fround(Math.SQRT1_2), SIMD.Float32x4.extractLane(c, 2));
+  equal(11.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
-test('float32x4 shuffle', function() {
-  var a    = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var b    = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var xyxy = SIMD.float32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.float32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.float32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1.0, SIMD.float32x4.extractLane(xyxy, 0));
-  equal(2.0, SIMD.float32x4.extractLane(xyxy, 1));
-  equal(5.0, SIMD.float32x4.extractLane(xyxy, 2));
-  equal(6.0, SIMD.float32x4.extractLane(xyxy, 3));
-  equal(3.0, SIMD.float32x4.extractLane(zwzw, 0));
-  equal(4.0, SIMD.float32x4.extractLane(zwzw, 1));
-  equal(7.0, SIMD.float32x4.extractLane(zwzw, 2));
-  equal(8.0, SIMD.float32x4.extractLane(zwzw, 3));
-  equal(1.0, SIMD.float32x4.extractLane(xxxx, 0));
-  equal(1.0, SIMD.float32x4.extractLane(xxxx, 1));
-  equal(5.0, SIMD.float32x4.extractLane(xxxx, 2));
-  equal(5.0, SIMD.float32x4.extractLane(xxxx, 3));
+test('Float32x4 shuffle', function() {
+  var a    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var b    = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var xyxy = SIMD.Float32x4.shuffle(a, b, 0, 1, 4, 5);
+  var zwzw = SIMD.Float32x4.shuffle(a, b, 2, 3, 6, 7);
+  var xxxx = SIMD.Float32x4.shuffle(a, b, 0, 0, 4, 4);
+  equal(1.0, SIMD.Float32x4.extractLane(xyxy, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(xyxy, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xyxy, 2));
+  equal(6.0, SIMD.Float32x4.extractLane(xyxy, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(zwzw, 0));
+  equal(4.0, SIMD.Float32x4.extractLane(zwzw, 1));
+  equal(7.0, SIMD.Float32x4.extractLane(zwzw, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(zwzw, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 2));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 3));
 
-  var c = SIMD.float32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.float32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.float32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1.0, SIMD.float32x4.extractLane(c, 0));
-  equal(5.0, SIMD.float32x4.extractLane(c, 1));
-  equal(6.0, SIMD.float32x4.extractLane(c, 2));
-  equal(2.0, SIMD.float32x4.extractLane(c, 3));
-  equal(3.0, SIMD.float32x4.extractLane(d, 0));
-  equal(7.0, SIMD.float32x4.extractLane(d, 1));
-  equal(4.0, SIMD.float32x4.extractLane(d, 2));
-  equal(8.0, SIMD.float32x4.extractLane(d, 3));
-  equal(1.0, SIMD.float32x4.extractLane(e, 0));
-  equal(5.0, SIMD.float32x4.extractLane(e, 1));
-  equal(1.0, SIMD.float32x4.extractLane(e, 2));
-  equal(5.0, SIMD.float32x4.extractLane(e, 3));
+  var c = SIMD.Float32x4.shuffle(a, b, 0, 4, 5, 1);
+  var d = SIMD.Float32x4.shuffle(a, b, 2, 6, 3, 7);
+  var e = SIMD.Float32x4.shuffle(a, b, 0, 4, 0, 4);
+  equal(1.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(5.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(6.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(d, 0));
+  equal(7.0, SIMD.Float32x4.extractLane(d, 1));
+  equal(4.0, SIMD.Float32x4.extractLane(d, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(d, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(e, 0));
+  equal(5.0, SIMD.Float32x4.extractLane(e, 1));
+  equal(1.0, SIMD.Float32x4.extractLane(e, 2));
+  equal(5.0, SIMD.Float32x4.extractLane(e, 3));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.float32x4.shuffle(a, b, index, 0, 0, 0); });
+      throws(function() { SIMD.Float32x4.shuffle(a, b, index, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -691,31 +691,31 @@ test('float32x4 shuffle', function() {
   testIndexCheck(8);
 });
 
-test('float32x4 replaceLane', function() {
-    var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.float32x4.replaceLane(a, 0, 20.0);
-    equal(20.0, SIMD.float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.float32x4.extractLane(c, 3));
-    c = SIMD.float32x4.replaceLane(a, 1, 20.0);
-    equal(16.0, SIMD.float32x4.extractLane(c, 0));
-    equal(20.0, SIMD.float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.float32x4.extractLane(c, 3));
-    c = SIMD.float32x4.replaceLane(a, 2, 20.0);
-    equal(16.0, SIMD.float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.float32x4.extractLane(c, 1));
-    equal(20.0, SIMD.float32x4.extractLane(c, 2));
-    equal(1.0, SIMD.float32x4.extractLane(c, 3));
-    c = SIMD.float32x4.replaceLane(a, 3, 20.0);
-    equal(16.0, SIMD.float32x4.extractLane(c, 0));
-    equal(9.0, SIMD.float32x4.extractLane(c, 1));
-    equal(4.0, SIMD.float32x4.extractLane(c, 2));
-    equal(20.0, SIMD.float32x4.extractLane(c, 3));
+test('Float32x4 replaceLane', function() {
+    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+    var c = SIMD.Float32x4.replaceLane(a, 0, 20.0);
+    equal(20.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+    c = SIMD.Float32x4.replaceLane(a, 1, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+    c = SIMD.Float32x4.replaceLane(a, 2, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
+    c = SIMD.Float32x4.replaceLane(a, 3, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 3));
 
     function testIndexCheck(index) {
-      throws(function() { SIMD.float32x4.replaceLane(a, index, 0.0); });
+      throws(function() { SIMD.Float32x4.replaceLane(a, index, 0.0); });
     }
     testIndexCheck(13.37);
     testIndexCheck(null);
@@ -727,168 +727,168 @@ test('float32x4 replaceLane', function() {
     testIndexCheck(8);
 });
 
-test('float32x4 comparisons', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 0.1, 0.001);
-  var n = SIMD.float32x4(2.0, 2.0, 0.001, 0.1);
+test('Float32x4 comparisons', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 0.1, 0.001);
+  var n = SIMD.Float32x4(2.0, 2.0, 0.001, 0.1);
   var cmp;
-  cmp = SIMD.float32x4.lessThan(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.lessThan(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.lessThanOrEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.lessThanOrEqual(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.equal(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.equal(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.notEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.notEqual(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.greaterThanOrEqual(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.greaterThanOrEqual(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.greaterThan(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.greaterThan(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  var o = SIMD.float32x4(0.0, -0.0, 0.0, NaN);
-  var p = SIMD.float32x4(-0.0, 0.0, NaN, 0.0);
-  cmp = SIMD.float32x4.lessThan(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  var o = SIMD.Float32x4(0.0, -0.0, 0.0, NaN);
+  var p = SIMD.Float32x4(-0.0, 0.0, NaN, 0.0);
+  cmp = SIMD.Float32x4.lessThan(o, p);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.lessThanOrEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.lessThanOrEqual(o, p);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.equal(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.equal(o, p);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.notEqual(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.notEqual(o, p);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.greaterThanOrEqual(o, p);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.greaterThanOrEqual(o, p);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.float32x4.greaterThan(o, p);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Float32x4.greaterThan(o, p);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 });
 
-test('float32x4 select', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
-  var t = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var f = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var s = SIMD.float32x4.select(m, t, f);
-  equal(1.0, SIMD.float32x4.extractLane(s, 0));
-  equal(2.0, SIMD.float32x4.extractLane(s, 1));
-  equal(7.0, SIMD.float32x4.extractLane(s, 2));
-  equal(8.0, SIMD.float32x4.extractLane(s, 3));
+test('Float32x4 select', function() {
+  var m = SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
+  var t = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var f = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var s = SIMD.Float32x4.select(m, t, f);
+  equal(1.0, SIMD.Float32x4.extractLane(s, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(s, 1));
+  equal(7.0, SIMD.Float32x4.extractLane(s, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(s, 3));
 });
 
-test('float32x4 selectBits', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
-  var t = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var f = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var s = SIMD.float32x4.selectBits(m, t, f);
-  equal(7.737125245533627e+25, SIMD.float32x4.extractLane(s, 0));
-  equal(3.0, SIMD.float32x4.extractLane(s, 1));
-  equal(7.0, SIMD.float32x4.extractLane(s, 2));
-  equal(2.0, SIMD.float32x4.extractLane(s, 3));
+test('Float32x4 selectBits', function() {
+  var m = SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
+  var t = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var f = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var s = SIMD.Float32x4.selectBits(m, t, f);
+  equal(7.737125245533627e+25, SIMD.Float32x4.extractLane(s, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(s, 1));
+  equal(7.0, SIMD.Float32x4.extractLane(s, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(s, 3));
 });
 
-test('float32x4 int32x4 bit conversion', function() {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var n = SIMD.float32x4.fromInt32x4Bits(m);
-  equal(1.0, SIMD.float32x4.extractLane(n, 0));
-  equal(2.0, SIMD.float32x4.extractLane(n, 1));
-  equal(3.0, SIMD.float32x4.extractLane(n, 2));
-  equal(4.0, SIMD.float32x4.extractLane(n, 3));
-  n = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  m = SIMD.int32x4.fromFloat32x4Bits(n);
-  equal(0x40A00000, SIMD.int32x4.extractLane(m, 0));
-  equal(0x40C00000, SIMD.int32x4.extractLane(m, 1));
-  equal(0x40E00000, SIMD.int32x4.extractLane(m, 2));
-  equal(0x41000000, SIMD.int32x4.extractLane(m, 3));
+test('Float32x4 Int32x4 bit conversion', function() {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var n = SIMD.Float32x4.fromInt32x4Bits(m);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
+  n = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  m = SIMD.Int32x4.fromFloat32x4Bits(n);
+  equal(0x40A00000, SIMD.Int32x4.extractLane(m, 0));
+  equal(0x40C00000, SIMD.Int32x4.extractLane(m, 1));
+  equal(0x40E00000, SIMD.Int32x4.extractLane(m, 2));
+  equal(0x41000000, SIMD.Int32x4.extractLane(m, 3));
   // Flip sign using bit-wise operators.
-  n = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  m = SIMD.int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
-  var nMask = SIMD.int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.float32x4.fromInt32x4Bits(nMask);
-  equal(-9.0, SIMD.float32x4.extractLane(n, 0));
-  equal(-10.0, SIMD.float32x4.extractLane(n, 1));
-  equal(-11.0, SIMD.float32x4.extractLane(n, 2));
-  equal(-12.0, SIMD.float32x4.extractLane(n, 3));
-  nMask = SIMD.int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.float32x4.fromInt32x4Bits(nMask);
-  equal(9.0, SIMD.float32x4.extractLane(n, 0));
-  equal(10.0, SIMD.float32x4.extractLane(n, 1));
-  equal(11.0, SIMD.float32x4.extractLane(n, 2));
-  equal(12.0, SIMD.float32x4.extractLane(n, 3));
+  n = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  m = SIMD.Int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  var nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
+  equal(-9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(-10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(-11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(-12.0, SIMD.Float32x4.extractLane(n, 3));
+  nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3));
   // Should stay unmodified across bit conversions
-  m = SIMD.int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
-  var m2 = SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.fromInt32x4Bits(m));
-  //equal(SIMD.float32x4.extractLane(m, 0), m2SIMD.float32x4.extractLane(m2, 0)); // FIXME: These get NaN-canonicalized
-  //equal(SIMD.float32x4.extractLane(m, 1), m2SIMD.float32x4.extractLane(m2, 1)); // FIXME: These get NaN-canonicalized
-  equal(SIMD.int32x4.extractLane(m, 2), SIMD.int32x4.extractLane(m2, 2));
-  equal(SIMD.int32x4.extractLane(m, 3), SIMD.int32x4.extractLane(m2, 3));
+  m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
+  var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
+  //equal(SIMD.Float32x4.extractLane(m, 0), m2SIMD.Float32x4.extractLane(m2, 0)); // FIXME: These get NaN-canonicalized
+  //equal(SIMD.Float32x4.extractLane(m, 1), m2SIMD.Float32x4.extractLane(m2, 1)); // FIXME: These get NaN-canonicalized
+  equal(SIMD.Int32x4.extractLane(m, 2), SIMD.Int32x4.extractLane(m2, 2));
+  equal(SIMD.Int32x4.extractLane(m, 3), SIMD.Int32x4.extractLane(m2, 3));
 });
 
-test('float32x4 float64x2 conversion', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.float64x2.fromFloat32x4(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float32x4 Float64x2 conversion', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.Float64x2.fromFloat32x4(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float32x4 load', function() {
+test('Float32x4 load', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.float32x4.load(a, i);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    equal(i+3, SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load(a, i);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 overaligned load', function() {
+test('Float32x4 overaligned load', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -896,15 +896,15 @@ test('float32x4 overaligned load', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i += 2) {
-    var v = SIMD.float32x4.load(af, i / 2);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    equal(i+3, SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load(af, i / 2);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 unaligned load', function() {
+test('Float32x4 unaligned load', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -919,29 +919,29 @@ test('float32x4 unaligned load', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.float32x4.load(b, i * 4 + 1);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    equal(i+3, SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load(b, i * 4 + 1);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 load1', function() {
+test('Float32x4 load1', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float32x4.load1(a, i);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load1(a, i);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 overaligned load1', function() {
+test('Float32x4 overaligned load1', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -949,15 +949,15 @@ test('float32x4 overaligned load1', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i += 2) {
-    var v = SIMD.float32x4.load1(af, i / 2);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load1(af, i / 2);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 unaligned load1', function() {
+test('Float32x4 unaligned load1', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -972,29 +972,29 @@ test('float32x4 unaligned load1', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float32x4.load1(b, i * 4 + 1);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load1(b, i * 4 + 1);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 load2', function() {
+test('Float32x4 load2', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float32x4.load2(a, i);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load2(a, i);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 overaligned load2', function() {
+test('Float32x4 overaligned load2', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -1002,15 +1002,15 @@ test('float32x4 overaligned load2', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i += 2) {
-    var v = SIMD.float32x4.load2(af, i / 2);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load2(af, i / 2);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 unaligned load2', function() {
+test('Float32x4 unaligned load2', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -1025,29 +1025,29 @@ test('float32x4 unaligned load2', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float32x4.load2(b, i * 4 + 1);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load2(b, i * 4 + 1);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 load3', function() {
+test('Float32x4 load3', function() {
   var a = new Float32Array(9);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.float32x4.load3(a, i);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load3(a, i);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 overaligned load3', function() {
+test('Float32x4 overaligned load3', function() {
   var b = new ArrayBuffer(48);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -1055,15 +1055,15 @@ test('float32x4 overaligned load3', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i += 2) {
-    var v = SIMD.float32x4.load3(af, i / 2);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load3(af, i / 2);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 unaligned load3', function() {
+test('Float32x4 unaligned load3', function() {
   var a = new Float32Array(9);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -1078,44 +1078,44 @@ test('float32x4 unaligned load3', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.float32x4.load3(b, i * 4 + 1);
-    equal(i, SIMD.float32x4.extractLane(v, 0));
-    equal(i+1, SIMD.float32x4.extractLane(v, 1));
-    equal(i+2, SIMD.float32x4.extractLane(v, 2));
-    isPositiveZero(SIMD.float32x4.extractLane(v, 3));
+    var v = SIMD.Float32x4.load3(b, i * 4 + 1);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    isPositiveZero(SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
-test('float32x4 store', function() {
+test('Float32x4 store', function() {
   var a = new Float32Array(12);
-  SIMD.float32x4.store(a, 0, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(a, 4, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(a, 8, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(a, 0, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(a, 4, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(a, 8, SIMD.Float32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.float32x4.equal(SIMD.float32x4.store(a, 0, v), v)));
+  var v = SIMD.Float32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Float32x4.equal(SIMD.Float32x4.store(a, 0, v), v)));
 });
 
-test('float32x4 overaligned store', function() {
+test('Float32x4 overaligned store', function() {
   var b = new ArrayBuffer(56);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.float32x4.store(af, 0, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(af, 2, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(af, 4, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(af, 0, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(af, 2, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(af, 4, SIMD.Float32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 unaligned store', function() {
+test('Float32x4 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.float32x4.store(c, 0 + 1, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(c, 16 + 1, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(c, 32 + 1, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(c, 0 + 1, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(c, 16 + 1, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(c, 32 + 1, SIMD.Float32x4(8, 9, 10, 11));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -1129,28 +1129,28 @@ test('float32x4 unaligned store', function() {
   }
 });
 
-test('float32x4 store1', function() {
+test('Float32x4 store1', function() {
   var a = new Float32Array(4);
-  SIMD.float32x4.store1(a, 0, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.store1(a, 1, SIMD.float32x4(1, -1, -1, -1));
-  SIMD.float32x4.store1(a, 2, SIMD.float32x4(2, -1, -1, -1));
-  SIMD.float32x4.store1(a, 3, SIMD.float32x4(3, -1, -1, -1));
+  SIMD.Float32x4.store1(a, 0, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.store1(a, 1, SIMD.Float32x4(1, -1, -1, -1));
+  SIMD.Float32x4.store1(a, 2, SIMD.Float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.store1(a, 3, SIMD.Float32x4(3, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.float32x4.equal(SIMD.float32x4.store1(a, 0, v), v)));
+  var v = SIMD.Float32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Float32x4.equal(SIMD.Float32x4.store1(a, 0, v), v)));
 });
 
-test('float32x4 overaligned store1', function() {
+test('Float32x4 overaligned store1', function() {
   var b = new ArrayBuffer(24);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[1] = -2;
   a[3] = -2;
-  SIMD.float32x4.store1(af, 0, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.store1(af, 1, SIMD.float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.store1(af, 0, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.store1(af, 1, SIMD.Float32x4(2, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 2 == 0) {
       equal(i, a[i]);
@@ -1160,12 +1160,12 @@ test('float32x4 overaligned store1', function() {
   }
 });
 
-test('float32x4 unaligned store1', function() {
+test('Float32x4 unaligned store1', function() {
   var c = new Int8Array(16 + 1);
-  SIMD.float32x4.store1(c, 0 + 1, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.store1(c, 4 + 1, SIMD.float32x4(1, -1, -1, -1));
-  SIMD.float32x4.store1(c, 8 + 1, SIMD.float32x4(2, -1, -1, -1));
-  SIMD.float32x4.store1(c, 12 + 1, SIMD.float32x4(3, -1, -1, -1));
+  SIMD.Float32x4.store1(c, 0 + 1, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.store1(c, 4 + 1, SIMD.Float32x4(1, -1, -1, -1));
+  SIMD.Float32x4.store1(c, 8 + 1, SIMD.Float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.store1(c, 12 + 1, SIMD.Float32x4(3, -1, -1, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -1179,39 +1179,39 @@ test('float32x4 unaligned store1', function() {
   }
 });
 
-test('float32x4 store2', function() {
+test('Float32x4 store2', function() {
   var a = new Float32Array(8);
-  SIMD.float32x4.store2(a, 0, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.store2(a, 2, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.store2(a, 4, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.store2(a, 6, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.store2(a, 0, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.store2(a, 2, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.store2(a, 4, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.store2(a, 6, SIMD.Float32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.float32x4.equal(SIMD.float32x4.store2(a, 0, v), v)));
+  var v = SIMD.Float32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Float32x4.equal(SIMD.Float32x4.store2(a, 0, v), v)));
 });
 
-test('float32x4 overaligned store2', function() {
+test('Float32x4 overaligned store2', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.float32x4.store2(af, 0, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.store2(af, 1, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.store2(af, 2, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.store2(af, 3, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.store2(af, 0, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.store2(af, 1, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.store2(af, 2, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.store2(af, 3, SIMD.Float32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 unaligned store2', function() {
+test('Float32x4 unaligned store2', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.float32x4.store2(c, 0 + 1, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.store2(c, 8 + 1, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.store2(c, 16 + 1, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.store2(c, 24 + 1, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.store2(c, 0 + 1, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.store2(c, 8 + 1, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.store2(c, 16 + 1, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.store2(c, 24 + 1, SIMD.Float32x4(6, 7, -1, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -1225,29 +1225,29 @@ test('float32x4 unaligned store2', function() {
   }
 });
 
-test('float32x4 store3', function() {
+test('Float32x4 store3', function() {
   var a = new Float32Array(9);
-  SIMD.float32x4.store3(a, 0, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.store3(a, 3, SIMD.float32x4(3, 4, 5, -1));
-  SIMD.float32x4.store3(a, 6, SIMD.float32x4(6, 7, 8, -1));
+  SIMD.Float32x4.store3(a, 0, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.store3(a, 3, SIMD.Float32x4(3, 4, 5, -1));
+  SIMD.Float32x4.store3(a, 6, SIMD.Float32x4(6, 7, 8, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.float32x4.equal(SIMD.float32x4.store3(a, 0, v), v)));
+  var v = SIMD.Float32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Float32x4.equal(SIMD.Float32x4.store3(a, 0, v), v)));
 });
 
-test('float32x4 overaligned store3', function() {
+test('Float32x4 overaligned store3', function() {
   var b = new ArrayBuffer(56);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[3] = -2;
   a[7] = -2;
   a[11] = -2;
-  SIMD.float32x4.store3(af, 0, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.store3(af, 2, SIMD.float32x4(4, 5, 6, -1));
-  SIMD.float32x4.store3(af, 4, SIMD.float32x4(8, 9, 10, -1));
+  SIMD.Float32x4.store3(af, 0, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.store3(af, 2, SIMD.Float32x4(4, 5, 6, -1));
+  SIMD.Float32x4.store3(af, 4, SIMD.Float32x4(8, 9, 10, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 4 != 3) {
       equal(i, a[i]);
@@ -1257,11 +1257,11 @@ test('float32x4 overaligned store3', function() {
   }
 });
 
-test('float32x4 unaligned store3', function() {
+test('Float32x4 unaligned store3', function() {
   var c = new Int8Array(36 + 1);
-  SIMD.float32x4.store3(c, 0 + 1, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.store3(c, 12 + 1, SIMD.float32x4(3, 4, 5, -1));
-  SIMD.float32x4.store3(c, 24 + 1, SIMD.float32x4(6, 7, 8, -1));
+  SIMD.Float32x4.store3(c, 0 + 1, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.store3(c, 12 + 1, SIMD.Float32x4(3, 4, 5, -1));
+  SIMD.Float32x4.store3(c, 24 + 1, SIMD.Float32x4(6, 7, 8, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -1275,514 +1275,514 @@ test('float32x4 unaligned store3', function() {
   }
 });
 
-test('float32x4 load exceptions', function () {
+test('Float32x4 load exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.load(a, -1);
+    var f = SIMD.Float32x4.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a, 5);
+    var f = SIMD.Float32x4.load(a, 5);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a.buffer, 1);
+    var f = SIMD.Float32x4.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a, "a");
+    var f = SIMD.Float32x4.load(a, "a");
   });
 });
 
-test('float32x4 load1 exceptions', function () {
+test('Float32x4 load1 exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.load1(a, -1);
+    var f = SIMD.Float32x4.load1(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load1(a, 8);
+    var f = SIMD.Float32x4.load1(a, 8);
   });
   throws(function () {
-    var f = SIMD.float32x4.load1(a.buffer, 1);
+    var f = SIMD.Float32x4.load1(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load1(a, "a");
+    var f = SIMD.Float32x4.load1(a, "a");
   });
 });
 
-test('float32x4 load2 exceptions', function () {
+test('Float32x4 load2 exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.load2(a, -1);
+    var f = SIMD.Float32x4.load2(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load2(a, 7);
+    var f = SIMD.Float32x4.load2(a, 7);
   });
   throws(function () {
-    var f = SIMD.float32x4.load2(a.buffer, 1);
+    var f = SIMD.Float32x4.load2(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load2(a, "a");
+    var f = SIMD.Float32x4.load2(a, "a");
   });
 });
 
-test('float32x4 load3 exceptions', function () {
+test('Float32x4 load3 exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.load3(a, -1);
+    var f = SIMD.Float32x4.load3(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load3(a, 6);
+    var f = SIMD.Float32x4.load3(a, 6);
   });
   throws(function () {
-    var f = SIMD.float32x4.load3(a.buffer, 1);
+    var f = SIMD.Float32x4.load3(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load3(a, "a");
+    var f = SIMD.Float32x4.load3(a, "a");
   });
 });
 
-test('float32x4 store exceptions', function () {
+test('Float32x4 store exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.store(a, -1, f);
+    SIMD.Float32x4.store(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, 5, f);
+    SIMD.Float32x4.store(a, 5, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a.buffer, 1, f);
+    SIMD.Float32x4.store(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, "a", f);
+    SIMD.Float32x4.store(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, 1, i);
+    SIMD.Float32x4.store(a, 1, i);
   });
 });
 
-test('float32x4 store1 exceptions', function () {
+test('Float32x4 store1 exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.store1(a, -1, f);
+    SIMD.Float32x4.store1(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.store1(a, 8, f);
+    SIMD.Float32x4.store1(a, 8, f);
   });
   throws(function () {
-    SIMD.float32x4.store1(a.buffer, 1, f);
+    SIMD.Float32x4.store1(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.store1(a, "a", f);
+    SIMD.Float32x4.store1(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.store1(a, 1, i);
+    SIMD.Float32x4.store1(a, 1, i);
   });
 });
 
-test('float32x4 store2 exceptions', function () {
+test('Float32x4 store2 exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.store2(a, -1, f);
+    SIMD.Float32x4.store2(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.store2(a, 7, f);
+    SIMD.Float32x4.store2(a, 7, f);
   });
   throws(function () {
-    SIMD.float32x4.store2(a.buffer, 1, f);
+    SIMD.Float32x4.store2(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.store2(a, "a", f);
+    SIMD.Float32x4.store2(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.store2(a, 1, i);
+    SIMD.Float32x4.store2(a, 1, i);
   });
 });
 
-test('float32x4 store3 exceptions', function () {
+test('Float32x4 store3 exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.store3(a, -1, f);
+    SIMD.Float32x4.store3(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.store3(a, 6, f);
+    SIMD.Float32x4.store3(a, 6, f);
   });
   throws(function () {
-    SIMD.float32x4.store3(a.buffer, 1, f);
+    SIMD.Float32x4.store3(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.store3(a, "a", f);
+    SIMD.Float32x4.store3(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.store3(a, 1, i);
+    SIMD.Float32x4.store3(a, 1, i);
   });
 });
 
-test('float64x2 constructor', function() {
-  equal('function', typeof SIMD.float64x2);
-  var m = SIMD.float64x2(1.0, 2.0);
-  equal(1.0, SIMD.float64x2.extractLane(m, 0));
-  equal(2.0, SIMD.float64x2.extractLane(m, 1));
+test('Float64x2 constructor', function() {
+  equal('function', typeof SIMD.Float64x2);
+  var m = SIMD.Float64x2(1.0, 2.0);
+  equal(1.0, SIMD.Float64x2.extractLane(m, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(m, 1));
 
-  m = SIMD.float64x2('hello', 'world');
-  isNaN(SIMD.float64x2.extractLane(m, 0))
-  isNaN(SIMD.float64x2.extractLane(m, 1))
+  m = SIMD.Float64x2('hello', 'world');
+  isNaN(SIMD.Float64x2.extractLane(m, 0))
+  isNaN(SIMD.Float64x2.extractLane(m, 1))
 });
 
-test('float64x2 splat constructor', function() {
-  equal('function', typeof SIMD.float64x2.splat);
-  var m = SIMD.float64x2.splat(3.0);
-  equal(3.0, SIMD.float64x2.extractLane(m, 0));
-  equal(SIMD.float64x2.extractLane(m, 0), SIMD.float64x2.extractLane(m, 1));
+test('Float64x2 splat constructor', function() {
+  equal('function', typeof SIMD.Float64x2.splat);
+  var m = SIMD.Float64x2.splat(3.0);
+  equal(3.0, SIMD.Float64x2.extractLane(m, 0));
+  equal(SIMD.Float64x2.extractLane(m, 0), SIMD.Float64x2.extractLane(m, 1));
 });
 
-test('float64x2 fromFloat32x4 constructor', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.float64x2.fromFloat32x4(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromFloat32x4 constructor', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.Float64x2.fromFloat32x4(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromInt32x4 constructor', function() {
-  var m = SIMD.int32x4(1, 2, 3, 4);
-  var n = SIMD.float64x2.fromInt32x4(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromInt32x4 constructor', function() {
+  var m = SIMD.Int32x4(1, 2, 3, 4);
+  var n = SIMD.Float64x2.fromInt32x4(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x3ff00000, 0x0000000, 0x40000000));
-  var n = SIMD.float64x2.fromFloat32x4Bits(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x3ff00000, 0x0000000, 0x40000000));
+  var n = SIMD.Float64x2.fromFloat32x4Bits(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromInt64x2Bits constructor', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000));
-  var n = SIMD.float64x2.fromInt64x2Bits(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromInt64x2Bits constructor', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000));
+  var n = SIMD.Float64x2.fromInt64x2Bits(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromInt32x4Bits constructor', function() {
-  var m = SIMD.int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000);
-  var n = SIMD.float64x2.fromInt32x4Bits(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromInt32x4Bits constructor', function() {
+  var m = SIMD.Int32x4(0x00000000, 0x3ff00000, 0x00000000, 0x40000000);
+  var n = SIMD.Float64x2.fromInt32x4Bits(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromInt16x8Bits constructor', function() {
-  var m = SIMD.int16x8(0x0000, 0x0000, 0x0000, 0x3ff0, 0x0000, 0x0000, 0x0000, 0x4000);
-  var n = SIMD.float64x2.fromInt16x8Bits(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromInt16x8Bits constructor', function() {
+  var m = SIMD.Int16x8(0x0000, 0x0000, 0x0000, 0x3ff0, 0x0000, 0x0000, 0x0000, 0x4000);
+  var n = SIMD.Float64x2.fromInt16x8Bits(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 fromInt8x16Bits constructor', function() {
-  var m = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40);
-  var n = SIMD.float64x2.fromInt8x16Bits(m);
-  equal(1.0, SIMD.float64x2.extractLane(n, 0));
-  equal(2.0, SIMD.float64x2.extractLane(n, 1));
+test('Float64x2 fromInt8x16Bits constructor', function() {
+  var m = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40);
+  var n = SIMD.Float64x2.fromInt8x16Bits(m);
+  equal(1.0, SIMD.Float64x2.extractLane(n, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(n, 1));
 });
 
-test('float64x2 scalar getters', function() {
-  var m = SIMD.float64x2(1.0, 2.0);
-  equal(1.0, SIMD.float64x2.extractLane(m, 0));
-  equal(2.0, SIMD.float64x2.extractLane(m, 1));
+test('Float64x2 scalar getters', function() {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  equal(1.0, SIMD.Float64x2.extractLane(m, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(m, 1));
 });
 
-test('float64x2 abs', function() {
-  var a = SIMD.float64x2(-2.0, -1.0);
-  var c = SIMD.float64x2.abs(a);
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
-  c = SIMD.float64x2.abs(SIMD.float64x2(2.0, 1.0));
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 abs', function() {
+  var a = SIMD.Float64x2(-2.0, -1.0);
+  var c = SIMD.Float64x2.abs(a);
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
+  c = SIMD.Float64x2.abs(SIMD.Float64x2(2.0, 1.0));
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var d0 = SIMD.float64x2(NaN, Infinity);
-  var d1 = SIMD.float64x2(0.0, 1.0);
-  var e0 = SIMD.float64x2.abs(d0);
-  var e1 = SIMD.float64x2.abs(d1);
-  var f0 = SIMD.float64x2(-NaN, -Infinity);
-  var f1 = SIMD.float64x2(-0.0, -1.0);
-  var g0 = SIMD.float64x2.abs(f0);
-  var g1 = SIMD.float64x2.abs(f1);
-  isNaN(SIMD.float64x2.extractLane(e0, 0))
-  equal(SIMD.float64x2.extractLane(e0, 1), Infinity);
-  isPositiveZero(SIMD.float64x2.extractLane(e1, 0), 0.0);
-  equal(SIMD.float64x2.extractLane(e1, 1), 1.0);
-  isNaN(SIMD.float64x2.extractLane(g0, 0))
-  equal(SIMD.float64x2.extractLane(g0, 1), Infinity);
-  isPositiveZero(SIMD.float64x2.extractLane(g1, 0));
-  equal(SIMD.float64x2.extractLane(g1, 1), 1.0);
+  var d0 = SIMD.Float64x2(NaN, Infinity);
+  var d1 = SIMD.Float64x2(0.0, 1.0);
+  var e0 = SIMD.Float64x2.abs(d0);
+  var e1 = SIMD.Float64x2.abs(d1);
+  var f0 = SIMD.Float64x2(-NaN, -Infinity);
+  var f1 = SIMD.Float64x2(-0.0, -1.0);
+  var g0 = SIMD.Float64x2.abs(f0);
+  var g1 = SIMD.Float64x2.abs(f1);
+  isNaN(SIMD.Float64x2.extractLane(e0, 0))
+  equal(SIMD.Float64x2.extractLane(e0, 1), Infinity);
+  isPositiveZero(SIMD.Float64x2.extractLane(e1, 0), 0.0);
+  equal(SIMD.Float64x2.extractLane(e1, 1), 1.0);
+  isNaN(SIMD.Float64x2.extractLane(g0, 0))
+  equal(SIMD.Float64x2.extractLane(g0, 1), Infinity);
+  isPositiveZero(SIMD.Float64x2.extractLane(g1, 0));
+  equal(SIMD.Float64x2.extractLane(g1, 1), 1.0);
 });
 
-test('float64x2 neg', function() {
-  var a = SIMD.float64x2(-2.0, -1.0);
-  var c = SIMD.float64x2.neg(a);
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
-  c = SIMD.float64x2.neg(SIMD.float64x2(2.0, 1.0));
-  equal(-2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(-1.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 neg', function() {
+  var a = SIMD.Float64x2(-2.0, -1.0);
+  var c = SIMD.Float64x2.neg(a);
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
+  c = SIMD.Float64x2.neg(SIMD.Float64x2(2.0, 1.0));
+  equal(-2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(-1.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var d0 = SIMD.float64x2(Infinity, -Infinity);
-  var d1 = SIMD.float64x2(0.0, -0.0);
-  var f0 = SIMD.float64x2.neg(d0);
-  var f1 = SIMD.float64x2.neg(d1);
-  equal(-Infinity, SIMD.float64x2.extractLane(f0, 0));
-  equal(Infinity, SIMD.float64x2.extractLane(f0, 1));
-  isNegativeZero(SIMD.float64x2.extractLane(f1, 0));
-  isPositiveZero(SIMD.float64x2.extractLane(f1, 1));
+  var d0 = SIMD.Float64x2(Infinity, -Infinity);
+  var d1 = SIMD.Float64x2(0.0, -0.0);
+  var f0 = SIMD.Float64x2.neg(d0);
+  var f1 = SIMD.Float64x2.neg(d1);
+  equal(-Infinity, SIMD.Float64x2.extractLane(f0, 0));
+  equal(Infinity, SIMD.Float64x2.extractLane(f0, 1));
+  isNegativeZero(SIMD.Float64x2.extractLane(f1, 0));
+  isPositiveZero(SIMD.Float64x2.extractLane(f1, 1));
 
-  var g = SIMD.float64x2.neg(SIMD.float64x2.splat(NaN));
-  isNaN(SIMD.float64x2.extractLane(g, 0))
+  var g = SIMD.Float64x2.neg(SIMD.Float64x2.splat(NaN));
+  isNaN(SIMD.Float64x2.extractLane(g, 0))
 });
 
-test('float64x2 add', function() {
-  var a = SIMD.float64x2(2.0, 1.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.add(a, b);
-  equal(12.0, SIMD.float64x2.extractLane(c, 0));
-  equal(21.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 add', function() {
+  var a = SIMD.Float64x2(2.0, 1.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.add(a, b);
+  equal(12.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(21.0, SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 sub', function() {
-  var a = SIMD.float64x2(2.0, 1.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.sub(a, b);
-  equal(-8.0, SIMD.float64x2.extractLane(c, 0));
-  equal(-19.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 sub', function() {
+  var a = SIMD.Float64x2(2.0, 1.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.sub(a, b);
+  equal(-8.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(-19.0, SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 mul', function() {
-  var a = SIMD.float64x2(2.0, 1.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.mul(a, b);
-  equal(20.0, SIMD.float64x2.extractLane(c, 0));
-  equal(20.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 mul', function() {
+  var a = SIMD.Float64x2(2.0, 1.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.mul(a, b);
+  equal(20.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(20.0, SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 div', function() {
-  var a = SIMD.float64x2(4.0, 9.0);
-  var b = SIMD.float64x2(2.0, 3.0);
-  var c = SIMD.float64x2.div(a, b);
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(3.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 div', function() {
+  var a = SIMD.Float64x2(4.0, 9.0);
+  var b = SIMD.Float64x2(2.0, 3.0);
+  var c = SIMD.Float64x2.div(a, b);
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var d0 = SIMD.float64x2(1.0, 0.0);
-  var d1 = SIMD.float64x2(Infinity, NaN);
-  var e0 = SIMD.float64x2(0.0, 0.0);
-  var e1 = SIMD.float64x2(Infinity, 1.0);
-  var f0 = SIMD.float64x2.div(d0, e0);
-  var f1 = SIMD.float64x2.div(d1, e1);
-  equal(SIMD.float64x2.extractLane(f0, 0), Infinity);
-  isNaN(SIMD.float64x2.extractLane(f0, 1))
-  isNaN(SIMD.float64x2.extractLane(f1, 0))
-  isNaN(SIMD.float64x2.extractLane(f1, 1))
+  var d0 = SIMD.Float64x2(1.0, 0.0);
+  var d1 = SIMD.Float64x2(Infinity, NaN);
+  var e0 = SIMD.Float64x2(0.0, 0.0);
+  var e1 = SIMD.Float64x2(Infinity, 1.0);
+  var f0 = SIMD.Float64x2.div(d0, e0);
+  var f1 = SIMD.Float64x2.div(d1, e1);
+  equal(SIMD.Float64x2.extractLane(f0, 0), Infinity);
+  isNaN(SIMD.Float64x2.extractLane(f0, 1))
+  isNaN(SIMD.Float64x2.extractLane(f1, 0))
+  isNaN(SIMD.Float64x2.extractLane(f1, 1))
 
-  var g0 = SIMD.float64x2(1.0, 1.0);
-  var g1 = SIMD.float64x2(-1.0, -1.0);
-  var h0 = SIMD.float64x2(0.0, -0.0);
-  var h1 = SIMD.float64x2(0.0, -0.0);
-  var i0 = SIMD.float64x2.div(g0, h0);
-  var i1 = SIMD.float64x2.div(g1, h1);
-  equal(SIMD.float64x2.extractLane(i0, 0), Infinity);
-  equal(SIMD.float64x2.extractLane(i0, 1), -Infinity);
-  equal(SIMD.float64x2.extractLane(i1, 0), -Infinity);
-  equal(SIMD.float64x2.extractLane(i1, 1), Infinity);
+  var g0 = SIMD.Float64x2(1.0, 1.0);
+  var g1 = SIMD.Float64x2(-1.0, -1.0);
+  var h0 = SIMD.Float64x2(0.0, -0.0);
+  var h1 = SIMD.Float64x2(0.0, -0.0);
+  var i0 = SIMD.Float64x2.div(g0, h0);
+  var i1 = SIMD.Float64x2.div(g1, h1);
+  equal(SIMD.Float64x2.extractLane(i0, 0), Infinity);
+  equal(SIMD.Float64x2.extractLane(i0, 1), -Infinity);
+  equal(SIMD.Float64x2.extractLane(i1, 0), -Infinity);
+  equal(SIMD.Float64x2.extractLane(i1, 1), Infinity);
 });
 
-test('float64x2 min', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var lower = SIMD.float64x2(2.0, 1.0);
-  var c = SIMD.float64x2.min(a, lower);
-  equal(-20.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 min', function() {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var lower = SIMD.Float64x2(2.0, 1.0);
+  var c = SIMD.Float64x2.min(a, lower);
+  equal(-20.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var x = SIMD.float64x2(-0, 0);
-  var y = SIMD.float64x2(0, -0);
-  var z = SIMD.float64x2.min(x, y);
-  isNegativeZero(SIMD.float64x2.extractLane(z, 0));
-  isNegativeZero(SIMD.float64x2.extractLane(z, 1));
-  x = SIMD.float64x2(NaN, 0);
-  y = SIMD.float64x2(0, NaN);
-  z = SIMD.float64x2.min(x, y);
-  isNaN(SIMD.float64x2.extractLane(z, 0))
-  isNaN(SIMD.float64x2.extractLane(z, 1))
+  var x = SIMD.Float64x2(-0, 0);
+  var y = SIMD.Float64x2(0, -0);
+  var z = SIMD.Float64x2.min(x, y);
+  isNegativeZero(SIMD.Float64x2.extractLane(z, 0));
+  isNegativeZero(SIMD.Float64x2.extractLane(z, 1));
+  x = SIMD.Float64x2(NaN, 0);
+  y = SIMD.Float64x2(0, NaN);
+  z = SIMD.Float64x2.min(x, y);
+  isNaN(SIMD.Float64x2.extractLane(z, 0))
+  isNaN(SIMD.Float64x2.extractLane(z, 1))
 });
 
-test('float64x2 minNum', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var lower = SIMD.float64x2(2.0, 1.0);
-  var c = SIMD.float64x2.minNum(a, lower);
-  equal(-20.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 minNum', function() {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var lower = SIMD.Float64x2(2.0, 1.0);
+  var c = SIMD.Float64x2.minNum(a, lower);
+  equal(-20.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var x = SIMD.float64x2(-0, 0);
-  var y = SIMD.float64x2(0, -0);
-  var z = SIMD.float64x2.minNum(x, y);
-  isNegativeZero(SIMD.float64x2.extractLane(z, 0));
-  isNegativeZero(SIMD.float64x2.extractLane(z, 1));
-  x = SIMD.float64x2(NaN, 0);
-  y = SIMD.float64x2(0, NaN);
-  z = SIMD.float64x2.minNum(x, y);
-  isPositiveZero(SIMD.float64x2.extractLane(z, 0));
-  isPositiveZero(SIMD.float64x2.extractLane(z, 1));
+  var x = SIMD.Float64x2(-0, 0);
+  var y = SIMD.Float64x2(0, -0);
+  var z = SIMD.Float64x2.minNum(x, y);
+  isNegativeZero(SIMD.Float64x2.extractLane(z, 0));
+  isNegativeZero(SIMD.Float64x2.extractLane(z, 1));
+  x = SIMD.Float64x2(NaN, 0);
+  y = SIMD.Float64x2(0, NaN);
+  z = SIMD.Float64x2.minNum(x, y);
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 0));
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 1));
 });
 
-test('float64x2 min exceptions', function() {
-  var ok    = SIMD.float64x2(1.0, 2.0);
+test('Float64x2 min exceptions', function() {
+  var ok    = SIMD.Float64x2(1.0, 2.0);
   var notOk = 1;
   throws(function() {
-    SIMD.float64x2.min(ok, notOk);
+    SIMD.Float64x2.min(ok, notOk);
   });
   throws(function() {
-    SIMD.float64x2.min(notOk, ok);
+    SIMD.Float64x2.min(notOk, ok);
   });
 });
 
-test('float64x2 max', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.max(a, upper);
-  equal(2.5, SIMD.float64x2.extractLane(c, 0));
-  equal(10.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 max', function() {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var upper = SIMD.Float64x2(2.5, 5.0);
+  var c = SIMD.Float64x2.max(a, upper);
+  equal(2.5, SIMD.Float64x2.extractLane(c, 0));
+  equal(10.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var x = SIMD.float64x2(-0, 0);
-  var y = SIMD.float64x2(0, -0);
-  var z = SIMD.float64x2.max(x, y);
-  isPositiveZero(SIMD.float64x2.extractLane(z, 0));
-  isPositiveZero(SIMD.float64x2.extractLane(z, 1));
-  x = SIMD.float64x2(NaN, 0);
-  y = SIMD.float64x2(0, NaN);
-  z = SIMD.float64x2.max(x, y);
-  isNaN(SIMD.float64x2.extractLane(z, 0))
-  isNaN(SIMD.float64x2.extractLane(z, 1))
+  var x = SIMD.Float64x2(-0, 0);
+  var y = SIMD.Float64x2(0, -0);
+  var z = SIMD.Float64x2.max(x, y);
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 0));
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 1));
+  x = SIMD.Float64x2(NaN, 0);
+  y = SIMD.Float64x2(0, NaN);
+  z = SIMD.Float64x2.max(x, y);
+  isNaN(SIMD.Float64x2.extractLane(z, 0))
+  isNaN(SIMD.Float64x2.extractLane(z, 1))
 });
 
-test('float64x2 maxNum', function() {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.maxNum(a, upper);
-  equal(2.5, SIMD.float64x2.extractLane(c, 0));
-  equal(10.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 maxNum', function() {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var upper = SIMD.Float64x2(2.5, 5.0);
+  var c = SIMD.Float64x2.maxNum(a, upper);
+  equal(2.5, SIMD.Float64x2.extractLane(c, 0));
+  equal(10.0, SIMD.Float64x2.extractLane(c, 1));
 
-  var x = SIMD.float64x2(-0, 0);
-  var y = SIMD.float64x2(0, -0);
-  var z = SIMD.float64x2.maxNum(x, y);
-  isPositiveZero(SIMD.float64x2.extractLane(z, 0));
-  isPositiveZero(SIMD.float64x2.extractLane(z, 1));
-  x = SIMD.float64x2(NaN, 0);
-  y = SIMD.float64x2(0, NaN);
-  z = SIMD.float64x2.maxNum(x, y);
-  isPositiveZero(SIMD.float64x2.extractLane(z, 0));
-  isPositiveZero(SIMD.float64x2.extractLane(z, 1));
+  var x = SIMD.Float64x2(-0, 0);
+  var y = SIMD.Float64x2(0, -0);
+  var z = SIMD.Float64x2.maxNum(x, y);
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 0));
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 1));
+  x = SIMD.Float64x2(NaN, 0);
+  y = SIMD.Float64x2(0, NaN);
+  z = SIMD.Float64x2.maxNum(x, y);
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 0));
+  isPositiveZero(SIMD.Float64x2.extractLane(z, 1));
 });
 
-test('float64x2 max exceptions', function() {
-  var ok    = SIMD.float64x2(1.0, 2.0);
+test('Float64x2 max exceptions', function() {
+  var ok    = SIMD.Float64x2(1.0, 2.0);
   var notOk = 1;
   throws(function() {
-    SIMD.float64x2.max(ok, notOk);
+    SIMD.Float64x2.max(ok, notOk);
   });
   throws(function() {
-    SIMD.float64x2.max(notOk, ok);
+    SIMD.Float64x2.max(notOk, ok);
   });
 });
 
-test('float64x2 reciprocal approximation', function() {
-  var a = SIMD.float64x2(2.0, -2.0);
-  var c = SIMD.float64x2.reciprocalApproximation(a);
-  almostEqual(0.5, SIMD.float64x2.extractLane(c, 0));
-  almostEqual(-0.5, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(NaN, Infinity);
-  c = SIMD.float64x2.reciprocalApproximation(a);
-  isNaN(SIMD.float64x2.extractLane(c, 0))
-  isPositiveZero(SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(-Infinity, -0);
-  c = SIMD.float64x2.reciprocalApproximation(a);
-  isNegativeZero(SIMD.float64x2.extractLane(c, 0));
-  equal(-Infinity, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(0, 2.3);
-  c = SIMD.float64x2.reciprocalApproximation(a);
-  equal(Infinity, SIMD.float64x2.extractLane(c, 0));
-  almostEqual(1/SIMD.float64x2.extractLane(a, 1), SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(-4.5, 7.8);
-  c = SIMD.float64x2.reciprocalApproximation(a);
-  almostEqual(1/SIMD.float64x2.extractLane(a, 0), SIMD.float64x2.extractLane(c, 0));
-  almostEqual(1/SIMD.float64x2.extractLane(a, 1), SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 reciprocal approximation', function() {
+  var a = SIMD.Float64x2(2.0, -2.0);
+  var c = SIMD.Float64x2.reciprocalApproximation(a);
+  almostEqual(0.5, SIMD.Float64x2.extractLane(c, 0));
+  almostEqual(-0.5, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(NaN, Infinity);
+  c = SIMD.Float64x2.reciprocalApproximation(a);
+  isNaN(SIMD.Float64x2.extractLane(c, 0))
+  isPositiveZero(SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(-Infinity, -0);
+  c = SIMD.Float64x2.reciprocalApproximation(a);
+  isNegativeZero(SIMD.Float64x2.extractLane(c, 0));
+  equal(-Infinity, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(0, 2.3);
+  c = SIMD.Float64x2.reciprocalApproximation(a);
+  equal(Infinity, SIMD.Float64x2.extractLane(c, 0));
+  almostEqual(1/SIMD.Float64x2.extractLane(a, 1), SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(-4.5, 7.8);
+  c = SIMD.Float64x2.reciprocalApproximation(a);
+  almostEqual(1/SIMD.Float64x2.extractLane(a, 0), SIMD.Float64x2.extractLane(c, 0));
+  almostEqual(1/SIMD.Float64x2.extractLane(a, 1), SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 reciprocal sqrt approximation', function() {
-  var a = SIMD.float64x2(1.0, 0.25);
-  var c = SIMD.float64x2.reciprocalSqrtApproximation(a);
-  almostEqual(1.0, SIMD.float64x2.extractLane(c, 0));
-  almostEqual(2.0, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(-Infinity, Infinity);
-  c = SIMD.float64x2.reciprocalSqrtApproximation(a);
-  isNaN(SIMD.float64x2.extractLane(c, 0))
-  isPositiveZero(SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(NaN, 0);
-  c = SIMD.float64x2.reciprocalSqrtApproximation(a);
-  isNaN(SIMD.float64x2.extractLane(c, 0))
-  equal(Infinity, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(-0, -1);
-  c = SIMD.float64x2.reciprocalSqrtApproximation(a);
-  equal(-Infinity, SIMD.float64x2.extractLane(c, 0));
-  isNaN(SIMD.float64x2.extractLane(c, 1))
-  a = SIMD.float64x2(121, 144);
-  c = SIMD.float64x2.reciprocalSqrtApproximation(a);
-  almostEqual(1/11, SIMD.float64x2.extractLane(c, 0));
-  almostEqual(1/12, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 reciprocal sqrt approximation', function() {
+  var a = SIMD.Float64x2(1.0, 0.25);
+  var c = SIMD.Float64x2.reciprocalSqrtApproximation(a);
+  almostEqual(1.0, SIMD.Float64x2.extractLane(c, 0));
+  almostEqual(2.0, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(-Infinity, Infinity);
+  c = SIMD.Float64x2.reciprocalSqrtApproximation(a);
+  isNaN(SIMD.Float64x2.extractLane(c, 0))
+  isPositiveZero(SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(NaN, 0);
+  c = SIMD.Float64x2.reciprocalSqrtApproximation(a);
+  isNaN(SIMD.Float64x2.extractLane(c, 0))
+  equal(Infinity, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(-0, -1);
+  c = SIMD.Float64x2.reciprocalSqrtApproximation(a);
+  equal(-Infinity, SIMD.Float64x2.extractLane(c, 0));
+  isNaN(SIMD.Float64x2.extractLane(c, 1))
+  a = SIMD.Float64x2(121, 144);
+  c = SIMD.Float64x2.reciprocalSqrtApproximation(a);
+  almostEqual(1/11, SIMD.Float64x2.extractLane(c, 0));
+  almostEqual(1/12, SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 sqrt', function() {
-  var a = SIMD.float64x2(16.0, 9.0);
-  var c = SIMD.float64x2.sqrt(a);
-  equal(4.0, SIMD.float64x2.extractLane(c, 0));
-  equal(3.0, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(0.0, -0.0);
-  c = SIMD.float64x2.sqrt(a);
-  isPositiveZero(SIMD.float64x2.extractLane(c, 0));
-  isNegativeZero(SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(Infinity, -Infinity);
-  c = SIMD.float64x2.sqrt(a);
-  equal(Infinity, SIMD.float64x2.extractLane(c, 0));
-  isNaN(SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(NaN, 2.0);
-  c = SIMD.float64x2.sqrt(a);
-  isNaN(SIMD.float64x2.extractLane(c, 0));
-  equal(Math.SQRT2, SIMD.float64x2.extractLane(c, 1));
-  a = SIMD.float64x2(0.5, 121.0);
-  c = SIMD.float64x2.sqrt(a);
-  equal(Math.SQRT1_2, SIMD.float64x2.extractLane(c, 0));
-  equal(11.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 sqrt', function() {
+  var a = SIMD.Float64x2(16.0, 9.0);
+  var c = SIMD.Float64x2.sqrt(a);
+  equal(4.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(0.0, -0.0);
+  c = SIMD.Float64x2.sqrt(a);
+  isPositiveZero(SIMD.Float64x2.extractLane(c, 0));
+  isNegativeZero(SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(Infinity, -Infinity);
+  c = SIMD.Float64x2.sqrt(a);
+  equal(Infinity, SIMD.Float64x2.extractLane(c, 0));
+  isNaN(SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(NaN, 2.0);
+  c = SIMD.Float64x2.sqrt(a);
+  isNaN(SIMD.Float64x2.extractLane(c, 0));
+  equal(Math.SQRT2, SIMD.Float64x2.extractLane(c, 1));
+  a = SIMD.Float64x2(0.5, 121.0);
+  c = SIMD.Float64x2.sqrt(a);
+  equal(Math.SQRT1_2, SIMD.Float64x2.extractLane(c, 0));
+  equal(11.0, SIMD.Float64x2.extractLane(c, 1));
 });
 
-test('float64x2 swizzle', function() {
-  var a  = SIMD.float64x2(1.0, 2.0);
-  var xx = SIMD.float64x2.swizzle(a, 0, 0);
-  var xy = SIMD.float64x2.swizzle(a, 0, 1);
-  var yx = SIMD.float64x2.swizzle(a, 1, 0);
-  var yy = SIMD.float64x2.swizzle(a, 1, 1);
-  equal(1.0, SIMD.float64x2.extractLane(xx, 0));
-  equal(1.0, SIMD.float64x2.extractLane(xx, 1));
-  equal(1.0, SIMD.float64x2.extractLane(xy, 0));
-  equal(2.0, SIMD.float64x2.extractLane(xy, 1));
-  equal(2.0, SIMD.float64x2.extractLane(yx, 0));
-  equal(1.0, SIMD.float64x2.extractLane(yx, 1));
-  equal(2.0, SIMD.float64x2.extractLane(yy, 0));
-  equal(2.0, SIMD.float64x2.extractLane(yy, 1));
+test('Float64x2 swizzle', function() {
+  var a  = SIMD.Float64x2(1.0, 2.0);
+  var xx = SIMD.Float64x2.swizzle(a, 0, 0);
+  var xy = SIMD.Float64x2.swizzle(a, 0, 1);
+  var yx = SIMD.Float64x2.swizzle(a, 1, 0);
+  var yy = SIMD.Float64x2.swizzle(a, 1, 1);
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(xy, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(xy, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(yx, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 1));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.float64x2.swizzle(a, index, 0); });
+      throws(function() { SIMD.Float64x2.swizzle(a, index, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -1794,37 +1794,37 @@ test('float64x2 swizzle', function() {
   testIndexCheck(2);
 });
 
-test('float64x2 shuffle', function() {
-  var a  = SIMD.float64x2(1.0, 2.0);
-  var b  = SIMD.float64x2(3.0, 4.0);
-  var xx = SIMD.float64x2.shuffle(a, b, 0, 2);
-  var xy = SIMD.float64x2.shuffle(a, b, 0, 3);
-  var yx = SIMD.float64x2.shuffle(a, b, 1, 0);
-  var yy = SIMD.float64x2.shuffle(a, b, 1, 3);
-  equal(1.0, SIMD.float64x2.extractLane(xx, 0));
-  equal(3.0, SIMD.float64x2.extractLane(xx, 1));
-  equal(1.0, SIMD.float64x2.extractLane(xy, 0));
-  equal(4.0, SIMD.float64x2.extractLane(xy, 1));
-  equal(2.0, SIMD.float64x2.extractLane(yx, 0));
-  equal(1.0, SIMD.float64x2.extractLane(yx, 1));
-  equal(2.0, SIMD.float64x2.extractLane(yy, 0));
-  equal(4.0, SIMD.float64x2.extractLane(yy, 1));
+test('Float64x2 shuffle', function() {
+  var a  = SIMD.Float64x2(1.0, 2.0);
+  var b  = SIMD.Float64x2(3.0, 4.0);
+  var xx = SIMD.Float64x2.shuffle(a, b, 0, 2);
+  var xy = SIMD.Float64x2.shuffle(a, b, 0, 3);
+  var yx = SIMD.Float64x2.shuffle(a, b, 1, 0);
+  var yy = SIMD.Float64x2.shuffle(a, b, 1, 3);
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(xx, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(xy, 0));
+  equal(4.0, SIMD.Float64x2.extractLane(xy, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(yx, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 0));
+  equal(4.0, SIMD.Float64x2.extractLane(yy, 1));
 
-  var c = SIMD.float64x2.shuffle(a, b, 1, 0);
-  var d = SIMD.float64x2.shuffle(a, b, 3, 2);
-  var e = SIMD.float64x2.shuffle(a, b, 0, 1);
-  var f = SIMD.float64x2.shuffle(a, b, 0, 2);
-  equal(2.0, SIMD.float64x2.extractLane(c, 0));
-  equal(1.0, SIMD.float64x2.extractLane(c, 1));
-  equal(4.0, SIMD.float64x2.extractLane(d, 0));
-  equal(3.0, SIMD.float64x2.extractLane(d, 1));
-  equal(1.0, SIMD.float64x2.extractLane(e, 0));
-  equal(2.0, SIMD.float64x2.extractLane(e, 1));
-  equal(1.0, SIMD.float64x2.extractLane(f, 0));
-  equal(3.0, SIMD.float64x2.extractLane(f, 1));
+  var c = SIMD.Float64x2.shuffle(a, b, 1, 0);
+  var d = SIMD.Float64x2.shuffle(a, b, 3, 2);
+  var e = SIMD.Float64x2.shuffle(a, b, 0, 1);
+  var f = SIMD.Float64x2.shuffle(a, b, 0, 2);
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
+  equal(4.0, SIMD.Float64x2.extractLane(d, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(d, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(e, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(e, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(f, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(f, 1));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.float64x2.shuffle(a, b, index, 0); });
+      throws(function() { SIMD.Float64x2.shuffle(a, b, index, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -1836,17 +1836,17 @@ test('float64x2 shuffle', function() {
   testIndexCheck(4);
 });
 
-test('float64x2 replaceLane', function() {
-    var a = SIMD.float64x2(16.0, 9.0);
-    var c = SIMD.float64x2.replaceLane(a, 0, 20.0);
-    equal(20.0, SIMD.float64x2.extractLane(c, 0));
-    equal(9.0, SIMD.float64x2.extractLane(c, 1));
-    c = SIMD.float64x2.replaceLane(a, 1, 20.0);
-    equal(16.0, SIMD.float64x2.extractLane(c, 0));
-    equal(20.0, SIMD.float64x2.extractLane(c, 1));
+test('Float64x2 replaceLane', function() {
+    var a = SIMD.Float64x2(16.0, 9.0);
+    var c = SIMD.Float64x2.replaceLane(a, 0, 20.0);
+    equal(20.0, SIMD.Float64x2.extractLane(c, 0));
+    equal(9.0, SIMD.Float64x2.extractLane(c, 1));
+    c = SIMD.Float64x2.replaceLane(a, 1, 20.0);
+    equal(16.0, SIMD.Float64x2.extractLane(c, 0));
+    equal(20.0, SIMD.Float64x2.extractLane(c, 1));
 
     function testIndexCheck(index) {
-      throws(function() { SIMD.float64x2.replaceLane(a, index, 0.0); });
+      throws(function() { SIMD.Float64x2.replaceLane(a, index, 0.0); });
     }
     testIndexCheck(13.37);
     testIndexCheck(null);
@@ -1858,135 +1858,135 @@ test('float64x2 replaceLane', function() {
     testIndexCheck(8);
 });
 
-test('float64x2 comparisons', function() {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
-  var o = SIMD.float64x2(0.1, 0.001);
-  var p = SIMD.float64x2(0.001, 0.1);
+test('Float64x2 comparisons', function() {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
+  var o = SIMD.Float64x2(0.1, 0.001);
+  var p = SIMD.Float64x2(0.001, 0.1);
 
   var cmp;
-  cmp = SIMD.float64x2.lessThan(m, n);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.lessThan(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThan(m, n);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThan(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.lessThanOrEqual(m, n);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.lessThanOrEqual(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThanOrEqual(m, n);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThanOrEqual(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.equal(m, n);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.equal(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.equal(m, n);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.equal(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.notEqual(m, n);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.notEqual(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.notEqual(m, n);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.notEqual(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.greaterThanOrEqual(m, n);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.greaterThanOrEqual(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThanOrEqual(m, n);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThanOrEqual(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.greaterThan(m, n);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.greaterThan(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThan(m, n);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThan(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  var o = SIMD.float64x2(0.0, -0.0);
-  var p = SIMD.float64x2(-0.0, 0.0);
-  var q = SIMD.float64x2(0.0, NaN);
-  var r = SIMD.float64x2(NaN, 0.0);
-  cmp = SIMD.float64x2.lessThan(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.lessThan(q, r);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  var o = SIMD.Float64x2(0.0, -0.0);
+  var p = SIMD.Float64x2(-0.0, 0.0);
+  var q = SIMD.Float64x2(0.0, NaN);
+  var r = SIMD.Float64x2(NaN, 0.0);
+  cmp = SIMD.Float64x2.lessThan(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThan(q, r);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.lessThanOrEqual(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.lessThanOrEqual(q, r);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThanOrEqual(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.lessThanOrEqual(q, r);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.equal(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.equal(q, r);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.equal(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.equal(q, r);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.notEqual(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.notEqual(q, r);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.notEqual(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.notEqual(q, r);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.greaterThanOrEqual(o, p);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.greaterThanOrEqual(q, r);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThanOrEqual(o, p);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThanOrEqual(q, r);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.float64x2.greaterThan(o, p);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
-  cmp = SIMD.float64x2.greaterThan(q, r);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThan(o, p);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Float64x2.greaterThan(q, r);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 });
 
-test('float64x2 select', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa,
+test('Float64x2 select', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa,
                                                     0x55555555, 0x55555555));
-  var t = SIMD.float64x2(1.0, 2.0);
-  var f = SIMD.float64x2(3.0, 4.0);
-  var s = SIMD.float64x2.select(m, t, f);
-  equal(1.0, SIMD.float64x2.extractLane(s, 0));
-  equal(4.0, SIMD.float64x2.extractLane(s, 1));
+  var t = SIMD.Float64x2(1.0, 2.0);
+  var f = SIMD.Float64x2(3.0, 4.0);
+  var s = SIMD.Float64x2.select(m, t, f);
+  equal(1.0, SIMD.Float64x2.extractLane(s, 0));
+  equal(4.0, SIMD.Float64x2.extractLane(s, 1));
 });
 
-test('float64x2 selectBits', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa,
+test('Float64x2 selectBits', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa,
                                                     0x55555555, 0x55555555));
-  var t = SIMD.float64x2(1.0, 2.0);
-  var f = SIMD.float64x2(3.0, 4.0);
-  var s = SIMD.float64x2.selectBits(m, t, f);
-  equal(4.013165208090495e+205, SIMD.float64x2.extractLane(s, 0));
-  equal(2.0, SIMD.float64x2.extractLane(s, 1));
+  var t = SIMD.Float64x2(1.0, 2.0);
+  var f = SIMD.Float64x2(3.0, 4.0);
+  var s = SIMD.Float64x2.selectBits(m, t, f);
+  equal(4.013165208090495e+205, SIMD.Float64x2.extractLane(s, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(s, 1));
 });
 
-test('float64x2 load', function() {
+test('Float64x2 load', function() {
   var a = new Float64Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float64x2.load(a, i);
-    equal(i, SIMD.float64x2.extractLane(v, 0));
-    equal(i+1, SIMD.float64x2.extractLane(v, 1));
+    var v = SIMD.Float64x2.load(a, i);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(i+1, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
-test('float64x2 unaligned load', function() {
+test('Float64x2 unaligned load', function() {
   var a = new Float64Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -2001,25 +2001,25 @@ test('float64x2 unaligned load', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float64x2.load(b, i * 8 + 1);
-    equal(i, SIMD.float64x2.extractLane(v, 0));
-    equal(i+1, SIMD.float64x2.extractLane(v, 1));
+    var v = SIMD.Float64x2.load(b, i * 8 + 1);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(i+1, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
-test('float64x2 load1', function() {
+test('Float64x2 load1', function() {
   var a = new Float64Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float64x2.load1(a, i);
-    equal(i, SIMD.float64x2.extractLane(v, 0));
-    isPositiveZero(SIMD.float64x2.extractLane(v, 1));
+    var v = SIMD.Float64x2.load1(a, i);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    isPositiveZero(SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
-test('float64x2 unaligned load1', function() {
+test('Float64x2 unaligned load1', function() {
   var a = new Float64Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -2034,30 +2034,30 @@ test('float64x2 unaligned load1', function() {
 
   // Copy the values unaligned.
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float64x2.load1(b, i * 8 + 1);
-    equal(i, SIMD.float64x2.extractLane(v, 0));
-    isPositiveZero(SIMD.float64x2.extractLane(v, 1));
+    var v = SIMD.Float64x2.load1(b, i * 8 + 1);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    isPositiveZero(SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
-test('float64x2 store', function() {
+test('Float64x2 store', function() {
   var a = new Float64Array(6);
-  SIMD.float64x2.store(a, 0, SIMD.float64x2(0, 1));
-  SIMD.float64x2.store(a, 2, SIMD.float64x2(2, 3));
-  SIMD.float64x2.store(a, 4, SIMD.float64x2(4, 5));
+  SIMD.Float64x2.store(a, 0, SIMD.Float64x2(0, 1));
+  SIMD.Float64x2.store(a, 2, SIMD.Float64x2(2, 3));
+  SIMD.Float64x2.store(a, 4, SIMD.Float64x2(4, 5));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float64x2(0, 1);
-  equal(true, SIMD.int64x2.allTrue(SIMD.float64x2.equal(SIMD.float64x2.store(a, 0, v), v)));
+  var v = SIMD.Float64x2(0, 1);
+  equal(true, SIMD.Int64x2.allTrue(SIMD.Float64x2.equal(SIMD.Float64x2.store(a, 0, v), v)));
 });
 
-test('float64x2 unaligned store', function() {
+test('Float64x2 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.float64x2.store(c, 0 + 1, SIMD.float64x2(0, 1));
-  SIMD.float64x2.store(c, 16 + 1, SIMD.float64x2(2, 3));
-  SIMD.float64x2.store(c, 32 + 1, SIMD.float64x2(4, 5));
+  SIMD.Float64x2.store(c, 0 + 1, SIMD.Float64x2(0, 1));
+  SIMD.Float64x2.store(c, 16 + 1, SIMD.Float64x2(2, 3));
+  SIMD.Float64x2.store(c, 32 + 1, SIMD.Float64x2(4, 5));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -2071,26 +2071,26 @@ test('float64x2 unaligned store', function() {
   }
 });
 
-test('float64x2 store1', function() {
+test('Float64x2 store1', function() {
   var a = new Float64Array(4);
-  SIMD.float64x2.store1(a, 0, SIMD.float64x2(0, -1));
-  SIMD.float64x2.store1(a, 1, SIMD.float64x2(1, -1));
-  SIMD.float64x2.store1(a, 2, SIMD.float64x2(2, -1));
-  SIMD.float64x2.store1(a, 3, SIMD.float64x2(3, -1));
+  SIMD.Float64x2.store1(a, 0, SIMD.Float64x2(0, -1));
+  SIMD.Float64x2.store1(a, 1, SIMD.Float64x2(1, -1));
+  SIMD.Float64x2.store1(a, 2, SIMD.Float64x2(2, -1));
+  SIMD.Float64x2.store1(a, 3, SIMD.Float64x2(3, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.float64x2(0, 1);
-  equal(true, SIMD.int64x2.allTrue(SIMD.float64x2.equal(SIMD.float64x2.store1(a, 0, v), v)));
+  var v = SIMD.Float64x2(0, 1);
+  equal(true, SIMD.Int64x2.allTrue(SIMD.Float64x2.equal(SIMD.Float64x2.store1(a, 0, v), v)));
 });
 
-test('float64x2 unaligned store1', function() {
+test('Float64x2 unaligned store1', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.float64x2.store1(c, 0 + 1, SIMD.float64x2(0, -1));
-  SIMD.float64x2.store1(c, 8 + 1, SIMD.float64x2(1, -1));
-  SIMD.float64x2.store1(c, 16 + 1, SIMD.float64x2(2, -1));
-  SIMD.float64x2.store1(c, 24 + 1, SIMD.float64x2(3, -1));
+  SIMD.Float64x2.store1(c, 0 + 1, SIMD.Float64x2(0, -1));
+  SIMD.Float64x2.store1(c, 8 + 1, SIMD.Float64x2(1, -1));
+  SIMD.Float64x2.store1(c, 16 + 1, SIMD.Float64x2(2, -1));
+  SIMD.Float64x2.store1(c, 24 + 1, SIMD.Float64x2(3, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -2104,189 +2104,189 @@ test('float64x2 unaligned store1', function() {
   }
 });
 
-test('float64x2 load exceptions', function () {
+test('Float64x2 load exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.float64x2.load(a, -1);
+    var f = SIMD.Float64x2.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a, 7);
+    var f = SIMD.Float64x2.load(a, 7);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a.buffer, 1);
+    var f = SIMD.Float64x2.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a, "a");
+    var f = SIMD.Float64x2.load(a, "a");
   });
 });
 
-test('float64x2 load1 exceptions', function () {
+test('Float64x2 load1 exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.float64x2.load1(a, -1);
+    var f = SIMD.Float64x2.load1(a, -1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load1(a, 8);
+    var f = SIMD.Float64x2.load1(a, 8);
   });
   throws(function () {
-    var f = SIMD.float64x2.load1(a.buffer, 1);
+    var f = SIMD.Float64x2.load1(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load1(a, "a");
+    var f = SIMD.Float64x2.load1(a, "a");
   });
 });
 
-test('float64x2 store exceptions', function () {
+test('Float64x2 store exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.float64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float64x2.store(a, -1, f);
+    SIMD.Float64x2.store(a, -1, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, 7, f);
+    SIMD.Float64x2.store(a, 7, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a.buffer, 1, f);
+    SIMD.Float64x2.store(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, "a", f);
+    SIMD.Float64x2.store(a, "a", f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, 1, i);
+    SIMD.Float64x2.store(a, 1, i);
   });
 });
 
-test('float64x2 store1 exceptions', function () {
+test('Float64x2 store1 exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.float64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float64x2.store1(a, -1, f);
+    SIMD.Float64x2.store1(a, -1, f);
   });
   throws(function () {
-    SIMD.float64x2.store1(a, 8, f);
+    SIMD.Float64x2.store1(a, 8, f);
   });
   throws(function () {
-    SIMD.float64x2.store1(a.buffer, 1, f);
+    SIMD.Float64x2.store1(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float64x2.store1(a, "a", f);
+    SIMD.Float64x2.store1(a, "a", f);
   });
   throws(function () {
-    SIMD.float64x2.store1(a, 1, i);
+    SIMD.Float64x2.store1(a, 1, i);
   });
 });
 
-test('int64x2 allTrue', function () {
-  var v0000 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
-  var v0001 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5));
-  var v0010 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
-  var v0100 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A));
-  var v1000 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
-  var v0011 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5));
-  var v0111 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
-  var v1111 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
-  equal(SIMD.int64x2.allTrue(v0000), false);
-  equal(SIMD.int64x2.allTrue(v0001), false);
-  equal(SIMD.int64x2.allTrue(v0010), false);
-  equal(SIMD.int64x2.allTrue(v0100), false);
-  equal(SIMD.int64x2.allTrue(v1000), false);
-  equal(SIMD.int64x2.allTrue(v0011), false);
-  equal(SIMD.int64x2.allTrue(v0111), false);
-  equal(SIMD.int64x2.allTrue(v1111), true);
+test('Int64x2 allTrue', function () {
+  var v0000 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v0001 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5));
+  var v0010 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  var v0100 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v1000 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v0011 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5));
+  var v0111 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
+  var v1111 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5));
+  equal(SIMD.Int64x2.allTrue(v0000), false);
+  equal(SIMD.Int64x2.allTrue(v0001), false);
+  equal(SIMD.Int64x2.allTrue(v0010), false);
+  equal(SIMD.Int64x2.allTrue(v0100), false);
+  equal(SIMD.Int64x2.allTrue(v1000), false);
+  equal(SIMD.Int64x2.allTrue(v0011), false);
+  equal(SIMD.Int64x2.allTrue(v0111), false);
+  equal(SIMD.Int64x2.allTrue(v1111), true);
 });
 
-test('int64x2 fromFloat64x2Bits constructor', function() {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.int64x2.fromFloat64x2Bits(m);
-  var v = SIMD.int32x4.fromInt64x2Bits(n);
-  equal(0x00000000, SIMD.int32x4.extractLane(v, 0));
-  equal(0x3FF00000, SIMD.int32x4.extractLane(v, 1));
-  equal(0x00000000, SIMD.int32x4.extractLane(v, 2));
-  equal(0x40000000, SIMD.int32x4.extractLane(v, 3));
+test('Int64x2 fromFloat64x2Bits constructor', function() {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Int64x2.fromFloat64x2Bits(m);
+  var v = SIMD.Int32x4.fromInt64x2Bits(n);
+  equal(0x00000000, SIMD.Int32x4.extractLane(v, 0));
+  equal(0x3FF00000, SIMD.Int32x4.extractLane(v, 1));
+  equal(0x00000000, SIMD.Int32x4.extractLane(v, 2));
+  equal(0x40000000, SIMD.Int32x4.extractLane(v, 3));
 });
 
-test('int64x2 anyTrue', function () {
-  var v00 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
-  var v01 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
-  var v10 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
-  var v11 = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
-  equal(SIMD.int64x2.anyTrue(v00), false);
-  equal(SIMD.int64x2.anyTrue(v01), true);
-  equal(SIMD.int64x2.anyTrue(v10), true);
-  equal(SIMD.int64x2.anyTrue(v11), true);
+test('Int64x2 anyTrue', function () {
+  var v00 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v01 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  var v10 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A));
+  var v11 = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x80000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A));
+  equal(SIMD.Int64x2.anyTrue(v00), false);
+  equal(SIMD.Int64x2.anyTrue(v01), true);
+  equal(SIMD.Int64x2.anyTrue(v10), true);
+  equal(SIMD.Int64x2.anyTrue(v11), true);
 });
 
-test('int64x2 and', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA));
-  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
-  var o = SIMD.int64x2.and(m,n);  // and
-  var p = SIMD.int32x4.fromInt64x2Bits(o);
-  equal(0x0, SIMD.int32x4.extractLane(p, 0));
-  equal(0x0, SIMD.int32x4.extractLane(p, 1));
-  equal(0x0, SIMD.int32x4.extractLane(p, 2));
-  equal(0x0, SIMD.int32x4.extractLane(p, 3));
-  equal(false, SIMD.int64x2.extractLaneAsBool(o, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(o, 1));
+test('Int64x2 and', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA));
+  var n = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.Int64x2.and(m,n);  // and
+  var p = SIMD.Int32x4.fromInt64x2Bits(o);
+  equal(0x0, SIMD.Int32x4.extractLane(p, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(p, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(p, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(p, 3));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(o, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(o, 1));
 });
 
-test('int64x2 or', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
-  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
-  var o = SIMD.int64x2.or(m,n);  // or
-  var p = SIMD.int32x4.fromInt64x2Bits(o);
-  equal(-1, SIMD.int32x4.extractLane(p, 0));
-  equal(-1, SIMD.int32x4.extractLane(p, 1));
-  equal(-1, SIMD.int32x4.extractLane(p, 2));
-  equal(-1, SIMD.int32x4.extractLane(p, 3));
-  equal(true, SIMD.int64x2.extractLaneAsBool(o, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(o, 1));
+test('Int64x2 or', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
+  var n = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.Int64x2.or(m,n);  // or
+  var p = SIMD.Int32x4.fromInt64x2Bits(o);
+  equal(-1, SIMD.Int32x4.extractLane(p, 0));
+  equal(-1, SIMD.Int32x4.extractLane(p, 1));
+  equal(-1, SIMD.Int32x4.extractLane(p, 2));
+  equal(-1, SIMD.Int32x4.extractLane(p, 3));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(o, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(o, 1));
 });
 
-test('int64x2 xor', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
-  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
-  var o = SIMD.int64x2.xor(m,n);  // xor
-  var p = SIMD.int32x4.fromInt64x2Bits(o);
-  equal(-1, SIMD.int32x4.extractLane(p, 0));
-  equal(-1, SIMD.int32x4.extractLane(p, 1));
-  equal(-1, SIMD.int32x4.extractLane(p, 2));
-  equal(-1, SIMD.int32x4.extractLane(p, 3));
-  equal(true, SIMD.int64x2.extractLaneAsBool(o, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(o, 1));
+test('Int64x2 xor', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA));
+  var n = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555));
+  var o = SIMD.Int64x2.xor(m,n);  // xor
+  var p = SIMD.Int32x4.fromInt64x2Bits(o);
+  equal(-1, SIMD.Int32x4.extractLane(p, 0));
+  equal(-1, SIMD.Int32x4.extractLane(p, 1));
+  equal(-1, SIMD.Int32x4.extractLane(p, 2));
+  equal(-1, SIMD.Int32x4.extractLane(p, 3));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(o, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(o, 1));
 });
 
-test('int64x2 comparisons', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(1000, 2000, 100, 100));
-  var n = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(-2000, 2000, 100, 100));
+test('Int64x2 comparisons', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(1000, 2000, 100, 100));
+  var n = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(-2000, 2000, 100, 100));
   var cmp;
 
-  cmp = SIMD.int64x2.equal(m, n);
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Int64x2.equal(m, n);
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 
-  cmp = SIMD.int64x2.notEqual(m, n);
-  equal(true, SIMD.int64x2.extractLaneAsBool(cmp, 0));
-  equal(false, SIMD.int64x2.extractLaneAsBool(cmp, 1));
+  cmp = SIMD.Int64x2.notEqual(m, n);
+  equal(true, SIMD.Int64x2.extractLaneAsBool(cmp, 0));
+  equal(false, SIMD.Int64x2.extractLaneAsBool(cmp, 1));
 });
 
-test('int64x2 load', function() {
+test('Int64x2 load', function() {
   var a = new Int32Array(16);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int64x2.load(a, i);
-    var w = SIMD.int32x4.fromInt64x2Bits(v);
-    equal(i, SIMD.int32x4.extractLane(w, 0));
-    equal(i+1, SIMD.int32x4.extractLane(w, 1));
-    equal(i+2, SIMD.int32x4.extractLane(w, 2));
-    equal(i+3, SIMD.int32x4.extractLane(w, 3));
+    var v = SIMD.Int64x2.load(a, i);
+    var w = SIMD.Int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.Int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(w, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(w, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(w, 3));
   }
 });
 
-test('int64x2 unaligned load', function() {
+test('Int64x2 unaligned load', function() {
   var a = new Int32Array(16);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -2301,31 +2301,31 @@ test('int64x2 unaligned load', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int64x2.load(b, i * 4 + 1);
-    var w = SIMD.int32x4.fromInt64x2Bits(v);
-    equal(i, SIMD.int32x4.extractLane(w, 0));
-    equal(i+1, SIMD.int32x4.extractLane(w, 1));
-    equal(i+2, SIMD.int32x4.extractLane(w, 2));
-    equal(i+3, SIMD.int32x4.extractLane(w, 3));
+    var v = SIMD.Int64x2.load(b, i * 4 + 1);
+    var w = SIMD.Int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.Int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(w, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(w, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(w, 3));
   }
 });
 
-test('int64x2 load1', function() {
+test('Int64x2 load1', function() {
   var a = new Int32Array(16);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int64x2.load1(a, i);
-    var w = SIMD.int32x4.fromInt64x2Bits(v);
-    equal(i, SIMD.int32x4.extractLane(w, 0));
-    equal(i+1, SIMD.int32x4.extractLane(w, 1));
-    isPositiveZero(SIMD.int32x4.extractLane(w, 2));
-    isPositiveZero(SIMD.int32x4.extractLane(w, 3));
+    var v = SIMD.Int64x2.load1(a, i);
+    var w = SIMD.Int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.Int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(w, 1));
+    isPositiveZero(SIMD.Int32x4.extractLane(w, 2));
+    isPositiveZero(SIMD.Int32x4.extractLane(w, 3));
   }
 });
 
-test('int64x2 unaligned load1', function() {
+test('Int64x2 unaligned load1', function() {
   var a = new Int32Array(16);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -2340,30 +2340,30 @@ test('int64x2 unaligned load1', function() {
 
   // Copy the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int64x2.load1(b, i * 4 + 1);
-    var w = SIMD.int32x4.fromInt64x2Bits(v);
-    equal(i, SIMD.int32x4.extractLane(w, 0));
-    equal(i+1, SIMD.int32x4.extractLane(w, 1));
-    isPositiveZero(SIMD.int32x4.extractLane(w, 2));
-    isPositiveZero(SIMD.int32x4.extractLane(w, 3));
+    var v = SIMD.Int64x2.load1(b, i * 4 + 1);
+    var w = SIMD.Int32x4.fromInt64x2Bits(v);
+    equal(i, SIMD.Int32x4.extractLane(w, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(w, 1));
+    isPositiveZero(SIMD.Int32x4.extractLane(w, 2));
+    isPositiveZero(SIMD.Int32x4.extractLane(w, 3));
   }
 });
 
-test('int64x2 store', function() {
+test('Int64x2 store', function() {
   var a = new Int32Array(12);
-  SIMD.int64x2.store(a, 0, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3)));
-  SIMD.int64x2.store(a, 4, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, 6, 7)));
-  SIMD.int64x2.store(a, 8, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(8, 9, 10, 11)));
+  SIMD.Int64x2.store(a, 0, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0, 1, 2, 3)));
+  SIMD.Int64x2.store(a, 4, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(4, 5, 6, 7)));
+  SIMD.Int64x2.store(a, 8, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(8, 9, 10, 11)));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int64x2 unaligned store', function() {
+test('Int64x2 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.int64x2.store(c, 0 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3)));
-  SIMD.int64x2.store(c, 16 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, 6, 7)));
-  SIMD.int64x2.store(c, 32 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(8, 9, 10, 11)));
+  SIMD.Int64x2.store(c, 0 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0, 1, 2, 3)));
+  SIMD.Int64x2.store(c, 16 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(4, 5, 6, 7)));
+  SIMD.Int64x2.store(c, 32 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(8, 9, 10, 11)));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -2377,23 +2377,23 @@ test('int64x2 unaligned store', function() {
   }
 });
 
-test('int64x2 store1', function() {
+test('Int64x2 store1', function() {
   var a = new Int32Array(8);
-  SIMD.int64x2.store1(a, 0, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, -1, -1)));
-  SIMD.int64x2.store1(a, 2, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(2, 3, -1, -1)));
-  SIMD.int64x2.store1(a, 4, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, -1, -1)));
-  SIMD.int64x2.store1(a, 6, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(6, 7, -1, -1)));
+  SIMD.Int64x2.store1(a, 0, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0, 1, -1, -1)));
+  SIMD.Int64x2.store1(a, 2, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(2, 3, -1, -1)));
+  SIMD.Int64x2.store1(a, 4, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(4, 5, -1, -1)));
+  SIMD.Int64x2.store1(a, 6, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(6, 7, -1, -1)));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int64x2 unaligned store1', function() {
+test('Int64x2 unaligned store1', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.int64x2.store1(c, 0 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, -1, -1)));
-  SIMD.int64x2.store1(c, 8 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(2, 3, -1, -1)));
-  SIMD.int64x2.store1(c, 16 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(4, 5, -1, -1)));
-  SIMD.int64x2.store1(c, 24 + 1, SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(6, 7, -1, -1)));
+  SIMD.Int64x2.store1(c, 0 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0, 1, -1, -1)));
+  SIMD.Int64x2.store1(c, 8 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(2, 3, -1, -1)));
+  SIMD.Int64x2.store1(c, 16 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(4, 5, -1, -1)));
+  SIMD.Int64x2.store1(c, 24 + 1, SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(6, 7, -1, -1)));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -2407,216 +2407,216 @@ test('int64x2 unaligned store1', function() {
   }
 });
 
-test('int64x2 load exceptions', function () {
+test('Int64x2 load exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.int64x2.load(a, -1);
+    var f = SIMD.Int64x2.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.int64x2.load(a, 7);
+    var f = SIMD.Int64x2.load(a, 7);
   });
   throws(function () {
-    var f = SIMD.int64x2.load(a.buffer, 1);
+    var f = SIMD.Int64x2.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int64x2.load(a, "a");
+    var f = SIMD.Int64x2.load(a, "a");
   });
 });
 
-test('int64x2 load1 exceptions', function () {
+test('Int64x2 load1 exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.int64x2.load1(a, -1);
+    var f = SIMD.Int64x2.load1(a, -1);
   });
   throws(function () {
-    var f = SIMD.int64x2.load1(a, 8);
+    var f = SIMD.Int64x2.load1(a, 8);
   });
   throws(function () {
-    var f = SIMD.int64x2.load1(a.buffer, 1);
+    var f = SIMD.Int64x2.load1(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int64x2.load1(a, "a");
+    var f = SIMD.Int64x2.load1(a, "a");
   });
 });
 
-test('int64x2 store exceptions', function () {
+test('Int64x2 store exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.int64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Int64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int64x2.store(a, -1, f);
+    SIMD.Int64x2.store(a, -1, f);
   });
   throws(function () {
-    SIMD.int64x2.store(a, 7, f);
+    SIMD.Int64x2.store(a, 7, f);
   });
   throws(function () {
-    SIMD.int64x2.store(a.buffer, 1, f);
+    SIMD.Int64x2.store(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.int64x2.store(a, "a", f);
+    SIMD.Int64x2.store(a, "a", f);
   });
   throws(function () {
-    SIMD.int64x2.store(a, 1, i);
+    SIMD.Int64x2.store(a, 1, i);
   });
 });
 
-test('int64x2 store1 exceptions', function () {
+test('Int64x2 store1 exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.int64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Int64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int64x2.store1(a, -1, f);
-  });
-  throws(function () {
-    SIMD.int64x2.store1(a, 8, f);
+    SIMD.Int64x2.store1(a, -1, f);
   });
   throws(function () {
-    SIMD.int64x2.store1(a.buffer, 1, f);
+    SIMD.Int64x2.store1(a, 8, f);
   });
   throws(function () {
-    SIMD.int64x2.store1(a, "a", f);
+    SIMD.Int64x2.store1(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.int64x2.store1(a, 1, i);
+    SIMD.Int64x2.store1(a, "a", f);
+  });
+  throws(function () {
+    SIMD.Int64x2.store1(a, 1, i);
   });
 });
 
-test('int32x4 fromFloat32x4 constructor', function() {
-  var m = SIMD.float32x4(1.0, 2.2, 3.6, 4.8);
-  var n = SIMD.int32x4.fromFloat32x4(m);
-  equal(1, SIMD.int32x4.extractLane(n, 0));
-  equal(2, SIMD.int32x4.extractLane(n, 1));
-  equal(3, SIMD.int32x4.extractLane(n, 2));
-  equal(4, SIMD.int32x4.extractLane(n, 3));
+test('Int32x4 fromFloat32x4 constructor', function() {
+  var m = SIMD.Float32x4(1.0, 2.2, 3.6, 4.8);
+  var n = SIMD.Int32x4.fromFloat32x4(m);
+  equal(1, SIMD.Int32x4.extractLane(n, 0));
+  equal(2, SIMD.Int32x4.extractLane(n, 1));
+  equal(3, SIMD.Int32x4.extractLane(n, 2));
+  equal(4, SIMD.Int32x4.extractLane(n, 3));
 
-  m = SIMD.float32x4(0.0, -0.0, -1.2, -3.8);
-  n = SIMD.int32x4.fromFloat32x4(m);
-  equal(0, SIMD.int32x4.extractLane(n, 0));
-  equal(0, SIMD.int32x4.extractLane(n, 1));
-  equal(-1, SIMD.int32x4.extractLane(n, 2));
-  equal(-3, SIMD.int32x4.extractLane(n, 3));
-
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0x7fffffff, 0, 0, 0));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, -0x80000081, 0, 0));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, 2147483648, 0));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, 0, -2147483904));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(Infinity, 0, 0, 0));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, -Infinity, 0, 0));
-  });
-  throws(function() {
-    SIMD.int32x4.fromFloat32x4(SIMD.float32x4(0, 0, NaN, 0));
-  });
-});
-
-test('int32x4 fromFloat64x2 constructor', function() {
-  var m = SIMD.float64x2(1.0, 2.2);
-  var n = SIMD.int32x4.fromFloat64x2(m);
-  equal(1, SIMD.int32x4.extractLane(n, 0));
-  equal(2, SIMD.int32x4.extractLane(n, 1));
-  equal(0, SIMD.int32x4.extractLane(n, 2));
-  equal(0, SIMD.int32x4.extractLane(n, 3));
-
-  m = SIMD.float64x2(3.6, 4.8);
-  n = SIMD.int32x4.fromFloat64x2(m);
-  equal(3, SIMD.int32x4.extractLane(n, 0));
-  equal(4, SIMD.int32x4.extractLane(n, 1));
-  equal(0, SIMD.int32x4.extractLane(n, 2));
-  equal(0, SIMD.int32x4.extractLane(n, 3));
-
-  m = SIMD.float64x2(0.0, -0.0);
-  n = SIMD.int32x4.fromFloat64x2(m);
-  equal(0, SIMD.int32x4.extractLane(n, 0));
-  equal(0, SIMD.int32x4.extractLane(n, 1));
-  equal(0, SIMD.int32x4.extractLane(n, 2));
-  equal(0, SIMD.int32x4.extractLane(n, 3));
-
-  m = SIMD.float64x2(-1.2, -3.8);
-  n = SIMD.int32x4.fromFloat64x2(m);
-  equal(-1, SIMD.int32x4.extractLane(n, 0));
-  equal(-3, SIMD.int32x4.extractLane(n, 1));
-  equal(0, SIMD.int32x4.extractLane(n, 2));
-  equal(0, SIMD.int32x4.extractLane(n, 3));
-
-  m = SIMD.float64x2(2147483647.9, -2147483648.9);
-  n = SIMD.int32x4.fromFloat64x2(m);
-  equal(2147483647, SIMD.int32x4.extractLane(n, 0));
-  equal(-2147483648, SIMD.int32x4.extractLane(n, 1));
+  m = SIMD.Float32x4(0.0, -0.0, -1.2, -3.8);
+  n = SIMD.Int32x4.fromFloat32x4(m);
+  equal(0, SIMD.Int32x4.extractLane(n, 0));
+  equal(0, SIMD.Int32x4.extractLane(n, 1));
+  equal(-1, SIMD.Int32x4.extractLane(n, 2));
+  equal(-3, SIMD.Int32x4.extractLane(n, 3));
 
   throws(function() {
-    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0x80000000, 0));
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0x7fffffff, 0, 0, 0));
   });
   throws(function() {
-    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0, -0x80000001));
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, -0x80000081, 0, 0));
   });
   throws(function() {
-    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(Infinity, 0));
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, 2147483648, 0));
   });
   throws(function() {
-    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(0, -Infinity));
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, 0, -2147483904));
   });
   throws(function() {
-    SIMD.int32x4.fromFloat64x2(SIMD.float64x2(NaN, 0));
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(Infinity, 0, 0, 0));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, -Infinity, 0, 0));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat32x4(SIMD.Float32x4(0, 0, NaN, 0));
   });
 });
 
-test('int32x4 fromInt64x2Bits constructor', function() {
-  var m = SIMD.int64x2.fromInt32x4Bits(SIMD.int32x4(0, 1, 2, 3));
-  var n = SIMD.int32x4.fromInt64x2Bits(m);
-  equal(0, SIMD.int32x4.extractLane(n, 0));
-  equal(1, SIMD.int32x4.extractLane(n, 1));
-  equal(2, SIMD.int32x4.extractLane(n, 2));
-  equal(3, SIMD.int32x4.extractLane(n, 3));
+test('Int32x4 fromFloat64x2 constructor', function() {
+  var m = SIMD.Float64x2(1.0, 2.2);
+  var n = SIMD.Int32x4.fromFloat64x2(m);
+  equal(1, SIMD.Int32x4.extractLane(n, 0));
+  equal(2, SIMD.Int32x4.extractLane(n, 1));
+  equal(0, SIMD.Int32x4.extractLane(n, 2));
+  equal(0, SIMD.Int32x4.extractLane(n, 3));
+
+  m = SIMD.Float64x2(3.6, 4.8);
+  n = SIMD.Int32x4.fromFloat64x2(m);
+  equal(3, SIMD.Int32x4.extractLane(n, 0));
+  equal(4, SIMD.Int32x4.extractLane(n, 1));
+  equal(0, SIMD.Int32x4.extractLane(n, 2));
+  equal(0, SIMD.Int32x4.extractLane(n, 3));
+
+  m = SIMD.Float64x2(0.0, -0.0);
+  n = SIMD.Int32x4.fromFloat64x2(m);
+  equal(0, SIMD.Int32x4.extractLane(n, 0));
+  equal(0, SIMD.Int32x4.extractLane(n, 1));
+  equal(0, SIMD.Int32x4.extractLane(n, 2));
+  equal(0, SIMD.Int32x4.extractLane(n, 3));
+
+  m = SIMD.Float64x2(-1.2, -3.8);
+  n = SIMD.Int32x4.fromFloat64x2(m);
+  equal(-1, SIMD.Int32x4.extractLane(n, 0));
+  equal(-3, SIMD.Int32x4.extractLane(n, 1));
+  equal(0, SIMD.Int32x4.extractLane(n, 2));
+  equal(0, SIMD.Int32x4.extractLane(n, 3));
+
+  m = SIMD.Float64x2(2147483647.9, -2147483648.9);
+  n = SIMD.Int32x4.fromFloat64x2(m);
+  equal(2147483647, SIMD.Int32x4.extractLane(n, 0));
+  equal(-2147483648, SIMD.Int32x4.extractLane(n, 1));
+
+  throws(function() {
+    SIMD.Int32x4.fromFloat64x2(SIMD.Float64x2(0x80000000, 0));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat64x2(SIMD.Float64x2(0, -0x80000001));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat64x2(SIMD.Float64x2(Infinity, 0));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat64x2(SIMD.Float64x2(0, -Infinity));
+  });
+  throws(function() {
+    SIMD.Int32x4.fromFloat64x2(SIMD.Float64x2(NaN, 0));
+  });
 });
 
-test('int32x4 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.int32x4.fromFloat32x4Bits(m);
-  equal(0x3F800000, SIMD.int32x4.extractLane(n, 0));
-  equal(0x40000000, SIMD.int32x4.extractLane(n, 1));
-  equal(0x40400000, SIMD.int32x4.extractLane(n, 2));
-  equal(0x40800000, SIMD.int32x4.extractLane(n, 3));
+test('Int32x4 fromInt64x2Bits constructor', function() {
+  var m = SIMD.Int64x2.fromInt32x4Bits(SIMD.Int32x4(0, 1, 2, 3));
+  var n = SIMD.Int32x4.fromInt64x2Bits(m);
+  equal(0, SIMD.Int32x4.extractLane(n, 0));
+  equal(1, SIMD.Int32x4.extractLane(n, 1));
+  equal(2, SIMD.Int32x4.extractLane(n, 2));
+  equal(3, SIMD.Int32x4.extractLane(n, 3));
 });
 
-test('int32x4 fromFloat64x2Bits constructor', function() {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.int32x4.fromFloat64x2Bits(m);
-  equal(0x00000000, SIMD.int32x4.extractLane(n, 0));
-  equal(0x3FF00000, SIMD.int32x4.extractLane(n, 1));
-  equal(0x00000000, SIMD.int32x4.extractLane(n, 2));
-  equal(0x40000000, SIMD.int32x4.extractLane(n, 3));
+test('Int32x4 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.Int32x4.fromFloat32x4Bits(m);
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0));
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1));
+  equal(0x40400000, SIMD.Int32x4.extractLane(n, 2));
+  equal(0x40800000, SIMD.Int32x4.extractLane(n, 3));
 });
 
-test('int32x4 swizzle', function() {
-  var a    = SIMD.int32x4(1, 2, 3, 2147483647);
-  var xyxy = SIMD.int32x4.swizzle(a, 0, 1, 0, 1);
-  var zwzw = SIMD.int32x4.swizzle(a, 2, 3, 2, 3);
-  var xxxx = SIMD.int32x4.swizzle(a, 0, 0, 0, 0);
-  equal(1, SIMD.int32x4.extractLane(xyxy, 0));
-  equal(2, SIMD.int32x4.extractLane(xyxy, 1));
-  equal(1, SIMD.int32x4.extractLane(xyxy, 2));
-  equal(2, SIMD.int32x4.extractLane(xyxy, 3));
-  equal(3, SIMD.int32x4.extractLane(zwzw, 0));
-  equal(2147483647, SIMD.int32x4.extractLane(zwzw, 1));
-  equal(3, SIMD.int32x4.extractLane(zwzw, 2));
-  equal(2147483647, SIMD.int32x4.extractLane(zwzw, 3));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 0));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 1));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 2));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 3));
+test('Int32x4 fromFloat64x2Bits constructor', function() {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Int32x4.fromFloat64x2Bits(m);
+  equal(0x00000000, SIMD.Int32x4.extractLane(n, 0));
+  equal(0x3FF00000, SIMD.Int32x4.extractLane(n, 1));
+  equal(0x00000000, SIMD.Int32x4.extractLane(n, 2));
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 3));
+});
+
+test('Int32x4 swizzle', function() {
+  var a    = SIMD.Int32x4(1, 2, 3, 2147483647);
+  var xyxy = SIMD.Int32x4.swizzle(a, 0, 1, 0, 1);
+  var zwzw = SIMD.Int32x4.swizzle(a, 2, 3, 2, 3);
+  var xxxx = SIMD.Int32x4.swizzle(a, 0, 0, 0, 0);
+  equal(1, SIMD.Int32x4.extractLane(xyxy, 0));
+  equal(2, SIMD.Int32x4.extractLane(xyxy, 1));
+  equal(1, SIMD.Int32x4.extractLane(xyxy, 2));
+  equal(2, SIMD.Int32x4.extractLane(xyxy, 3));
+  equal(3, SIMD.Int32x4.extractLane(zwzw, 0));
+  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 1));
+  equal(3, SIMD.Int32x4.extractLane(zwzw, 2));
+  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 3));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 0));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 1));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 2));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 3));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int32x4.swizzle(a, index, 0, 0, 0); });
+      throws(function() { SIMD.Int32x4.swizzle(a, index, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -2628,43 +2628,43 @@ test('int32x4 swizzle', function() {
   testIndexCheck(4);
 });
 
-test('int32x4 shuffle', function() {
-  var a    = SIMD.int32x4(1, 2, 3, 4);
-  var b    = SIMD.int32x4(5, 6, 7, 2147483647);
-  var xyxy = SIMD.int32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.int32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.int32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1, SIMD.int32x4.extractLane(xyxy, 0));
-  equal(2, SIMD.int32x4.extractLane(xyxy, 1));
-  equal(5, SIMD.int32x4.extractLane(xyxy, 2));
-  equal(6, SIMD.int32x4.extractLane(xyxy, 3));
-  equal(3, SIMD.int32x4.extractLane(zwzw, 0));
-  equal(4, SIMD.int32x4.extractLane(zwzw, 1));
-  equal(7, SIMD.int32x4.extractLane(zwzw, 2));
-  equal(2147483647, SIMD.int32x4.extractLane(zwzw, 3));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 0));
-  equal(1, SIMD.int32x4.extractLane(xxxx, 1));
-  equal(5, SIMD.int32x4.extractLane(xxxx, 2));
-  equal(5, SIMD.int32x4.extractLane(xxxx, 3));
+test('Int32x4 shuffle', function() {
+  var a    = SIMD.Int32x4(1, 2, 3, 4);
+  var b    = SIMD.Int32x4(5, 6, 7, 2147483647);
+  var xyxy = SIMD.Int32x4.shuffle(a, b, 0, 1, 4, 5);
+  var zwzw = SIMD.Int32x4.shuffle(a, b, 2, 3, 6, 7);
+  var xxxx = SIMD.Int32x4.shuffle(a, b, 0, 0, 4, 4);
+  equal(1, SIMD.Int32x4.extractLane(xyxy, 0));
+  equal(2, SIMD.Int32x4.extractLane(xyxy, 1));
+  equal(5, SIMD.Int32x4.extractLane(xyxy, 2));
+  equal(6, SIMD.Int32x4.extractLane(xyxy, 3));
+  equal(3, SIMD.Int32x4.extractLane(zwzw, 0));
+  equal(4, SIMD.Int32x4.extractLane(zwzw, 1));
+  equal(7, SIMD.Int32x4.extractLane(zwzw, 2));
+  equal(2147483647, SIMD.Int32x4.extractLane(zwzw, 3));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 0));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 1));
+  equal(5, SIMD.Int32x4.extractLane(xxxx, 2));
+  equal(5, SIMD.Int32x4.extractLane(xxxx, 3));
 
-  var c = SIMD.int32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.int32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.int32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1, SIMD.int32x4.extractLane(c, 0));
-  equal(5, SIMD.int32x4.extractLane(c, 1));
-  equal(6, SIMD.int32x4.extractLane(c, 2));
-  equal(2, SIMD.int32x4.extractLane(c, 3));
-  equal(3, SIMD.int32x4.extractLane(d, 0));
-  equal(7, SIMD.int32x4.extractLane(d, 1));
-  equal(4, SIMD.int32x4.extractLane(d, 2));
-  equal(2147483647, SIMD.int32x4.extractLane(d, 3));
-  equal(1, SIMD.int32x4.extractLane(e, 0));
-  equal(5, SIMD.int32x4.extractLane(e, 1));
-  equal(1, SIMD.int32x4.extractLane(e, 2));
-  equal(5, SIMD.int32x4.extractLane(e, 3));
+  var c = SIMD.Int32x4.shuffle(a, b, 0, 4, 5, 1);
+  var d = SIMD.Int32x4.shuffle(a, b, 2, 6, 3, 7);
+  var e = SIMD.Int32x4.shuffle(a, b, 0, 4, 0, 4);
+  equal(1, SIMD.Int32x4.extractLane(c, 0));
+  equal(5, SIMD.Int32x4.extractLane(c, 1));
+  equal(6, SIMD.Int32x4.extractLane(c, 2));
+  equal(2, SIMD.Int32x4.extractLane(c, 3));
+  equal(3, SIMD.Int32x4.extractLane(d, 0));
+  equal(7, SIMD.Int32x4.extractLane(d, 1));
+  equal(4, SIMD.Int32x4.extractLane(d, 2));
+  equal(2147483647, SIMD.Int32x4.extractLane(d, 3));
+  equal(1, SIMD.Int32x4.extractLane(e, 0));
+  equal(5, SIMD.Int32x4.extractLane(e, 1));
+  equal(1, SIMD.Int32x4.extractLane(e, 2));
+  equal(5, SIMD.Int32x4.extractLane(e, 3));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int32x4.shuffle(a, b, index, 0, 0, 0); });
+      throws(function() { SIMD.Int32x4.shuffle(a, b, index, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -2676,31 +2676,31 @@ test('int32x4 shuffle', function() {
   testIndexCheck(8);
 });
 
-test('int32x4 replaceLane', function() {
-    var a = SIMD.int32x4(1, 2, 3, 4);
-    var c = SIMD.int32x4.replaceLane(a, 0, 20);
-    equal(20, SIMD.int32x4.extractLane(c, 0));
-    equal(2, SIMD.int32x4.extractLane(c, 1));
-    equal(3, SIMD.int32x4.extractLane(c, 2));
-    equal(4, SIMD.int32x4.extractLane(c, 3));
-    c = SIMD.int32x4.replaceLane(a, 1, 20);
-    equal(1, SIMD.int32x4.extractLane(c, 0));
-    equal(20, SIMD.int32x4.extractLane(c, 1));
-    equal(3, SIMD.int32x4.extractLane(c, 2));
-    equal(4, SIMD.int32x4.extractLane(c, 3));
-    c = SIMD.int32x4.replaceLane(a, 2, 20);
-    equal(1, SIMD.int32x4.extractLane(c, 0));
-    equal(2, SIMD.int32x4.extractLane(c, 1));
-    equal(20, SIMD.int32x4.extractLane(c, 2));
-    equal(4, SIMD.int32x4.extractLane(c, 3));
-    c = SIMD.int32x4.replaceLane(a, 3, 20);
-    equal(1, SIMD.int32x4.extractLane(c, 0));
-    equal(2, SIMD.int32x4.extractLane(c, 1));
-    equal(3, SIMD.int32x4.extractLane(c, 2));
-    equal(20, SIMD.int32x4.extractLane(c, 3));
+test('Int32x4 replaceLane', function() {
+    var a = SIMD.Int32x4(1, 2, 3, 4);
+    var c = SIMD.Int32x4.replaceLane(a, 0, 20);
+    equal(20, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
+    c = SIMD.Int32x4.replaceLane(a, 1, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(20, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
+    c = SIMD.Int32x4.replaceLane(a, 2, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(20, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
+    c = SIMD.Int32x4.replaceLane(a, 3, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(20, SIMD.Int32x4.extractLane(c, 3));
 
     function testIndexCheck(index) {
-      throws(function() { SIMD.int32x4.replaceLane(a, index, 0.0); });
+      throws(function() { SIMD.Int32x4.replaceLane(a, index, 0.0); });
     }
     testIndexCheck(13.37);
     testIndexCheck(null);
@@ -2712,371 +2712,371 @@ test('int32x4 replaceLane', function() {
     testIndexCheck(8);
 });
 
-test('int32x4 and', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  equal(-1431655766, SIMD.int32x4.extractLane(m, 0));
-  equal(-1431655766, SIMD.int32x4.extractLane(m, 1));
-  equal(-1431655766, SIMD.int32x4.extractLane(m, 2));
-  equal(-1431655766, SIMD.int32x4.extractLane(m, 3));
-  equal(0x55555555, SIMD.int32x4.extractLane(n, 0));
-  equal(0x55555555, SIMD.int32x4.extractLane(n, 1));
-  equal(0x55555555, SIMD.int32x4.extractLane(n, 2));
-  equal(0x55555555, SIMD.int32x4.extractLane(n, 3));
-  equal(true, toBool(SIMD.int32x4.extractLane(m, 0)));
-  equal(true, toBool(SIMD.int32x4.extractLane(m, 1)));
-  equal(true, toBool(SIMD.int32x4.extractLane(m, 2)));
-  equal(true, toBool(SIMD.int32x4.extractLane(m, 3)));
-  equal(false, toBool(SIMD.int32x4.extractLane(n, 0)));
-  equal(false, toBool(SIMD.int32x4.extractLane(n, 1)));
-  equal(false, toBool(SIMD.int32x4.extractLane(n, 2)));
-  equal(false, toBool(SIMD.int32x4.extractLane(n, 3)));
-  var o = SIMD.int32x4.and(m,n);  // and
-  equal(0x0, SIMD.int32x4.extractLane(o, 0));
-  equal(0x0, SIMD.int32x4.extractLane(o, 1));
-  equal(0x0, SIMD.int32x4.extractLane(o, 2));
-  equal(0x0, SIMD.int32x4.extractLane(o, 3));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 0)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 1)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 2)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 3)));
+test('Int32x4 and', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 0));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 1));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 2));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 3));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 0));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 1));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 2));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 3));
+  equal(true, toBool(SIMD.Int32x4.extractLane(m, 0)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(m, 1)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(m, 2)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(m, 3)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(n, 0)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(n, 1)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(n, 2)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(n, 3)));
+  var o = SIMD.Int32x4.and(m,n);  // and
+  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 0)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 1)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 2)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 3)));
 });
 
-test('int32x4 or', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  var o = SIMD.int32x4.or(m,n);  // or
-  equal(-1, SIMD.int32x4.extractLane(o, 0));
-  equal(-1, SIMD.int32x4.extractLane(o, 1));
-  equal(-1, SIMD.int32x4.extractLane(o, 2));
-  equal(-1, SIMD.int32x4.extractLane(o, 3));
-  equal(true, toBool(SIMD.int32x4.extractLane(o, 0)));
-  equal(true, toBool(SIMD.int32x4.extractLane(o, 1)));
-  equal(true, toBool(SIMD.int32x4.extractLane(o, 2)));
-  equal(true, toBool(SIMD.int32x4.extractLane(o, 3)));
+test('Int32x4 or', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+  var o = SIMD.Int32x4.or(m,n);  // or
+  equal(-1, SIMD.Int32x4.extractLane(o, 0));
+  equal(-1, SIMD.Int32x4.extractLane(o, 1));
+  equal(-1, SIMD.Int32x4.extractLane(o, 2));
+  equal(-1, SIMD.Int32x4.extractLane(o, 3));
+  equal(true, toBool(SIMD.Int32x4.extractLane(o, 0)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(o, 1)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(o, 2)));
+  equal(true, toBool(SIMD.Int32x4.extractLane(o, 3)));
 });
 
-test('int32x4 xor', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  n = SIMD.int32x4.replaceLane(n, 0, 0xAAAAAAAA);
-  n = SIMD.int32x4.replaceLane(n, 1, 0xAAAAAAAA);
-  n = SIMD.int32x4.replaceLane(n, 2, 0xAAAAAAAA);
-  n = SIMD.int32x4.replaceLane(n, 3, 0xAAAAAAAA);
-  equal(-1431655766, SIMD.int32x4.extractLane(n, 0));
-  equal(-1431655766, SIMD.int32x4.extractLane(n, 1));
-  equal(-1431655766, SIMD.int32x4.extractLane(n, 2));
-  equal(-1431655766, SIMD.int32x4.extractLane(n, 3));
-  var o = SIMD.int32x4.xor(m,n);  // xor
-  equal(0x0, SIMD.int32x4.extractLane(o, 0));
-  equal(0x0, SIMD.int32x4.extractLane(o, 1));
-  equal(0x0, SIMD.int32x4.extractLane(o, 2));
-  equal(0x0, SIMD.int32x4.extractLane(o, 3));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 0)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 1)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 2)));
-  equal(false, toBool(SIMD.int32x4.extractLane(o, 3)));
+test('Int32x4 xor', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+  n = SIMD.Int32x4.replaceLane(n, 0, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 1, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 2, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 3, 0xAAAAAAAA);
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 0));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 1));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 2));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 3));
+  var o = SIMD.Int32x4.xor(m,n);  // xor
+  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 0)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 1)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 2)));
+  equal(false, toBool(SIMD.Int32x4.extractLane(o, 3)));
 });
 
-test('int32x4 neg', function() {
-  var m = SIMD.int32x4(16, -32, 64, -128);
-  m = SIMD.int32x4.neg(m);
-  equal(-16, SIMD.int32x4.extractLane(m, 0));
-  equal(32, SIMD.int32x4.extractLane(m, 1));
-  equal(-64, SIMD.int32x4.extractLane(m, 2));
-  equal(128, SIMD.int32x4.extractLane(m, 3));
+test('Int32x4 neg', function() {
+  var m = SIMD.Int32x4(16, -32, 64, -128);
+  m = SIMD.Int32x4.neg(m);
+  equal(-16, SIMD.Int32x4.extractLane(m, 0));
+  equal(32, SIMD.Int32x4.extractLane(m, 1));
+  equal(-64, SIMD.Int32x4.extractLane(m, 2));
+  equal(128, SIMD.Int32x4.extractLane(m, 3));
 
-  var n = SIMD.int32x4(0, 0x7fffffff, -1, 0x80000000);
-  n = SIMD.int32x4.neg(n);
-  equal(0, SIMD.int32x4.extractLane(n, 0));
-  equal(-2147483647, SIMD.int32x4.extractLane(n, 1));
-  equal(1, SIMD.int32x4.extractLane(n, 2));
-  equal(-2147483648, SIMD.int32x4.extractLane(n, 3));
+  var n = SIMD.Int32x4(0, 0x7fffffff, -1, 0x80000000);
+  n = SIMD.Int32x4.neg(n);
+  equal(0, SIMD.Int32x4.extractLane(n, 0));
+  equal(-2147483647, SIMD.Int32x4.extractLane(n, 1));
+  equal(1, SIMD.Int32x4.extractLane(n, 2));
+  equal(-2147483648, SIMD.Int32x4.extractLane(n, 3));
 });
 
-test('int32x4 allTrue', function () {
-  var v0000 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v0001 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5);
-  var v0010 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A);
-  var v0100 = SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v1000 = SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v0011 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5);
-  var v0111 = SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
-  var v1111 = SIMD.int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
-  equal(SIMD.int32x4.allTrue(v0000), false);
-  equal(SIMD.int32x4.allTrue(v0001), false);
-  equal(SIMD.int32x4.allTrue(v0010), false);
-  equal(SIMD.int32x4.allTrue(v0100), false);
-  equal(SIMD.int32x4.allTrue(v1000), false);
-  equal(SIMD.int32x4.allTrue(v0011), false);
-  equal(SIMD.int32x4.allTrue(v0111), false);
-  equal(SIMD.int32x4.allTrue(v1111), true);
+test('Int32x4 allTrue', function () {
+  var v0000 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v0001 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5);
+  var v0010 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A);
+  var v0100 = SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v1000 = SIMD.Int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v0011 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5);
+  var v0111 = SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
+  var v1111 = SIMD.Int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
+  equal(SIMD.Int32x4.allTrue(v0000), false);
+  equal(SIMD.Int32x4.allTrue(v0001), false);
+  equal(SIMD.Int32x4.allTrue(v0010), false);
+  equal(SIMD.Int32x4.allTrue(v0100), false);
+  equal(SIMD.Int32x4.allTrue(v1000), false);
+  equal(SIMD.Int32x4.allTrue(v0011), false);
+  equal(SIMD.Int32x4.allTrue(v0111), false);
+  equal(SIMD.Int32x4.allTrue(v1111), true);
 });
 
-test('int32x4 anyTrue', function () {
-  var v0000 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v0001 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5);
-  var v0010 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A);
-  var v0100 = SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v1000 = SIMD.int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
-  var v0011 = SIMD.int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5);
-  var v0111 = SIMD.int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
-  var v1111 = SIMD.int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
-  equal(SIMD.int32x4.anyTrue(v0000), false);
-  equal(SIMD.int32x4.anyTrue(v0001), true);
-  equal(SIMD.int32x4.anyTrue(v0010), true);
-  equal(SIMD.int32x4.anyTrue(v0100), true);
-  equal(SIMD.int32x4.anyTrue(v1000), true);
-  equal(SIMD.int32x4.anyTrue(v0011), true);
-  equal(SIMD.int32x4.anyTrue(v0111), true);
-  equal(SIMD.int32x4.anyTrue(v1111), true);
+test('Int32x4 anyTrue', function () {
+  var v0000 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v0001 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x00000001, 0xA5A5A5A5);
+  var v0010 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0x5A5A5A5A);
+  var v0100 = SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v1000 = SIMD.Int32x4(0x80000000, 0x7FFFFFFF, 0x00000001, 0x5A5A5A5A);
+  var v0011 = SIMD.Int32x4(0x00000000, 0x7FFFFFFF, 0x80000001, 0xA5A5A5A5);
+  var v0111 = SIMD.Int32x4(0x00000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
+  var v1111 = SIMD.Int32x4(0x80000000, 0xFFFFFFFF, 0x80000001, 0xA5A5A5A5);
+  equal(SIMD.Int32x4.anyTrue(v0000), false);
+  equal(SIMD.Int32x4.anyTrue(v0001), true);
+  equal(SIMD.Int32x4.anyTrue(v0010), true);
+  equal(SIMD.Int32x4.anyTrue(v0100), true);
+  equal(SIMD.Int32x4.anyTrue(v1000), true);
+  equal(SIMD.Int32x4.anyTrue(v0011), true);
+  equal(SIMD.Int32x4.anyTrue(v0111), true);
+  equal(SIMD.Int32x4.anyTrue(v1111), true);
 });
 
-test('int32x4 vector getters', function () {
-  var a = SIMD.int32x4(4, 3, 2, 1);
-  var xxxx = SIMD.int32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.int32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.int32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.int32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.int32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4, SIMD.int32x4.extractLane(xxxx, 0));
-  equal(4, SIMD.int32x4.extractLane(xxxx, 1));
-  equal(4, SIMD.int32x4.extractLane(xxxx, 2));
-  equal(4, SIMD.int32x4.extractLane(xxxx, 3));
-  equal(3, SIMD.int32x4.extractLane(yyyy, 0));
-  equal(3, SIMD.int32x4.extractLane(yyyy, 1));
-  equal(3, SIMD.int32x4.extractLane(yyyy, 2));
-  equal(3, SIMD.int32x4.extractLane(yyyy, 3));
-  equal(2, SIMD.int32x4.extractLane(zzzz, 0));
-  equal(2, SIMD.int32x4.extractLane(zzzz, 1));
-  equal(2, SIMD.int32x4.extractLane(zzzz, 2));
-  equal(2, SIMD.int32x4.extractLane(zzzz, 3));
-  equal(1, SIMD.int32x4.extractLane(wwww, 0));
-  equal(1, SIMD.int32x4.extractLane(wwww, 1));
-  equal(1, SIMD.int32x4.extractLane(wwww, 2));
-  equal(1, SIMD.int32x4.extractLane(wwww, 3));
-  equal(1, SIMD.int32x4.extractLane(wzyx, 0));
-  equal(2, SIMD.int32x4.extractLane(wzyx, 1));
-  equal(3, SIMD.int32x4.extractLane(wzyx, 2));
-  equal(4, SIMD.int32x4.extractLane(wzyx, 3));
+test('Int32x4 vector getters', function () {
+  var a = SIMD.Int32x4(4, 3, 2, 1);
+  var xxxx = SIMD.Int32x4.swizzle(a, 0, 0, 0, 0);
+  var yyyy = SIMD.Int32x4.swizzle(a, 1, 1, 1, 1);
+  var zzzz = SIMD.Int32x4.swizzle(a, 2, 2, 2, 2);
+  var wwww = SIMD.Int32x4.swizzle(a, 3, 3, 3, 3);
+  var wzyx = SIMD.Int32x4.swizzle(a, 3, 2, 1, 0);
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 0));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 1));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 2));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 3));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 0));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 1));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 2));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 3));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 0));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 1));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 2));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 3));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 0));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 1));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 2));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 3));
+  equal(1, SIMD.Int32x4.extractLane(wzyx, 0));
+  equal(2, SIMD.Int32x4.extractLane(wzyx, 1));
+  equal(3, SIMD.Int32x4.extractLane(wzyx, 2));
+  equal(4, SIMD.Int32x4.extractLane(wzyx, 3));
 });
 
-test('int32x4 add', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.int32x4.add(a, b);
-  equal(0x0, SIMD.int32x4.extractLane(c, 0));
-  equal(-2, SIMD.int32x4.extractLane(c, 1));
-  equal(-0x80000000, SIMD.int32x4.extractLane(c, 2));
-  equal(-1, SIMD.int32x4.extractLane(c, 3));
+test('Int32x4 add', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.add(a, b);
+  equal(0x0, SIMD.Int32x4.extractLane(c, 0));
+  equal(-2, SIMD.Int32x4.extractLane(c, 1));
+  equal(-0x80000000, SIMD.Int32x4.extractLane(c, 2));
+  equal(-1, SIMD.Int32x4.extractLane(c, 3));
 });
 
-test('int32x4 sub', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.int32x4.sub(a, b);
-  equal(-2, SIMD.int32x4.extractLane(c, 0));
-  equal(0x0, SIMD.int32x4.extractLane(c, 1));
-  equal(0x7FFFFFFF, SIMD.int32x4.extractLane(c, 2));
-  equal(0x1, SIMD.int32x4.extractLane(c, 3));
+test('Int32x4 sub', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.sub(a, b);
+  equal(-2, SIMD.Int32x4.extractLane(c, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+  equal(0x7FFFFFFF, SIMD.Int32x4.extractLane(c, 2));
+  equal(0x1, SIMD.Int32x4.extractLane(c, 3));
 });
 
-test('int32x4 mul', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
-  var c = SIMD.int32x4.mul(a, b);
-  equal(-1, SIMD.int32x4.extractLane(c, 0));
-  equal(0x1, SIMD.int32x4.extractLane(c, 1));
-  equal(0x0, SIMD.int32x4.extractLane(c, 2));
-  equal(0x0, SIMD.int32x4.extractLane(c, 3));
+test('Int32x4 mul', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.mul(a, b);
+  equal(-1, SIMD.Int32x4.extractLane(c, 0));
+  equal(0x1, SIMD.Int32x4.extractLane(c, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
-test('int32x4 comparisons', function() {
-  var m = SIMD.int32x4(1000, 2000, 100, 1);
-  var n = SIMD.int32x4(-2000, 2000, 1, 100);
+test('Int32x4 comparisons', function() {
+  var m = SIMD.Int32x4(1000, 2000, 100, 1);
+  var n = SIMD.Int32x4(-2000, 2000, 1, 100);
   var cmp;
-  cmp = SIMD.int32x4.lessThan(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.lessThan(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.int32x4.lessThanOrEqual(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.lessThanOrEqual(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.int32x4.equal(m, n);
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.equal(m, n);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.int32x4.notEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.notEqual(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.int32x4.greaterThan(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.greaterThan(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
-  cmp = SIMD.int32x4.greaterThanOrEqual(m, n);
-  equal(-1, SIMD.int32x4.extractLane(cmp, 0));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 1));
-  equal(-1, SIMD.int32x4.extractLane(cmp, 2));
-  equal(0x0, SIMD.int32x4.extractLane(cmp, 3));
+  cmp = SIMD.Int32x4.greaterThanOrEqual(m, n);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 });
 
-test('int32x4 shiftLeftByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftLeftByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
 
-  b = SIMD.int32x4.shiftLeftByScalar(a, 1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xfffffffe|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0xfffffffe|0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000002);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 2);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xfffffffc|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0xfffffffc|0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000004);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 30);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xc0000000|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0xc0000000|0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x40000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 31);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x80000000|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x80000000|0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x80000000|0);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x0);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 32);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x0);
-  b = SIMD.int32x4.shiftLeftByScalar(a, -1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x0);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x0);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffe|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffe|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000002);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 2);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffc|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffc|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000004);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 30);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xc0000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xc0000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x40000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 31);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 32);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, -1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
 });
 
-test('int32x4 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
 
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x3fffffff);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x1fffffff);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 30);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000001);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 31);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 32);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0xffffffff|0);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 2);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 30);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 31);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 32);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, -1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
 });
 
-test('int32x4 shiftRightLogicalByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftRightLogicalByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
 
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x7fffffff);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x3fffffff);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x3fffffff);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x1fffffff);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 30);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x00000003);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000001);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 31);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x00000001);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 32);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.int32x4.extractLane(b, 0), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 1), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 2), 0x00000000);
-  equal(SIMD.int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x7fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 2);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 30);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000003);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 31);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 32);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, -1);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
 });
 
-test('int32x4 select', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
-  var t = SIMD.int32x4(1, 2, 3, 4);
-  var f = SIMD.int32x4(5, 6, 7, 8);
-  var s = SIMD.int32x4.select(m, t, f);
-  equal(1, SIMD.int32x4.extractLane(s, 0));
-  equal(2, SIMD.int32x4.extractLane(s, 1));
-  equal(7, SIMD.int32x4.extractLane(s, 2));
-  equal(8, SIMD.int32x4.extractLane(s, 3));
+test('Int32x4 select', function() {
+  var m = SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
+  var t = SIMD.Int32x4(1, 2, 3, 4);
+  var f = SIMD.Int32x4(5, 6, 7, 8);
+  var s = SIMD.Int32x4.select(m, t, f);
+  equal(1, SIMD.Int32x4.extractLane(s, 0));
+  equal(2, SIMD.Int32x4.extractLane(s, 1));
+  equal(7, SIMD.Int32x4.extractLane(s, 2));
+  equal(8, SIMD.Int32x4.extractLane(s, 3));
 });
 
-test('int32x4 selectBits', function() {
-  var m = SIMD.int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
-  var t = SIMD.int32x4(1, 2, 3, 4);
-  var f = SIMD.int32x4(5, 6, 7, 8);
-  var s = SIMD.int32x4.selectBits(m, t, f);
-  equal(5, SIMD.int32x4.extractLane(s, 0));
-  equal(6, SIMD.int32x4.extractLane(s, 1));
-  equal(3, SIMD.int32x4.extractLane(s, 2));
-  equal(12, SIMD.int32x4.extractLane(s, 3));
+test('Int32x4 selectBits', function() {
+  var m = SIMD.Int32x4(0xaaaaaaaa, 0xaaaaaaaa, 0x55555555, 0x55555555);
+  var t = SIMD.Int32x4(1, 2, 3, 4);
+  var f = SIMD.Int32x4(5, 6, 7, 8);
+  var s = SIMD.Int32x4.selectBits(m, t, f);
+  equal(5, SIMD.Int32x4.extractLane(s, 0));
+  equal(6, SIMD.Int32x4.extractLane(s, 1));
+  equal(3, SIMD.Int32x4.extractLane(s, 2));
+  equal(12, SIMD.Int32x4.extractLane(s, 3));
 });
 
-test('int32x4 load', function() {
+test('Int32x4 load', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int32x4.load(a, i);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(i+3, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load(a, i);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 overaligned load', function() {
+test('Int32x4 overaligned load', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -3084,15 +3084,15 @@ test('int32x4 overaligned load', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i += 2) {
-    var v = SIMD.int32x4.load(af, i / 2);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(i+3, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load(af, i / 2);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 unaligned load', function() {
+test('Int32x4 unaligned load', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -3107,29 +3107,29 @@ test('int32x4 unaligned load', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int32x4.load(b, i * 4 + 1);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(i+3, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load(b, i * 4 + 1);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 load1', function() {
+test('Int32x4 load1', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length ; i++) {
-    var v = SIMD.int32x4.load1(a, i);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(0, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load1(a, i);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 overaligned load1', function() {
+test('Int32x4 overaligned load1', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Int32Array(b, 8);
@@ -3137,15 +3137,15 @@ test('int32x4 overaligned load1', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.int32x4.load1(af, i);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(0, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load1(af, i);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 unaligned load1', function() {
+test('Int32x4 unaligned load1', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -3160,29 +3160,29 @@ test('int32x4 unaligned load1', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length ; i++) {
-    var v = SIMD.int32x4.load1(b, i * 4 + 1);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(0, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load1(b, i * 4 + 1);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 load2', function() {
+test('Int32x4 load2', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int32x4.load2(a, i);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load2(a, i);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 overaligned load2', function() {
+test('Int32x4 overaligned load2', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -3190,15 +3190,15 @@ test('int32x4 overaligned load2', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i += 2) {
-    var v = SIMD.int32x4.load2(af, i / 2);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load2(af, i / 2);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 unaligned load2', function() {
+test('Int32x4 unaligned load2', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -3213,29 +3213,29 @@ test('int32x4 unaligned load2', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int32x4.load2(b, i * 4 + 1);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(0, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load2(b, i * 4 + 1);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 load3', function() {
+test('Int32x4 load3', function() {
   var a = new Int32Array(9);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.int32x4.load3(a, i);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load3(a, i);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 overaligned load3', function() {
+test('Int32x4 overaligned load3', function() {
   var b = new ArrayBuffer(48);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -3243,15 +3243,15 @@ test('int32x4 overaligned load3', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i += 2) {
-    var v = SIMD.int32x4.load3(af, i / 2);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load3(af, i / 2);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 load3', function() {
+test('Int32x4 load3', function() {
   var a = new Int32Array(9);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -3266,44 +3266,44 @@ test('int32x4 load3', function() {
 
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.int32x4.load3(b, i * 4 + 1);
-    equal(i, SIMD.int32x4.extractLane(v, 0));
-    equal(i+1, SIMD.int32x4.extractLane(v, 1));
-    equal(i+2, SIMD.int32x4.extractLane(v, 2));
-    equal(0, SIMD.int32x4.extractLane(v, 3));
+    var v = SIMD.Int32x4.load3(b, i * 4 + 1);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
-test('int32x4 store', function() {
+test('Int32x4 store', function() {
   var a = new Int32Array(12);
-  SIMD.int32x4.store(a, 0, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(a, 4, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(a, 8, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(a, 0, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(a, 4, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(a, 8, SIMD.Int32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.int32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.int32x4.equal(SIMD.int32x4.store(a, 0, v), v)));
+  var v = SIMD.Int32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Int32x4.equal(SIMD.Int32x4.store(a, 0, v), v)));
 });
 
-test('int32x4 overaligned store', function() {
+test('Int32x4 overaligned store', function() {
   var b = new ArrayBuffer(56);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.int32x4.store(af, 0, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(af, 2, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(af, 4, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(af, 0, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(af, 2, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(af, 4, SIMD.Int32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 unaligned store', function() {
+test('Int32x4 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.int32x4.store(c, 0 + 1, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(c, 16 + 1, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(c, 32 + 1, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(c, 0 + 1, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(c, 16 + 1, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(c, 32 + 1, SIMD.Int32x4(8, 9, 10, 11));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -3317,28 +3317,28 @@ test('int32x4 unaligned store', function() {
   }
 });
 
-test('int32x4 store1', function() {
+test('Int32x4 store1', function() {
   var a = new Int32Array(4);
-  SIMD.int32x4.store1(a, 0, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.store1(a, 1, SIMD.int32x4(1, -1, -1, -1));
-  SIMD.int32x4.store1(a, 2, SIMD.int32x4(2, -1, -1, -1));
-  SIMD.int32x4.store1(a, 3, SIMD.int32x4(3, -1, -1, -1));
+  SIMD.Int32x4.store1(a, 0, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.store1(a, 1, SIMD.Int32x4(1, -1, -1, -1));
+  SIMD.Int32x4.store1(a, 2, SIMD.Int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.store1(a, 3, SIMD.Int32x4(3, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.int32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.int32x4.equal(SIMD.int32x4.store1(a, 0, v), v)));
+  var v = SIMD.Int32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Int32x4.equal(SIMD.Int32x4.store1(a, 0, v), v)));
 });
 
-test('int32x4 overaligned store1', function() {
+test('Int32x4 overaligned store1', function() {
   var b = new ArrayBuffer(24);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[1] = -2;
   a[3] = -2;
-  SIMD.int32x4.store1(af, 0, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.store1(af, 1, SIMD.int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.store1(af, 0, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.store1(af, 1, SIMD.Int32x4(2, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 2 == 0) {
       equal(i, a[i]);
@@ -3348,12 +3348,12 @@ test('int32x4 overaligned store1', function() {
   }
 });
 
-test('int32x4 unaligned store1', function() {
+test('Int32x4 unaligned store1', function() {
   var c = new Int8Array(16 + 1);
-  SIMD.int32x4.store1(c, 0 + 1, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.store1(c, 4 + 1, SIMD.int32x4(1, -1, -1, -1));
-  SIMD.int32x4.store1(c, 8 + 1, SIMD.int32x4(2, -1, -1, -1));
-  SIMD.int32x4.store1(c, 12 + 1, SIMD.int32x4(3, -1, -1, -1));
+  SIMD.Int32x4.store1(c, 0 + 1, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.store1(c, 4 + 1, SIMD.Int32x4(1, -1, -1, -1));
+  SIMD.Int32x4.store1(c, 8 + 1, SIMD.Int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.store1(c, 12 + 1, SIMD.Int32x4(3, -1, -1, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -3366,39 +3366,39 @@ test('int32x4 unaligned store1', function() {
     equal(i, a[i]);
   }
 
-  var v = SIMD.int32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.int32x4.equal(SIMD.int32x4.store2(a, 0, v), v)));
+  var v = SIMD.Int32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Int32x4.equal(SIMD.Int32x4.store2(a, 0, v), v)));
 });
 
-test('int32x4 store2', function() {
+test('Int32x4 store2', function() {
   var a = new Int32Array(8);
-  SIMD.int32x4.store2(a, 0, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.store2(a, 2, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.store2(a, 4, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.store2(a, 6, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.store2(a, 0, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.store2(a, 2, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.store2(a, 4, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.store2(a, 6, SIMD.Int32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 store2', function() {
+test('Int32x4 store2', function() {
   var a = new Int32Array(8);
   var af = new Float64Array(a.buffer);
-  SIMD.int32x4.store2(af, 0, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.store2(af, 1, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.store2(af, 2, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.store2(af, 3, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.store2(af, 0, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.store2(af, 1, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.store2(af, 2, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.store2(af, 3, SIMD.Int32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 unaligned store2', function() {
+test('Int32x4 unaligned store2', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.int32x4.store2(c, 0 + 1, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.store2(c, 8 + 1, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.store2(c, 16 + 1, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.store2(c, 24 + 1, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.store2(c, 0 + 1, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.store2(c, 8 + 1, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.store2(c, 16 + 1, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.store2(c, 24 + 1, SIMD.Int32x4(6, 7, -1, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -3412,29 +3412,29 @@ test('int32x4 unaligned store2', function() {
   }
 });
 
-test('int32x4 store3', function() {
+test('Int32x4 store3', function() {
   var a = new Int32Array(9);
-  SIMD.int32x4.store3(a, 0, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.store3(a, 3, SIMD.int32x4(3, 4, 5, -1));
-  SIMD.int32x4.store3(a, 6, SIMD.int32x4(6, 7, 8, -1));
+  SIMD.Int32x4.store3(a, 0, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.store3(a, 3, SIMD.Int32x4(3, 4, 5, -1));
+  SIMD.Int32x4.store3(a, 6, SIMD.Int32x4(6, 7, 8, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 
-  var v = SIMD.int32x4(0, 1, 2, 3);
-  equal(true, SIMD.int32x4.allTrue(SIMD.int32x4.equal(SIMD.int32x4.store3(a, 0, v), v)));
+  var v = SIMD.Int32x4(0, 1, 2, 3);
+  equal(true, SIMD.Int32x4.allTrue(SIMD.Int32x4.equal(SIMD.Int32x4.store3(a, 0, v), v)));
 });
 
-test('int32x4 overaligned store3', function() {
+test('Int32x4 overaligned store3', function() {
   var b = new ArrayBuffer(56);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[3] = -2;
   a[7] = -2;
   a[11] = -2;
-  SIMD.int32x4.store3(af, 0, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.store3(af, 2, SIMD.int32x4(4, 5, 6, -1));
-  SIMD.int32x4.store3(af, 4, SIMD.int32x4(8, 9, 10, -1));
+  SIMD.Int32x4.store3(af, 0, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.store3(af, 2, SIMD.Int32x4(4, 5, 6, -1));
+  SIMD.Int32x4.store3(af, 4, SIMD.Int32x4(8, 9, 10, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 4 != 3) {
       equal(i, a[i]);
@@ -3444,11 +3444,11 @@ test('int32x4 overaligned store3', function() {
   }
 });
 
-test('int32x4 unaligned store3', function() {
+test('Int32x4 unaligned store3', function() {
   var c = new Int8Array(36 + 1);
-  SIMD.int32x4.store3(c, 0 + 1, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.store3(c, 12 + 1, SIMD.int32x4(3, 4, 5, -1));
-  SIMD.int32x4.store3(c, 24 + 1, SIMD.int32x4(6, 7, 8, -1));
+  SIMD.Int32x4.store3(c, 0 + 1, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.store3(c, 12 + 1, SIMD.Int32x4(3, 4, 5, -1));
+  SIMD.Int32x4.store3(c, 24 + 1, SIMD.Int32x4(6, 7, 8, -1));
 
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
@@ -3462,199 +3462,199 @@ test('int32x4 unaligned store3', function() {
   }
 });
 
-test('int32x4 load exceptions', function () {
+test('Int32x4 load exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.load(a, -1);
+    var f = SIMD.Int32x4.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a, 5);
+    var f = SIMD.Int32x4.load(a, 5);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a.buffer, 1);
+    var f = SIMD.Int32x4.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a, "a");
+    var f = SIMD.Int32x4.load(a, "a");
   });
 });
 
-test('int32x4 load1 exceptions', function () {
+test('Int32x4 load1 exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.load1(a, -1);
+    var f = SIMD.Int32x4.load1(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load1(a, 8);
+    var f = SIMD.Int32x4.load1(a, 8);
   });
   throws(function () {
-    var f = SIMD.int32x4.load1(a.buffer, 1);
+    var f = SIMD.Int32x4.load1(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load1(a, "a");
+    var f = SIMD.Int32x4.load1(a, "a");
   });
 });
 
-test('int32x4 load2 exceptions', function () {
+test('Int32x4 load2 exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.load2(a, -1);
+    var f = SIMD.Int32x4.load2(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load2(a, 7);
+    var f = SIMD.Int32x4.load2(a, 7);
   });
   throws(function () {
-    var f = SIMD.int32x4.load2(a.buffer, 1);
+    var f = SIMD.Int32x4.load2(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load2(a, "a");
+    var f = SIMD.Int32x4.load2(a, "a");
   });
 });
 
-test('int32x4 load3 exceptions', function () {
+test('Int32x4 load3 exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.load3(a, -1);
+    var f = SIMD.Int32x4.load3(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load3(a, 6);
+    var f = SIMD.Int32x4.load3(a, 6);
   });
   throws(function () {
-    var f = SIMD.int32x4.load3(a.buffer, 1);
+    var f = SIMD.Int32x4.load3(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load3(a, "a");
+    var f = SIMD.Int32x4.load3(a, "a");
   });
 });
 
-test('int32x4 store exceptions', function () {
+test('Int32x4 store exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.store(a, -1, i);
+    SIMD.Int32x4.store(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, 5, i);
+    SIMD.Int32x4.store(a, 5, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a.buffer, 1, i);
+    SIMD.Int32x4.store(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, "a", i);
+    SIMD.Int32x4.store(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, 1, f);
+    SIMD.Int32x4.store(a, 1, f);
   });
 });
 
-test('int32x4 store1 exceptions', function () {
+test('Int32x4 store1 exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.store1(a, -1, i);
+    SIMD.Int32x4.store1(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.store1(a, 8, i);
+    SIMD.Int32x4.store1(a, 8, i);
   });
   throws(function () {
-    SIMD.int32x4.store1(a.buffer, 1, i);
+    SIMD.Int32x4.store1(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.store1(a, "a", i);
+    SIMD.Int32x4.store1(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.store1(a, 1, f);
+    SIMD.Int32x4.store1(a, 1, f);
   });
 });
 
-test('int32x4 store2 exceptions', function () {
+test('Int32x4 store2 exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.store2(a, -1, i);
+    SIMD.Int32x4.store2(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.store2(a, 7, i);
+    SIMD.Int32x4.store2(a, 7, i);
   });
   throws(function () {
-    SIMD.int32x4.store2(a.buffer, 1, i);
+    SIMD.Int32x4.store2(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.store2(a, "a", i);
+    SIMD.Int32x4.store2(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.store2(a, 1, f);
+    SIMD.Int32x4.store2(a, 1, f);
   });
 });
 
-test('int32x4 store3 exceptions', function () {
+test('Int32x4 store3 exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.store3(a, -1, i);
+    SIMD.Int32x4.store3(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.store3(a, 6, i);
+    SIMD.Int32x4.store3(a, 6, i);
   });
   throws(function () {
-    SIMD.int32x4.store3(a.buffer, 1, i);
+    SIMD.Int32x4.store3(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.store3(a, "a", i);
+    SIMD.Int32x4.store3(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.store3(a, 1, f);
+    SIMD.Int32x4.store3(a, 1, f);
   });
 });
 
-test('int16x8 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.int16x8.fromFloat32x4Bits(m);
-  equal(0x0000, SIMD.int16x8.extractLane(n, 0));
-  equal(0x3F80, SIMD.int16x8.extractLane(n, 1));
-  equal(0x0000, SIMD.int16x8.extractLane(n, 2));
-  equal(0x4000, SIMD.int16x8.extractLane(n, 3));
-  equal(0x0000, SIMD.int16x8.extractLane(n, 4));
-  equal(0x4040, SIMD.int16x8.extractLane(n, 5));  
-  equal(0x0000, SIMD.int16x8.extractLane(n, 6));
-  equal(0x4080, SIMD.int16x8.extractLane(n, 7));
+test('Int16x8 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.Int16x8.fromFloat32x4Bits(m);
+  equal(0x0000, SIMD.Int16x8.extractLane(n, 0));
+  equal(0x3F80, SIMD.Int16x8.extractLane(n, 1));
+  equal(0x0000, SIMD.Int16x8.extractLane(n, 2));
+  equal(0x4000, SIMD.Int16x8.extractLane(n, 3));
+  equal(0x0000, SIMD.Int16x8.extractLane(n, 4));
+  equal(0x4040, SIMD.Int16x8.extractLane(n, 5));  
+  equal(0x0000, SIMD.Int16x8.extractLane(n, 6));
+  equal(0x4080, SIMD.Int16x8.extractLane(n, 7));
 });
 
-test('int16x8 swizzle', function() {
-  var a    = SIMD.int16x8(1, 2, 3, 2147483647, 5, 6, 7, -37);
-  var xyxy = SIMD.int16x8.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1);
-  var zwzw = SIMD.int16x8.swizzle(a, 4, 5, 4, 5, 4, 5, 4, 5);
-  var xxxx = SIMD.int16x8.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0);
-  equal(1, SIMD.int16x8.extractLane(xyxy, 0));
-  equal(2, SIMD.int16x8.extractLane(xyxy, 1));
-  equal(1, SIMD.int16x8.extractLane(xyxy, 2));
-  equal(2, SIMD.int16x8.extractLane(xyxy, 3));
-  equal(1, SIMD.int16x8.extractLane(xyxy, 4));
-  equal(2, SIMD.int16x8.extractLane(xyxy, 5));
-  equal(1, SIMD.int16x8.extractLane(xyxy, 6));
-  equal(2, SIMD.int16x8.extractLane(xyxy, 7));
-  equal(5, SIMD.int16x8.extractLane(zwzw, 0));
-  equal(6, SIMD.int16x8.extractLane(zwzw, 1));
-  equal(5, SIMD.int16x8.extractLane(zwzw, 2));
-  equal(6, SIMD.int16x8.extractLane(zwzw, 3));
-  equal(5, SIMD.int16x8.extractLane(zwzw, 4));
-  equal(6, SIMD.int16x8.extractLane(zwzw, 5));
-  equal(5, SIMD.int16x8.extractLane(zwzw, 6));
-  equal(6, SIMD.int16x8.extractLane(zwzw, 7));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 0));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 1));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 2));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 3));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 4));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 5));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 6));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 7));
+test('Int16x8 swizzle', function() {
+  var a    = SIMD.Int16x8(1, 2, 3, 2147483647, 5, 6, 7, -37);
+  var xyxy = SIMD.Int16x8.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1);
+  var zwzw = SIMD.Int16x8.swizzle(a, 4, 5, 4, 5, 4, 5, 4, 5);
+  var xxxx = SIMD.Int16x8.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0);
+  equal(1, SIMD.Int16x8.extractLane(xyxy, 0));
+  equal(2, SIMD.Int16x8.extractLane(xyxy, 1));
+  equal(1, SIMD.Int16x8.extractLane(xyxy, 2));
+  equal(2, SIMD.Int16x8.extractLane(xyxy, 3));
+  equal(1, SIMD.Int16x8.extractLane(xyxy, 4));
+  equal(2, SIMD.Int16x8.extractLane(xyxy, 5));
+  equal(1, SIMD.Int16x8.extractLane(xyxy, 6));
+  equal(2, SIMD.Int16x8.extractLane(xyxy, 7));
+  equal(5, SIMD.Int16x8.extractLane(zwzw, 0));
+  equal(6, SIMD.Int16x8.extractLane(zwzw, 1));
+  equal(5, SIMD.Int16x8.extractLane(zwzw, 2));
+  equal(6, SIMD.Int16x8.extractLane(zwzw, 3));
+  equal(5, SIMD.Int16x8.extractLane(zwzw, 4));
+  equal(6, SIMD.Int16x8.extractLane(zwzw, 5));
+  equal(5, SIMD.Int16x8.extractLane(zwzw, 6));
+  equal(6, SIMD.Int16x8.extractLane(zwzw, 7));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 0));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 1));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 2));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 3));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 4));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 5));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 6));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 7));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int16x8.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0); });
+      throws(function() { SIMD.Int16x8.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -3666,39 +3666,39 @@ test('int16x8 swizzle', function() {
   testIndexCheck(8);
 });
 
-test('int16x8 shuffle', function() {
-  var a    = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var b    = SIMD.int16x8(9, 10, 11, 12, 13, 14, 15, 32767);
-  var xyxy = SIMD.int16x8.shuffle(a, b, 0, 1, 2, 3, 8, 9, 10, 11);
-  var zwzw = SIMD.int16x8.shuffle(a, b, 4, 5, 6, 7, 12, 13, 14, 15);
-  var xxxx = SIMD.int16x8.shuffle(a, b, 0, 0, 0, 0, 8, 8, 8, 8);
-  equal(1, SIMD.int16x8.extractLane(xyxy, 0));
-  equal(2, SIMD.int16x8.extractLane(xyxy, 1));
-  equal(3, SIMD.int16x8.extractLane(xyxy, 2));
-  equal(4, SIMD.int16x8.extractLane(xyxy, 3));
-  equal(9, SIMD.int16x8.extractLane(xyxy, 4));
-  equal(10, SIMD.int16x8.extractLane(xyxy, 5));
-  equal(11, SIMD.int16x8.extractLane(xyxy, 6));
-  equal(12, SIMD.int16x8.extractLane(xyxy, 7));
-  equal(5, SIMD.int16x8.extractLane(zwzw, 0));
-  equal(6, SIMD.int16x8.extractLane(zwzw, 1));
-  equal(7, SIMD.int16x8.extractLane(zwzw, 2));
-  equal(8, SIMD.int16x8.extractLane(zwzw, 3));
-  equal(13, SIMD.int16x8.extractLane(zwzw, 4));
-  equal(14, SIMD.int16x8.extractLane(zwzw, 5));
-  equal(15, SIMD.int16x8.extractLane(zwzw, 6));
-  equal(32767, SIMD.int16x8.extractLane(zwzw, 7));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 0));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 1));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 2));
-  equal(1, SIMD.int16x8.extractLane(xxxx, 3));
-  equal(9, SIMD.int16x8.extractLane(xxxx, 4));
-  equal(9, SIMD.int16x8.extractLane(xxxx, 5));
-  equal(9, SIMD.int16x8.extractLane(xxxx, 6));
-  equal(9, SIMD.int16x8.extractLane(xxxx, 7));
+test('Int16x8 shuffle', function() {
+  var a    = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var b    = SIMD.Int16x8(9, 10, 11, 12, 13, 14, 15, 32767);
+  var xyxy = SIMD.Int16x8.shuffle(a, b, 0, 1, 2, 3, 8, 9, 10, 11);
+  var zwzw = SIMD.Int16x8.shuffle(a, b, 4, 5, 6, 7, 12, 13, 14, 15);
+  var xxxx = SIMD.Int16x8.shuffle(a, b, 0, 0, 0, 0, 8, 8, 8, 8);
+  equal(1, SIMD.Int16x8.extractLane(xyxy, 0));
+  equal(2, SIMD.Int16x8.extractLane(xyxy, 1));
+  equal(3, SIMD.Int16x8.extractLane(xyxy, 2));
+  equal(4, SIMD.Int16x8.extractLane(xyxy, 3));
+  equal(9, SIMD.Int16x8.extractLane(xyxy, 4));
+  equal(10, SIMD.Int16x8.extractLane(xyxy, 5));
+  equal(11, SIMD.Int16x8.extractLane(xyxy, 6));
+  equal(12, SIMD.Int16x8.extractLane(xyxy, 7));
+  equal(5, SIMD.Int16x8.extractLane(zwzw, 0));
+  equal(6, SIMD.Int16x8.extractLane(zwzw, 1));
+  equal(7, SIMD.Int16x8.extractLane(zwzw, 2));
+  equal(8, SIMD.Int16x8.extractLane(zwzw, 3));
+  equal(13, SIMD.Int16x8.extractLane(zwzw, 4));
+  equal(14, SIMD.Int16x8.extractLane(zwzw, 5));
+  equal(15, SIMD.Int16x8.extractLane(zwzw, 6));
+  equal(32767, SIMD.Int16x8.extractLane(zwzw, 7));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 0));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 1));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 2));
+  equal(1, SIMD.Int16x8.extractLane(xxxx, 3));
+  equal(9, SIMD.Int16x8.extractLane(xxxx, 4));
+  equal(9, SIMD.Int16x8.extractLane(xxxx, 5));
+  equal(9, SIMD.Int16x8.extractLane(xxxx, 6));
+  equal(9, SIMD.Int16x8.extractLane(xxxx, 7));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int16x8.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0); });
+      throws(function() { SIMD.Int16x8.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -3710,556 +3710,556 @@ test('int16x8 shuffle', function() {
   testIndexCheck(16);
 });
 
-test('int16x8 and', function() {
-  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 43690, 43690, 0xAAAA, 0xAAAA);
-  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  equal(-21846, SIMD.int16x8.extractLane(m, 0));
-  equal(-21846, SIMD.int16x8.extractLane(m, 1));
-  equal(-21846, SIMD.int16x8.extractLane(m, 2));
-  equal(-21846, SIMD.int16x8.extractLane(m, 3));
-  equal(-21846, SIMD.int16x8.extractLane(m, 4));
-  equal(-21846, SIMD.int16x8.extractLane(m, 5));
-  equal(-21846, SIMD.int16x8.extractLane(m, 6));
-  equal(-21846, SIMD.int16x8.extractLane(m, 7));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 0));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 1));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 2));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 3));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 4));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 5));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 6));
-  equal(0x5555, SIMD.int16x8.extractLane(n, 7));
-  var o = SIMD.int16x8.and(m,n);  // and
-  equal(0x0, SIMD.int16x8.extractLane(o, 0));
-  equal(0x0, SIMD.int16x8.extractLane(o, 1));
-  equal(0x0, SIMD.int16x8.extractLane(o, 2));
-  equal(0x0, SIMD.int16x8.extractLane(o, 3));
-  equal(0x0, SIMD.int16x8.extractLane(o, 4));
-  equal(0x0, SIMD.int16x8.extractLane(o, 5));
-  equal(0x0, SIMD.int16x8.extractLane(o, 6));
-  equal(0x0, SIMD.int16x8.extractLane(o, 7));
+test('Int16x8 and', function() {
+  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 43690, 43690, 0xAAAA, 0xAAAA);
+  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  equal(-21846, SIMD.Int16x8.extractLane(m, 0));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 1));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 2));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 3));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 4));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 5));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 6));
+  equal(-21846, SIMD.Int16x8.extractLane(m, 7));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 0));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 1));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 2));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 3));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 4));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 5));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 6));
+  equal(0x5555, SIMD.Int16x8.extractLane(n, 7));
+  var o = SIMD.Int16x8.and(m,n);  // and
+  equal(0x0, SIMD.Int16x8.extractLane(o, 0));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 1));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 2));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 3));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 4));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 5));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 6));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 7));
 });
 
-test('int16x8 or', function() {
-  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
-  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  var o = SIMD.int16x8.or(m,n);  // or
-  equal(-1, SIMD.int16x8.extractLane(o, 0));
-  equal(-1, SIMD.int16x8.extractLane(o, 1));
-  equal(-1, SIMD.int16x8.extractLane(o, 2));
-  equal(-1, SIMD.int16x8.extractLane(o, 3));
-  equal(-1, SIMD.int16x8.extractLane(o, 4));
-  equal(-1, SIMD.int16x8.extractLane(o, 5));
-  equal(-1, SIMD.int16x8.extractLane(o, 6));
-  equal(-1, SIMD.int16x8.extractLane(o, 7));
+test('Int16x8 or', function() {
+  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
+  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  var o = SIMD.Int16x8.or(m,n);  // or
+  equal(-1, SIMD.Int16x8.extractLane(o, 0));
+  equal(-1, SIMD.Int16x8.extractLane(o, 1));
+  equal(-1, SIMD.Int16x8.extractLane(o, 2));
+  equal(-1, SIMD.Int16x8.extractLane(o, 3));
+  equal(-1, SIMD.Int16x8.extractLane(o, 4));
+  equal(-1, SIMD.Int16x8.extractLane(o, 5));
+  equal(-1, SIMD.Int16x8.extractLane(o, 6));
+  equal(-1, SIMD.Int16x8.extractLane(o, 7));
 });
 
-test('int16x8 xor', function() {
-  var m = SIMD.int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
-  var n = SIMD.int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
-  var o = SIMD.int16x8.xor(m,n);  // xor
-  equal(-1, SIMD.int16x8.extractLane(o, 0));
-  equal(-1, SIMD.int16x8.extractLane(o, 1));
-  equal(-1, SIMD.int16x8.extractLane(o, 2));
-  equal(-1, SIMD.int16x8.extractLane(o, 3));
-  equal(-1, SIMD.int16x8.extractLane(o, 4));
-  equal(-1, SIMD.int16x8.extractLane(o, 5));
-  equal(-1, SIMD.int16x8.extractLane(o, 6));
-  equal(-1, SIMD.int16x8.extractLane(o, 7));
-  o = SIMD.int16x8.xor(m,m);  // xor
-  equal(0x0, SIMD.int16x8.extractLane(o, 0));
-  equal(0x0, SIMD.int16x8.extractLane(o, 1));
-  equal(0x0, SIMD.int16x8.extractLane(o, 2));
-  equal(0x0, SIMD.int16x8.extractLane(o, 3));
-  equal(0x0, SIMD.int16x8.extractLane(o, 4));
-  equal(0x0, SIMD.int16x8.extractLane(o, 5));
-  equal(0x0, SIMD.int16x8.extractLane(o, 6));
-  equal(0x0, SIMD.int16x8.extractLane(o, 7));
+test('Int16x8 xor', function() {
+  var m = SIMD.Int16x8(0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA, 0xAAAA);
+  var n = SIMD.Int16x8(0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555, 0x5555);
+  var o = SIMD.Int16x8.xor(m,n);  // xor
+  equal(-1, SIMD.Int16x8.extractLane(o, 0));
+  equal(-1, SIMD.Int16x8.extractLane(o, 1));
+  equal(-1, SIMD.Int16x8.extractLane(o, 2));
+  equal(-1, SIMD.Int16x8.extractLane(o, 3));
+  equal(-1, SIMD.Int16x8.extractLane(o, 4));
+  equal(-1, SIMD.Int16x8.extractLane(o, 5));
+  equal(-1, SIMD.Int16x8.extractLane(o, 6));
+  equal(-1, SIMD.Int16x8.extractLane(o, 7));
+  o = SIMD.Int16x8.xor(m,m);  // xor
+  equal(0x0, SIMD.Int16x8.extractLane(o, 0));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 1));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 2));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 3));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 4));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 5));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 6));
+  equal(0x0, SIMD.Int16x8.extractLane(o, 7));
 });
 
-test('int16x8 neg', function() {
-  var m = SIMD.int16x8(16, -32, 64, -128, 256, -512, 1024, -2048);
-  m = SIMD.int16x8.neg(m);
-  equal(-16, SIMD.int16x8.extractLane(m, 0));
-  equal(32, SIMD.int16x8.extractLane(m, 1));
-  equal(-64, SIMD.int16x8.extractLane(m, 2));
-  equal(128, SIMD.int16x8.extractLane(m, 3));
-  equal(-256, SIMD.int16x8.extractLane(m, 4));
-  equal(512, SIMD.int16x8.extractLane(m, 5));
-  equal(-1024, SIMD.int16x8.extractLane(m, 6));
-  equal(2048, SIMD.int16x8.extractLane(m, 7));
+test('Int16x8 neg', function() {
+  var m = SIMD.Int16x8(16, -32, 64, -128, 256, -512, 1024, -2048);
+  m = SIMD.Int16x8.neg(m);
+  equal(-16, SIMD.Int16x8.extractLane(m, 0));
+  equal(32, SIMD.Int16x8.extractLane(m, 1));
+  equal(-64, SIMD.Int16x8.extractLane(m, 2));
+  equal(128, SIMD.Int16x8.extractLane(m, 3));
+  equal(-256, SIMD.Int16x8.extractLane(m, 4));
+  equal(512, SIMD.Int16x8.extractLane(m, 5));
+  equal(-1024, SIMD.Int16x8.extractLane(m, 6));
+  equal(2048, SIMD.Int16x8.extractLane(m, 7));
 
-  var n = SIMD.int16x8(0, 0, 0x7fff, 0xffff, -1, -1, 0x8000, 0x0000);
-  n = SIMD.int16x8.neg(n);
-  equal(0, SIMD.int16x8.extractLane(n, 0));
-  equal(0, SIMD.int16x8.extractLane(n, 1));
-  equal(-32767, SIMD.int16x8.extractLane(n, 2));
-  equal(1, SIMD.int16x8.extractLane(n, 3));
-  equal(1, SIMD.int16x8.extractLane(n, 4));
-  equal(1, SIMD.int16x8.extractLane(n, 5));
-  equal(-32768, SIMD.int16x8.extractLane(n, 6));
-  equal(0, SIMD.int16x8.extractLane(n, 7));
+  var n = SIMD.Int16x8(0, 0, 0x7fff, 0xffff, -1, -1, 0x8000, 0x0000);
+  n = SIMD.Int16x8.neg(n);
+  equal(0, SIMD.Int16x8.extractLane(n, 0));
+  equal(0, SIMD.Int16x8.extractLane(n, 1));
+  equal(-32767, SIMD.Int16x8.extractLane(n, 2));
+  equal(1, SIMD.Int16x8.extractLane(n, 3));
+  equal(1, SIMD.Int16x8.extractLane(n, 4));
+  equal(1, SIMD.Int16x8.extractLane(n, 5));
+  equal(-32768, SIMD.Int16x8.extractLane(n, 6));
+  equal(0, SIMD.Int16x8.extractLane(n, 7));
 });
 
-test('int16x8 allTrue', function () {
-  var v0000 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v0001 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0xA5A5, 0xA5A5);
-  var v0010 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8000, 0x8001, 0x5A5A, 0x5A5A);
-  var v0100 = SIMD.int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v1000 = SIMD.int16x8(0x8000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v0011 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
-  var v0111 = SIMD.int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x8000, 0x8001, 0xA5A5, 0xA5A5);
-  var v1111 = SIMD.int16x8(0x8000, 0x8000, 0xFFFF, 0xFFFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
-  equal(SIMD.int16x8.allTrue(v0000), false);
-  equal(SIMD.int16x8.allTrue(v0001), false);
-  equal(SIMD.int16x8.allTrue(v0010), false);
-  equal(SIMD.int16x8.allTrue(v0100), false);
-  equal(SIMD.int16x8.allTrue(v1000), false);
-  equal(SIMD.int16x8.allTrue(v0011), false);
-  equal(SIMD.int16x8.allTrue(v0111), false);
-  equal(SIMD.int16x8.allTrue(v1111), true);
+test('Int16x8 allTrue', function () {
+  var v0000 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v0001 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0xA5A5, 0xA5A5);
+  var v0010 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8000, 0x8001, 0x5A5A, 0x5A5A);
+  var v0100 = SIMD.Int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v1000 = SIMD.Int16x8(0x8000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v0011 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
+  var v0111 = SIMD.Int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x8000, 0x8001, 0xA5A5, 0xA5A5);
+  var v1111 = SIMD.Int16x8(0x8000, 0x8000, 0xFFFF, 0xFFFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
+  equal(SIMD.Int16x8.allTrue(v0000), false);
+  equal(SIMD.Int16x8.allTrue(v0001), false);
+  equal(SIMD.Int16x8.allTrue(v0010), false);
+  equal(SIMD.Int16x8.allTrue(v0100), false);
+  equal(SIMD.Int16x8.allTrue(v1000), false);
+  equal(SIMD.Int16x8.allTrue(v0011), false);
+  equal(SIMD.Int16x8.allTrue(v0111), false);
+  equal(SIMD.Int16x8.allTrue(v1111), true);
 });
 
-test('int16x8 anyTrue', function () {
-  var v0000 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v0001 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0xA5A5, 0xA5A5);
-  var v0010 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8000, 0x8001, 0x5A5A, 0x5A5A);
-  var v0100 = SIMD.int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v1000 = SIMD.int16x8(0x8000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
-  var v0011 = SIMD.int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
-  var v0111 = SIMD.int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x8000, 0x8001, 0xA5A5, 0xA5A5);
-  var v1111 = SIMD.int16x8(0x8000, 0x8000, 0xFFFF, 0xFFFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
-  equal(SIMD.int16x8.anyTrue(v0000), false);
-  equal(SIMD.int16x8.anyTrue(v0001), true);
-  equal(SIMD.int16x8.anyTrue(v0010), true);
-  equal(SIMD.int16x8.anyTrue(v0100), true);
-  equal(SIMD.int16x8.anyTrue(v1000), true);
-  equal(SIMD.int16x8.anyTrue(v0011), true);
-  equal(SIMD.int16x8.anyTrue(v0111), true);
-  equal(SIMD.int16x8.anyTrue(v1111), true);
+test('Int16x8 anyTrue', function () {
+  var v0000 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v0001 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0xA5A5, 0xA5A5);
+  var v0010 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8000, 0x8001, 0x5A5A, 0x5A5A);
+  var v0100 = SIMD.Int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v1000 = SIMD.Int16x8(0x8000, 0x0000, 0x7FFF, 0x7FFF, 0x0001, 0x0001, 0x5A5A, 0x5A5A);
+  var v0011 = SIMD.Int16x8(0x0000, 0x0000, 0x7FFF, 0x7FFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
+  var v0111 = SIMD.Int16x8(0x0000, 0x0000, 0xFFFF, 0xFFFF, 0x8000, 0x8001, 0xA5A5, 0xA5A5);
+  var v1111 = SIMD.Int16x8(0x8000, 0x8000, 0xFFFF, 0xFFFF, 0x8001, 0x8001, 0xA5A5, 0xA5A5);
+  equal(SIMD.Int16x8.anyTrue(v0000), false);
+  equal(SIMD.Int16x8.anyTrue(v0001), true);
+  equal(SIMD.Int16x8.anyTrue(v0010), true);
+  equal(SIMD.Int16x8.anyTrue(v0100), true);
+  equal(SIMD.Int16x8.anyTrue(v1000), true);
+  equal(SIMD.Int16x8.anyTrue(v0011), true);
+  equal(SIMD.Int16x8.anyTrue(v0111), true);
+  equal(SIMD.Int16x8.anyTrue(v1111), true);
 });
 
-test('int16x8 add', function() {
-  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x7fff, 0xffff, 0x0, 0x0);
-  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
-  var c = SIMD.int16x8.add(a, b);
-  equal(-1, SIMD.int16x8.extractLane(c, 0));
-  equal(0, SIMD.int16x8.extractLane(c, 1));
-  equal(-2, SIMD.int16x8.extractLane(c, 2));
-  equal(-2, SIMD.int16x8.extractLane(c, 3));
-  equal(0x7fff, SIMD.int16x8.extractLane(c, 4));
-  equal(0, SIMD.int16x8.extractLane(c, 5));
-  equal(-1, SIMD.int16x8.extractLane(c, 6));
-  equal(-1, SIMD.int16x8.extractLane(c, 7));
+test('Int16x8 add', function() {
+  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x7fff, 0xffff, 0x0, 0x0);
+  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
+  var c = SIMD.Int16x8.add(a, b);
+  equal(-1, SIMD.Int16x8.extractLane(c, 0));
+  equal(0, SIMD.Int16x8.extractLane(c, 1));
+  equal(-2, SIMD.Int16x8.extractLane(c, 2));
+  equal(-2, SIMD.Int16x8.extractLane(c, 3));
+  equal(0x7fff, SIMD.Int16x8.extractLane(c, 4));
+  equal(0, SIMD.Int16x8.extractLane(c, 5));
+  equal(-1, SIMD.Int16x8.extractLane(c, 6));
+  equal(-1, SIMD.Int16x8.extractLane(c, 7));
 });
 
-test('int16x8 sub', function() {
-  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
-  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0x0FFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
-  var c = SIMD.int16x8.sub(a, b);
-  equal(-1, SIMD.int16x8.extractLane(c, 0));
-  equal(-2, SIMD.int16x8.extractLane(c, 1));
-  equal(0, SIMD.int16x8.extractLane(c, 2));
-  equal(0, SIMD.int16x8.extractLane(c, 3));
-  equal(-32768, SIMD.int16x8.extractLane(c, 4));
-  equal(-1, SIMD.int16x8.extractLane(c, 5));
-  equal(1, SIMD.int16x8.extractLane(c, 6));
-  equal(1, SIMD.int16x8.extractLane(c, 7));
+test('Int16x8 sub', function() {
+  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
+  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0x0FFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
+  var c = SIMD.Int16x8.sub(a, b);
+  equal(-1, SIMD.Int16x8.extractLane(c, 0));
+  equal(-2, SIMD.Int16x8.extractLane(c, 1));
+  equal(0, SIMD.Int16x8.extractLane(c, 2));
+  equal(0, SIMD.Int16x8.extractLane(c, 3));
+  equal(-32768, SIMD.Int16x8.extractLane(c, 4));
+  equal(-1, SIMD.Int16x8.extractLane(c, 5));
+  equal(1, SIMD.Int16x8.extractLane(c, 6));
+  equal(1, SIMD.Int16x8.extractLane(c, 7));
 });
 
-test('int16x8 mul', function() {
-  var a = SIMD.int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
-  var b = SIMD.int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0xFFFF, 0xFFFF);
-  var c = SIMD.int16x8.mul(a, b);
-  equal(0, SIMD.int16x8.extractLane(c, 0));
-  equal(-1, SIMD.int16x8.extractLane(c, 1));
-  equal(1, SIMD.int16x8.extractLane(c, 2));
-  equal(1, SIMD.int16x8.extractLane(c, 3));
-  equal(0, SIMD.int16x8.extractLane(c, 4));
-  equal(0, SIMD.int16x8.extractLane(c, 5));
-  equal(0, SIMD.int16x8.extractLane(c, 6));
-  equal(0, SIMD.int16x8.extractLane(c, 7));
+test('Int16x8 mul', function() {
+  var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0x0, 0x0);
+  var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x8000, 0x0000, 0xFFFF, 0xFFFF);
+  var c = SIMD.Int16x8.mul(a, b);
+  equal(0, SIMD.Int16x8.extractLane(c, 0));
+  equal(-1, SIMD.Int16x8.extractLane(c, 1));
+  equal(1, SIMD.Int16x8.extractLane(c, 2));
+  equal(1, SIMD.Int16x8.extractLane(c, 3));
+  equal(0, SIMD.Int16x8.extractLane(c, 4));
+  equal(0, SIMD.Int16x8.extractLane(c, 5));
+  equal(0, SIMD.Int16x8.extractLane(c, 6));
+  equal(0, SIMD.Int16x8.extractLane(c, 7));
 });
 
-test('int16x8 addSaturate', function() {
-  var a = SIMD.int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
-  var b = SIMD.int16x8.splat(1);
-  var c = SIMD.int16x8.splat(-1);
-  var d = SIMD.int16x8.addSaturate(a, b);
-  var e = SIMD.int16x8.addSaturate(a, c);
-  equal(1, SIMD.int16x8.extractLane(d, 0));
-  equal(2, SIMD.int16x8.extractLane(d, 1));
-  equal(0x7fff, SIMD.int16x8.extractLane(d, 2));
-  equal(-0x7fff, SIMD.int16x8.extractLane(d, 3));
-  equal(0, SIMD.int16x8.extractLane(d, 4));
-  equal(0x7fff, SIMD.int16x8.extractLane(d, 5));
-  equal(-0x7ffe, SIMD.int16x8.extractLane(d, 6));
-  equal(11, SIMD.int16x8.extractLane(d, 7));
-  equal(-1, SIMD.int16x8.extractLane(e, 0));
-  equal(0, SIMD.int16x8.extractLane(e, 1));
-  equal(0x7ffe, SIMD.int16x8.extractLane(e, 2));
-  equal(-0x8000, SIMD.int16x8.extractLane(e, 3));
-  equal(-2, SIMD.int16x8.extractLane(e, 4));
-  equal(0x7ffd, SIMD.int16x8.extractLane(e, 5));
-  equal(-0x8000, SIMD.int16x8.extractLane(e, 6));
-  equal(9, SIMD.int16x8.extractLane(e, 7));
+test('Int16x8 addSaturate', function() {
+  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
+  var b = SIMD.Int16x8.splat(1);
+  var c = SIMD.Int16x8.splat(-1);
+  var d = SIMD.Int16x8.addSaturate(a, b);
+  var e = SIMD.Int16x8.addSaturate(a, c);
+  equal(1, SIMD.Int16x8.extractLane(d, 0));
+  equal(2, SIMD.Int16x8.extractLane(d, 1));
+  equal(0x7fff, SIMD.Int16x8.extractLane(d, 2));
+  equal(-0x7fff, SIMD.Int16x8.extractLane(d, 3));
+  equal(0, SIMD.Int16x8.extractLane(d, 4));
+  equal(0x7fff, SIMD.Int16x8.extractLane(d, 5));
+  equal(-0x7ffe, SIMD.Int16x8.extractLane(d, 6));
+  equal(11, SIMD.Int16x8.extractLane(d, 7));
+  equal(-1, SIMD.Int16x8.extractLane(e, 0));
+  equal(0, SIMD.Int16x8.extractLane(e, 1));
+  equal(0x7ffe, SIMD.Int16x8.extractLane(e, 2));
+  equal(-0x8000, SIMD.Int16x8.extractLane(e, 3));
+  equal(-2, SIMD.Int16x8.extractLane(e, 4));
+  equal(0x7ffd, SIMD.Int16x8.extractLane(e, 5));
+  equal(-0x8000, SIMD.Int16x8.extractLane(e, 6));
+  equal(9, SIMD.Int16x8.extractLane(e, 7));
 });
 
-test('int16x8 subSaturate', function() {
-  var a = SIMD.int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
-  var b = SIMD.int16x8.splat(1);
-  var c = SIMD.int16x8.splat(-1);
-  var d = SIMD.int16x8.subSaturate(a, b);
-  var e = SIMD.int16x8.subSaturate(a, c);
-  equal(-1, SIMD.int16x8.extractLane(d, 0));
-  equal(0, SIMD.int16x8.extractLane(d, 1));
-  equal(0x7ffe, SIMD.int16x8.extractLane(d, 2));
-  equal(-0x8000, SIMD.int16x8.extractLane(d, 3));
-  equal(-2, SIMD.int16x8.extractLane(d, 4));
-  equal(0x7ffd, SIMD.int16x8.extractLane(d, 5));
-  equal(-0x8000, SIMD.int16x8.extractLane(d, 6));
-  equal(9, SIMD.int16x8.extractLane(d, 7));
-  equal(1, SIMD.int16x8.extractLane(e, 0));
-  equal(2, SIMD.int16x8.extractLane(e, 1));
-  equal(0x7fff, SIMD.int16x8.extractLane(e, 2));
-  equal(-0x7fff, SIMD.int16x8.extractLane(e, 3));
-  equal(0, SIMD.int16x8.extractLane(e, 4));
-  equal(0x7fff, SIMD.int16x8.extractLane(e, 5));
-  equal(-0x7ffe, SIMD.int16x8.extractLane(e, 6));
-  equal(11, SIMD.int16x8.extractLane(e, 7));
+test('Int16x8 subSaturate', function() {
+  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
+  var b = SIMD.Int16x8.splat(1);
+  var c = SIMD.Int16x8.splat(-1);
+  var d = SIMD.Int16x8.subSaturate(a, b);
+  var e = SIMD.Int16x8.subSaturate(a, c);
+  equal(-1, SIMD.Int16x8.extractLane(d, 0));
+  equal(0, SIMD.Int16x8.extractLane(d, 1));
+  equal(0x7ffe, SIMD.Int16x8.extractLane(d, 2));
+  equal(-0x8000, SIMD.Int16x8.extractLane(d, 3));
+  equal(-2, SIMD.Int16x8.extractLane(d, 4));
+  equal(0x7ffd, SIMD.Int16x8.extractLane(d, 5));
+  equal(-0x8000, SIMD.Int16x8.extractLane(d, 6));
+  equal(9, SIMD.Int16x8.extractLane(d, 7));
+  equal(1, SIMD.Int16x8.extractLane(e, 0));
+  equal(2, SIMD.Int16x8.extractLane(e, 1));
+  equal(0x7fff, SIMD.Int16x8.extractLane(e, 2));
+  equal(-0x7fff, SIMD.Int16x8.extractLane(e, 3));
+  equal(0, SIMD.Int16x8.extractLane(e, 4));
+  equal(0x7fff, SIMD.Int16x8.extractLane(e, 5));
+  equal(-0x7ffe, SIMD.Int16x8.extractLane(e, 6));
+  equal(11, SIMD.Int16x8.extractLane(e, 7));
 });
 
-test('int16x8 comparisons', function() {
-  var m = SIMD.int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
-  var n = SIMD.int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
+test('Int16x8 comparisons', function() {
+  var m = SIMD.Int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
+  var n = SIMD.Int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
   var cmp;
-  cmp = SIMD.int16x8.lessThan(m, n);
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 0));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 1));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 2));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 3));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 4));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 5));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 6));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.lessThan(m, n);
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 7));
 
-  cmp = SIMD.int16x8.lessThanOrEqual(m, n);
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 0));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 1));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 2));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 3));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 4));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 5));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 6));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.lessThanOrEqual(m, n);
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 7));
 
-  cmp = SIMD.int16x8.equal(m, n);
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 0));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 1));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 2));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 3));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 4));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 5));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 6));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.equal(m, n);
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 7));
 
-  cmp = SIMD.int16x8.notEqual(m, n);
-  equal(-1, SIMD.int16x8.extractLane(cmp, 0));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 1));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 2));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 3));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 4));
-  equal(0x0, SIMD.int16x8.extractLane(cmp, 5));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 6));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.notEqual(m, n);
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(0x0, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 7));
 
-  cmp = SIMD.int16x8.greaterThan(m, n);
-  equal(-1, SIMD.int16x8.extractLane(cmp, 0));
-  equal(0, SIMD.int16x8.extractLane(cmp, 1));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 2));
-  equal(0, SIMD.int16x8.extractLane(cmp, 3));
-  equal(0, SIMD.int16x8.extractLane(cmp, 4));
-  equal(0, SIMD.int16x8.extractLane(cmp, 5));
-  equal(0, SIMD.int16x8.extractLane(cmp, 6));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.greaterThan(m, n);
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 7));
 
-  cmp = SIMD.int16x8.greaterThanOrEqual(m, n);
-  equal(-1, SIMD.int16x8.extractLane(cmp, 0));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 1));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 2));
-  equal(0, SIMD.int16x8.extractLane(cmp, 3));
-  equal(0, SIMD.int16x8.extractLane(cmp, 4));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 5));
-  equal(0, SIMD.int16x8.extractLane(cmp, 6));
-  equal(-1, SIMD.int16x8.extractLane(cmp, 7));
+  cmp = SIMD.Int16x8.greaterThanOrEqual(m, n);
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 0));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 1));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 2));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 3));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 4));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 5));
+  equal(0, SIMD.Int16x8.extractLane(cmp, 6));
+  equal(-1, SIMD.Int16x8.extractLane(cmp, 7));
 });
 
-test('int16x8 shiftLeftByScalar', function() {
-  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+test('Int16x8 shiftLeftByScalar', function() {
+  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
   var b;
 
-  b = SIMD.int16x8.shiftLeftByScalar(a, 1);
-  equal(SIMD.int16x8.extractLane(b, 0), -2);
-  equal(SIMD.int16x8.extractLane(b, 1), -2);
-  equal(SIMD.int16x8.extractLane(b, 2), -2);
-  equal(SIMD.int16x8.extractLane(b, 3), -2);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0002);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftLeftByScalar(a, 2);
-  equal(SIMD.int16x8.extractLane(b, 0), -4);
-  equal(SIMD.int16x8.extractLane(b, 1), -4);
-  equal(SIMD.int16x8.extractLane(b, 2), -4);
-  equal(SIMD.int16x8.extractLane(b, 3), -4);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0004);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftLeftByScalar(a, 14);
-  equal(SIMD.int16x8.extractLane(b, 0), -16384);
-  equal(SIMD.int16x8.extractLane(b, 1), -16384);
-  equal(SIMD.int16x8.extractLane(b, 2), -16384);
-  equal(SIMD.int16x8.extractLane(b, 3), -16384);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x4000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftLeftByScalar(a, 15);
-  equal(SIMD.int16x8.extractLane(b, 0), -32768);
-  equal(SIMD.int16x8.extractLane(b, 1), -32768);
-  equal(SIMD.int16x8.extractLane(b, 2), -32768);
-  equal(SIMD.int16x8.extractLane(b, 3), -32768);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), -32768);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftLeftByScalar(a, 16);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.int16x8.shiftLeftByScalar(a, -1);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, 1);
+  equal(SIMD.Int16x8.extractLane(b, 0), -2);
+  equal(SIMD.Int16x8.extractLane(b, 1), -2);
+  equal(SIMD.Int16x8.extractLane(b, 2), -2);
+  equal(SIMD.Int16x8.extractLane(b, 3), -2);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0002);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, 2);
+  equal(SIMD.Int16x8.extractLane(b, 0), -4);
+  equal(SIMD.Int16x8.extractLane(b, 1), -4);
+  equal(SIMD.Int16x8.extractLane(b, 2), -4);
+  equal(SIMD.Int16x8.extractLane(b, 3), -4);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0004);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, 14);
+  equal(SIMD.Int16x8.extractLane(b, 0), -16384);
+  equal(SIMD.Int16x8.extractLane(b, 1), -16384);
+  equal(SIMD.Int16x8.extractLane(b, 2), -16384);
+  equal(SIMD.Int16x8.extractLane(b, 3), -16384);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x4000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, 15);
+  equal(SIMD.Int16x8.extractLane(b, 0), -32768);
+  equal(SIMD.Int16x8.extractLane(b, 1), -32768);
+  equal(SIMD.Int16x8.extractLane(b, 2), -32768);
+  equal(SIMD.Int16x8.extractLane(b, 3), -32768);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), -32768);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, 16);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftLeftByScalar(a, -1);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
 });
 
-test('int16x8 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+test('Int16x8 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
   var b;
 
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x3fff);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x1fff);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 14);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0001);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 15);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, 16);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.int16x8.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.int16x8.extractLane(b, 0), -1);
-  equal(SIMD.int16x8.extractLane(b, 1), -1);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), -1);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 1);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x3fff);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 2);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x1fff);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 14);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0001);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 15);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, 16);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftRightArithmeticByScalar(a, -1);
+  equal(SIMD.Int16x8.extractLane(b, 0), -1);
+  equal(SIMD.Int16x8.extractLane(b, 1), -1);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), -1);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
 });
 
-test('int16x8 shiftRightLogicalByScalar', function() {
-  var a = SIMD.int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
+test('Int16x8 shiftRightLogicalByScalar', function() {
+  var a = SIMD.Int16x8(0xffff, 0xffff, 0x7fff, 0xffff, 0x0, 0x1, 0x0, 0x0);
   var b;
 
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x7fff);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x7fff);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x3fff);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x7fff);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x3fff);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x3fff);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x1fff);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x3fff);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 14);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0003);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0003);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0001);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0003);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 15);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0001);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0001);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0001);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0000);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0000);
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, 16);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
-  b = SIMD.int16x8.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.int16x8.extractLane(b, 0), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 1), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 2), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 3), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 4), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 5), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 6), 0x0);
-  equal(SIMD.int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 1);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x7fff);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x7fff);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x3fff);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x7fff);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 2);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x3fff);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x3fff);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x1fff);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x3fff);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 14);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0003);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0003);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0001);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0003);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 15);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0001);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0001);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0001);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0000);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0000);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, 16);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
+  b = SIMD.Int16x8.shiftRightLogicalByScalar(a, -1);
+  equal(SIMD.Int16x8.extractLane(b, 0), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 1), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 2), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 3), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 4), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 5), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 6), 0x0);
+  equal(SIMD.Int16x8.extractLane(b, 7), 0x0);
 });
 
-test('int16x8 select', function() {
-  var m = SIMD.int16x8.bool(true, true, true, true, false, false, false, false);
-  var t = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var f = SIMD.int16x8(9, 10, 11, 12, 13, 14, 15, 16);
-  var s = SIMD.int16x8.select(m, t, f);
-  equal(1, SIMD.int16x8.extractLane(s, 0));
-  equal(2, SIMD.int16x8.extractLane(s, 1));
-  equal(3, SIMD.int16x8.extractLane(s, 2));
-  equal(4, SIMD.int16x8.extractLane(s, 3));
-  equal(13, SIMD.int16x8.extractLane(s, 4));
-  equal(14, SIMD.int16x8.extractLane(s, 5));
-  equal(15, SIMD.int16x8.extractLane(s, 6));
-  equal(16, SIMD.int16x8.extractLane(s, 7));
+test('Int16x8 select', function() {
+  var m = SIMD.Int16x8.bool(true, true, true, true, false, false, false, false);
+  var t = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var f = SIMD.Int16x8(9, 10, 11, 12, 13, 14, 15, 16);
+  var s = SIMD.Int16x8.select(m, t, f);
+  equal(1, SIMD.Int16x8.extractLane(s, 0));
+  equal(2, SIMD.Int16x8.extractLane(s, 1));
+  equal(3, SIMD.Int16x8.extractLane(s, 2));
+  equal(4, SIMD.Int16x8.extractLane(s, 3));
+  equal(13, SIMD.Int16x8.extractLane(s, 4));
+  equal(14, SIMD.Int16x8.extractLane(s, 5));
+  equal(15, SIMD.Int16x8.extractLane(s, 6));
+  equal(16, SIMD.Int16x8.extractLane(s, 7));
 });
 
-test('int16x8 selectBits', function() {
-  var m = SIMD.int16x8(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x55555555);
-  var t = SIMD.int16x8(1, 2, 3, 4, 5, 6, 7, 8);
-  var f = SIMD.int16x8(9, 10, 11, 12, 13, 14, 15, 16);
-  var s = SIMD.int16x8.selectBits(m, t, f);
-  equal(1, SIMD.int16x8.extractLane(s, 0));
-  equal(2, SIMD.int16x8.extractLane(s, 1));
-  equal(3, SIMD.int16x8.extractLane(s, 2));
-  equal(4, SIMD.int16x8.extractLane(s, 3));
-  equal(5, SIMD.int16x8.extractLane(s, 4));
-  equal(6, SIMD.int16x8.extractLane(s, 5));
-  equal(15, SIMD.int16x8.extractLane(s, 6));
-  equal(0, SIMD.int16x8.extractLane(s, 7));
+test('Int16x8 selectBits', function() {
+  var m = SIMD.Int16x8(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x55555555);
+  var t = SIMD.Int16x8(1, 2, 3, 4, 5, 6, 7, 8);
+  var f = SIMD.Int16x8(9, 10, 11, 12, 13, 14, 15, 16);
+  var s = SIMD.Int16x8.selectBits(m, t, f);
+  equal(1, SIMD.Int16x8.extractLane(s, 0));
+  equal(2, SIMD.Int16x8.extractLane(s, 1));
+  equal(3, SIMD.Int16x8.extractLane(s, 2));
+  equal(4, SIMD.Int16x8.extractLane(s, 3));
+  equal(5, SIMD.Int16x8.extractLane(s, 4));
+  equal(6, SIMD.Int16x8.extractLane(s, 5));
+  equal(15, SIMD.Int16x8.extractLane(s, 6));
+  equal(0, SIMD.Int16x8.extractLane(s, 7));
 });
 
-test('int8x16 swizzle', function() {
-  var a    = SIMD.int8x16(1, 2, 3, 2147483647, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -37);
-  var xyxy = SIMD.int8x16.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
-  var zwzw = SIMD.int8x16.swizzle(a, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9);
-  var xxxx = SIMD.int8x16.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-  equal(1, SIMD.int8x16.extractLane(xyxy, 0));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 1));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 2));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 3));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 4));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 5));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 6));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 7));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 8));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 9));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 10));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 11));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 12));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 13));
-  equal(1, SIMD.int8x16.extractLane(xyxy, 14));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 15));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 0));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 1));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 2));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 3));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 4));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 5));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 6));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 7));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 8));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 9));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 10));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 11));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 12));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 13));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 14));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 15));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 0));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 1));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 2));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 3));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 4));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 5));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 6));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 7));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 8));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 9));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 10));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 11));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 12));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 13));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 14));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 15));
+test('Int8x16 swizzle', function() {
+  var a    = SIMD.Int8x16(1, 2, 3, 2147483647, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -37);
+  var xyxy = SIMD.Int8x16.swizzle(a, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+  var zwzw = SIMD.Int8x16.swizzle(a, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9);
+  var xxxx = SIMD.Int8x16.swizzle(a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 0));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 1));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 2));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 3));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 4));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 5));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 6));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 7));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 8));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 9));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 10));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 11));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 12));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 13));
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 14));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 15));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 0));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 1));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 2));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 3));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 4));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 5));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 6));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 7));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 8));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 9));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 10));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 11));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 12));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 13));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 14));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 15));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 0));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 1));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 2));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 3));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 4));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 5));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 6));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 7));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 8));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 9));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 10));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 11));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 12));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 13));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 14));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 15));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int8x16.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
+      throws(function() { SIMD.Int8x16.swizzle(a, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -4271,63 +4271,63 @@ test('int8x16 swizzle', function() {
   testIndexCheck(16);
 });
 
-test('int8x16 shuffle', function() {
-  var a    = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var b    = SIMD.int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127);
-  var xyxy = SIMD.int8x16.shuffle(a, b, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
-  var zwzw = SIMD.int8x16.shuffle(a, b, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
-  var xxxx = SIMD.int8x16.shuffle(a, b, 0, 0, 0, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16, 16, 16);
-  equal(1, SIMD.int8x16.extractLane(xyxy, 0));
-  equal(2, SIMD.int8x16.extractLane(xyxy, 1));
-  equal(3, SIMD.int8x16.extractLane(xyxy, 2));
-  equal(4, SIMD.int8x16.extractLane(xyxy, 3));
-  equal(5, SIMD.int8x16.extractLane(xyxy, 4));
-  equal(6, SIMD.int8x16.extractLane(xyxy, 5));
-  equal(7, SIMD.int8x16.extractLane(xyxy, 6));
-  equal(8, SIMD.int8x16.extractLane(xyxy, 7));
-  equal(17, SIMD.int8x16.extractLane(xyxy, 8));
-  equal(18, SIMD.int8x16.extractLane(xyxy, 9));
-  equal(19, SIMD.int8x16.extractLane(xyxy, 10));
-  equal(20, SIMD.int8x16.extractLane(xyxy, 11));
-  equal(21, SIMD.int8x16.extractLane(xyxy, 12));
-  equal(22, SIMD.int8x16.extractLane(xyxy, 13));
-  equal(23, SIMD.int8x16.extractLane(xyxy, 14));
-  equal(24, SIMD.int8x16.extractLane(xyxy, 15));
-  equal(9, SIMD.int8x16.extractLane(zwzw, 0));
-  equal(10, SIMD.int8x16.extractLane(zwzw, 1));
-  equal(11, SIMD.int8x16.extractLane(zwzw, 2));
-  equal(12, SIMD.int8x16.extractLane(zwzw, 3));
-  equal(13, SIMD.int8x16.extractLane(zwzw, 4));
-  equal(14, SIMD.int8x16.extractLane(zwzw, 5));
-  equal(15, SIMD.int8x16.extractLane(zwzw, 6));
-  equal(16, SIMD.int8x16.extractLane(zwzw, 7));
-  equal(25, SIMD.int8x16.extractLane(zwzw, 8));
-  equal(26, SIMD.int8x16.extractLane(zwzw, 9));
-  equal(27, SIMD.int8x16.extractLane(zwzw, 10));
-  equal(28, SIMD.int8x16.extractLane(zwzw, 11));
-  equal(29, SIMD.int8x16.extractLane(zwzw, 12));
-  equal(30, SIMD.int8x16.extractLane(zwzw, 13));
-  equal(31, SIMD.int8x16.extractLane(zwzw, 14));
-  equal(127, SIMD.int8x16.extractLane(zwzw, 15));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 0));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 1));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 2));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 3));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 4));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 5));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 6));
-  equal(1, SIMD.int8x16.extractLane(xxxx, 7));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 8));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 9));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 10));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 11));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 12));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 13));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 14));
-  equal(17, SIMD.int8x16.extractLane(xxxx, 15));
+test('Int8x16 shuffle', function() {
+  var a    = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var b    = SIMD.Int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127);
+  var xyxy = SIMD.Int8x16.shuffle(a, b, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
+  var zwzw = SIMD.Int8x16.shuffle(a, b, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
+  var xxxx = SIMD.Int8x16.shuffle(a, b, 0, 0, 0, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16, 16, 16);
+  equal(1, SIMD.Int8x16.extractLane(xyxy, 0));
+  equal(2, SIMD.Int8x16.extractLane(xyxy, 1));
+  equal(3, SIMD.Int8x16.extractLane(xyxy, 2));
+  equal(4, SIMD.Int8x16.extractLane(xyxy, 3));
+  equal(5, SIMD.Int8x16.extractLane(xyxy, 4));
+  equal(6, SIMD.Int8x16.extractLane(xyxy, 5));
+  equal(7, SIMD.Int8x16.extractLane(xyxy, 6));
+  equal(8, SIMD.Int8x16.extractLane(xyxy, 7));
+  equal(17, SIMD.Int8x16.extractLane(xyxy, 8));
+  equal(18, SIMD.Int8x16.extractLane(xyxy, 9));
+  equal(19, SIMD.Int8x16.extractLane(xyxy, 10));
+  equal(20, SIMD.Int8x16.extractLane(xyxy, 11));
+  equal(21, SIMD.Int8x16.extractLane(xyxy, 12));
+  equal(22, SIMD.Int8x16.extractLane(xyxy, 13));
+  equal(23, SIMD.Int8x16.extractLane(xyxy, 14));
+  equal(24, SIMD.Int8x16.extractLane(xyxy, 15));
+  equal(9, SIMD.Int8x16.extractLane(zwzw, 0));
+  equal(10, SIMD.Int8x16.extractLane(zwzw, 1));
+  equal(11, SIMD.Int8x16.extractLane(zwzw, 2));
+  equal(12, SIMD.Int8x16.extractLane(zwzw, 3));
+  equal(13, SIMD.Int8x16.extractLane(zwzw, 4));
+  equal(14, SIMD.Int8x16.extractLane(zwzw, 5));
+  equal(15, SIMD.Int8x16.extractLane(zwzw, 6));
+  equal(16, SIMD.Int8x16.extractLane(zwzw, 7));
+  equal(25, SIMD.Int8x16.extractLane(zwzw, 8));
+  equal(26, SIMD.Int8x16.extractLane(zwzw, 9));
+  equal(27, SIMD.Int8x16.extractLane(zwzw, 10));
+  equal(28, SIMD.Int8x16.extractLane(zwzw, 11));
+  equal(29, SIMD.Int8x16.extractLane(zwzw, 12));
+  equal(30, SIMD.Int8x16.extractLane(zwzw, 13));
+  equal(31, SIMD.Int8x16.extractLane(zwzw, 14));
+  equal(127, SIMD.Int8x16.extractLane(zwzw, 15));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 0));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 1));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 2));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 3));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 4));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 5));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 6));
+  equal(1, SIMD.Int8x16.extractLane(xxxx, 7));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 8));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 9));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 10));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 11));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 12));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 13));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 14));
+  equal(17, SIMD.Int8x16.extractLane(xxxx, 15));
 
   function testIndexCheck(index) {
-      throws(function() { SIMD.int8x16.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
+      throws(function() { SIMD.Int8x16.shuffle(a, b, index, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); });
   }
   testIndexCheck(13.37);
   testIndexCheck(null);
@@ -4339,853 +4339,853 @@ test('int8x16 shuffle', function() {
   testIndexCheck(32);
 });
 
-test('int8x16 and', function() {
-  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 170, 170, 170, 170, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  equal(-86, SIMD.int8x16.extractLane(m, 0));
-  equal(-86, SIMD.int8x16.extractLane(m, 1));
-  equal(-86, SIMD.int8x16.extractLane(m, 2));
-  equal(-86, SIMD.int8x16.extractLane(m, 3));
-  equal(-86, SIMD.int8x16.extractLane(m, 4));
-  equal(-86, SIMD.int8x16.extractLane(m, 5));
-  equal(-86, SIMD.int8x16.extractLane(m, 6));
-  equal(-86, SIMD.int8x16.extractLane(m, 7));
-  equal(-86, SIMD.int8x16.extractLane(m, 8));
-  equal(-86, SIMD.int8x16.extractLane(m, 9));
-  equal(-86, SIMD.int8x16.extractLane(m, 10));
-  equal(-86, SIMD.int8x16.extractLane(m, 11));
-  equal(-86, SIMD.int8x16.extractLane(m, 12));
-  equal(-86, SIMD.int8x16.extractLane(m, 13));
-  equal(-86, SIMD.int8x16.extractLane(m, 14));
-  equal(-86, SIMD.int8x16.extractLane(m, 15));
-  equal(85, SIMD.int8x16.extractLane(n, 0));
-  equal(85, SIMD.int8x16.extractLane(n, 1));
-  equal(85, SIMD.int8x16.extractLane(n, 2));
-  equal(85, SIMD.int8x16.extractLane(n, 3));
-  equal(85, SIMD.int8x16.extractLane(n, 4));
-  equal(85, SIMD.int8x16.extractLane(n, 5));
-  equal(85, SIMD.int8x16.extractLane(n, 6));
-  equal(85, SIMD.int8x16.extractLane(n, 7));
-  equal(85, SIMD.int8x16.extractLane(n, 8));
-  equal(85, SIMD.int8x16.extractLane(n, 9));
-  equal(85, SIMD.int8x16.extractLane(n, 10));
-  equal(85, SIMD.int8x16.extractLane(n, 11));
-  equal(85, SIMD.int8x16.extractLane(n, 12));
-  equal(85, SIMD.int8x16.extractLane(n, 13));
-  equal(85, SIMD.int8x16.extractLane(n, 14));
-  equal(85, SIMD.int8x16.extractLane(n, 15));
-  var o = SIMD.int8x16.and(m,n);  // and
-  equal(0x0, SIMD.int8x16.extractLane(o, 0));
-  equal(0x0, SIMD.int8x16.extractLane(o, 1));
-  equal(0x0, SIMD.int8x16.extractLane(o, 2));
-  equal(0x0, SIMD.int8x16.extractLane(o, 3));
-  equal(0x0, SIMD.int8x16.extractLane(o, 4));
-  equal(0x0, SIMD.int8x16.extractLane(o, 5));
-  equal(0x0, SIMD.int8x16.extractLane(o, 6));
-  equal(0x0, SIMD.int8x16.extractLane(o, 7));
-  equal(0x0, SIMD.int8x16.extractLane(o, 8));
-  equal(0x0, SIMD.int8x16.extractLane(o, 9));
-  equal(0x0, SIMD.int8x16.extractLane(o, 10));
-  equal(0x0, SIMD.int8x16.extractLane(o, 11));
-  equal(0x0, SIMD.int8x16.extractLane(o, 12));
-  equal(0x0, SIMD.int8x16.extractLane(o, 13));
-  equal(0x0, SIMD.int8x16.extractLane(o, 14));
-  equal(0x0, SIMD.int8x16.extractLane(o, 15));
+test('Int8x16 and', function() {
+  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 170, 170, 170, 170, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  equal(-86, SIMD.Int8x16.extractLane(m, 0));
+  equal(-86, SIMD.Int8x16.extractLane(m, 1));
+  equal(-86, SIMD.Int8x16.extractLane(m, 2));
+  equal(-86, SIMD.Int8x16.extractLane(m, 3));
+  equal(-86, SIMD.Int8x16.extractLane(m, 4));
+  equal(-86, SIMD.Int8x16.extractLane(m, 5));
+  equal(-86, SIMD.Int8x16.extractLane(m, 6));
+  equal(-86, SIMD.Int8x16.extractLane(m, 7));
+  equal(-86, SIMD.Int8x16.extractLane(m, 8));
+  equal(-86, SIMD.Int8x16.extractLane(m, 9));
+  equal(-86, SIMD.Int8x16.extractLane(m, 10));
+  equal(-86, SIMD.Int8x16.extractLane(m, 11));
+  equal(-86, SIMD.Int8x16.extractLane(m, 12));
+  equal(-86, SIMD.Int8x16.extractLane(m, 13));
+  equal(-86, SIMD.Int8x16.extractLane(m, 14));
+  equal(-86, SIMD.Int8x16.extractLane(m, 15));
+  equal(85, SIMD.Int8x16.extractLane(n, 0));
+  equal(85, SIMD.Int8x16.extractLane(n, 1));
+  equal(85, SIMD.Int8x16.extractLane(n, 2));
+  equal(85, SIMD.Int8x16.extractLane(n, 3));
+  equal(85, SIMD.Int8x16.extractLane(n, 4));
+  equal(85, SIMD.Int8x16.extractLane(n, 5));
+  equal(85, SIMD.Int8x16.extractLane(n, 6));
+  equal(85, SIMD.Int8x16.extractLane(n, 7));
+  equal(85, SIMD.Int8x16.extractLane(n, 8));
+  equal(85, SIMD.Int8x16.extractLane(n, 9));
+  equal(85, SIMD.Int8x16.extractLane(n, 10));
+  equal(85, SIMD.Int8x16.extractLane(n, 11));
+  equal(85, SIMD.Int8x16.extractLane(n, 12));
+  equal(85, SIMD.Int8x16.extractLane(n, 13));
+  equal(85, SIMD.Int8x16.extractLane(n, 14));
+  equal(85, SIMD.Int8x16.extractLane(n, 15));
+  var o = SIMD.Int8x16.and(m,n);  // and
+  equal(0x0, SIMD.Int8x16.extractLane(o, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 3));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 4));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 5));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 6));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 7));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 8));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 9));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 11));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 12));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 13));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 14));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 15));
 });
 
-test('int8x16 or', function() {
-  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  var o = SIMD.int8x16.or(m,n);  // or
-  equal(-1, SIMD.int8x16.extractLane(o, 0));
-  equal(-1, SIMD.int8x16.extractLane(o, 1));
-  equal(-1, SIMD.int8x16.extractLane(o, 2));
-  equal(-1, SIMD.int8x16.extractLane(o, 3));
-  equal(-1, SIMD.int8x16.extractLane(o, 4));
-  equal(-1, SIMD.int8x16.extractLane(o, 5));
-  equal(-1, SIMD.int8x16.extractLane(o, 6));
-  equal(-1, SIMD.int8x16.extractLane(o, 7));
-  equal(-1, SIMD.int8x16.extractLane(o, 8));
-  equal(-1, SIMD.int8x16.extractLane(o, 9));
-  equal(-1, SIMD.int8x16.extractLane(o, 10));
-  equal(-1, SIMD.int8x16.extractLane(o, 11));
-  equal(-1, SIMD.int8x16.extractLane(o, 12));
-  equal(-1, SIMD.int8x16.extractLane(o, 13));
-  equal(-1, SIMD.int8x16.extractLane(o, 14));
-  equal(-1, SIMD.int8x16.extractLane(o, 15));
+test('Int8x16 or', function() {
+  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  var o = SIMD.Int8x16.or(m,n);  // or
+  equal(-1, SIMD.Int8x16.extractLane(o, 0));
+  equal(-1, SIMD.Int8x16.extractLane(o, 1));
+  equal(-1, SIMD.Int8x16.extractLane(o, 2));
+  equal(-1, SIMD.Int8x16.extractLane(o, 3));
+  equal(-1, SIMD.Int8x16.extractLane(o, 4));
+  equal(-1, SIMD.Int8x16.extractLane(o, 5));
+  equal(-1, SIMD.Int8x16.extractLane(o, 6));
+  equal(-1, SIMD.Int8x16.extractLane(o, 7));
+  equal(-1, SIMD.Int8x16.extractLane(o, 8));
+  equal(-1, SIMD.Int8x16.extractLane(o, 9));
+  equal(-1, SIMD.Int8x16.extractLane(o, 10));
+  equal(-1, SIMD.Int8x16.extractLane(o, 11));
+  equal(-1, SIMD.Int8x16.extractLane(o, 12));
+  equal(-1, SIMD.Int8x16.extractLane(o, 13));
+  equal(-1, SIMD.Int8x16.extractLane(o, 14));
+  equal(-1, SIMD.Int8x16.extractLane(o, 15));
 });
 
-test('int8x16 xor', function() {
-  var m = SIMD.int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
-  var n = SIMD.int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
-  var o = SIMD.int8x16.xor(m,n);  // xor
-  equal(-1, SIMD.int8x16.extractLane(o, 0));
-  equal(-1, SIMD.int8x16.extractLane(o, 1));
-  equal(-1, SIMD.int8x16.extractLane(o, 2));
-  equal(-1, SIMD.int8x16.extractLane(o, 3));
-  equal(-1, SIMD.int8x16.extractLane(o, 4));
-  equal(-1, SIMD.int8x16.extractLane(o, 5));
-  equal(-1, SIMD.int8x16.extractLane(o, 6));
-  equal(-1, SIMD.int8x16.extractLane(o, 7));
-  equal(-1, SIMD.int8x16.extractLane(o, 8));
-  equal(-1, SIMD.int8x16.extractLane(o, 9));
-  equal(-1, SIMD.int8x16.extractLane(o, 10));
-  equal(-1, SIMD.int8x16.extractLane(o, 11));
-  equal(-1, SIMD.int8x16.extractLane(o, 12));
-  equal(-1, SIMD.int8x16.extractLane(o, 13));
-  equal(-1, SIMD.int8x16.extractLane(o, 14));
-  equal(-1, SIMD.int8x16.extractLane(o, 15));
-  o = SIMD.int8x16.xor(m,m);  // xor
-  equal(0x0, SIMD.int8x16.extractLane(o, 0));
-  equal(0x0, SIMD.int8x16.extractLane(o, 1));
-  equal(0x0, SIMD.int8x16.extractLane(o, 2));
-  equal(0x0, SIMD.int8x16.extractLane(o, 3));
-  equal(0x0, SIMD.int8x16.extractLane(o, 4));
-  equal(0x0, SIMD.int8x16.extractLane(o, 5));
-  equal(0x0, SIMD.int8x16.extractLane(o, 6));
-  equal(0x0, SIMD.int8x16.extractLane(o, 7));
-  equal(0x0, SIMD.int8x16.extractLane(o, 8));
-  equal(0x0, SIMD.int8x16.extractLane(o, 9));
-  equal(0x0, SIMD.int8x16.extractLane(o, 10));
-  equal(0x0, SIMD.int8x16.extractLane(o, 11));
-  equal(0x0, SIMD.int8x16.extractLane(o, 12));
-  equal(0x0, SIMD.int8x16.extractLane(o, 13));
-  equal(0x0, SIMD.int8x16.extractLane(o, 14));
-  equal(0x0, SIMD.int8x16.extractLane(o, 15));
+test('Int8x16 xor', function() {
+  var m = SIMD.Int8x16(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
+  var n = SIMD.Int8x16(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55);
+  var o = SIMD.Int8x16.xor(m,n);  // xor
+  equal(-1, SIMD.Int8x16.extractLane(o, 0));
+  equal(-1, SIMD.Int8x16.extractLane(o, 1));
+  equal(-1, SIMD.Int8x16.extractLane(o, 2));
+  equal(-1, SIMD.Int8x16.extractLane(o, 3));
+  equal(-1, SIMD.Int8x16.extractLane(o, 4));
+  equal(-1, SIMD.Int8x16.extractLane(o, 5));
+  equal(-1, SIMD.Int8x16.extractLane(o, 6));
+  equal(-1, SIMD.Int8x16.extractLane(o, 7));
+  equal(-1, SIMD.Int8x16.extractLane(o, 8));
+  equal(-1, SIMD.Int8x16.extractLane(o, 9));
+  equal(-1, SIMD.Int8x16.extractLane(o, 10));
+  equal(-1, SIMD.Int8x16.extractLane(o, 11));
+  equal(-1, SIMD.Int8x16.extractLane(o, 12));
+  equal(-1, SIMD.Int8x16.extractLane(o, 13));
+  equal(-1, SIMD.Int8x16.extractLane(o, 14));
+  equal(-1, SIMD.Int8x16.extractLane(o, 15));
+  o = SIMD.Int8x16.xor(m,m);  // xor
+  equal(0x0, SIMD.Int8x16.extractLane(o, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 3));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 4));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 5));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 6));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 7));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 8));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 9));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 11));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 12));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 13));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 14));
+  equal(0x0, SIMD.Int8x16.extractLane(o, 15));
 });
 
-test('int8x16 neg', function() {
-  var m = SIMD.int8x16(16, -32, 64, -128, 256, -512, 1024, -2048, 4096, -8192, 16384, -32768, 65536, -131072, 262144, -524288);
-  m = SIMD.int8x16.neg(m);
-  equal(-16, SIMD.int8x16.extractLane(m, 0));
-  equal(32, SIMD.int8x16.extractLane(m, 1));
-  equal(-64, SIMD.int8x16.extractLane(m, 2));
-  equal(-128, SIMD.int8x16.extractLane(m, 3));
-  equal(0, SIMD.int8x16.extractLane(m, 4));
-  equal(0, SIMD.int8x16.extractLane(m, 5));
-  equal(0, SIMD.int8x16.extractLane(m, 6));
-  equal(0, SIMD.int8x16.extractLane(m, 7));
-  equal(0, SIMD.int8x16.extractLane(m, 8));
-  equal(0, SIMD.int8x16.extractLane(m, 9));
-  equal(0, SIMD.int8x16.extractLane(m, 10));
-  equal(0, SIMD.int8x16.extractLane(m, 11));
-  equal(0, SIMD.int8x16.extractLane(m, 12));
-  equal(0, SIMD.int8x16.extractLane(m, 13));
-  equal(0, SIMD.int8x16.extractLane(m, 14));
-  equal(0, SIMD.int8x16.extractLane(m, 15));
+test('Int8x16 neg', function() {
+  var m = SIMD.Int8x16(16, -32, 64, -128, 256, -512, 1024, -2048, 4096, -8192, 16384, -32768, 65536, -131072, 262144, -524288);
+  m = SIMD.Int8x16.neg(m);
+  equal(-16, SIMD.Int8x16.extractLane(m, 0));
+  equal(32, SIMD.Int8x16.extractLane(m, 1));
+  equal(-64, SIMD.Int8x16.extractLane(m, 2));
+  equal(-128, SIMD.Int8x16.extractLane(m, 3));
+  equal(0, SIMD.Int8x16.extractLane(m, 4));
+  equal(0, SIMD.Int8x16.extractLane(m, 5));
+  equal(0, SIMD.Int8x16.extractLane(m, 6));
+  equal(0, SIMD.Int8x16.extractLane(m, 7));
+  equal(0, SIMD.Int8x16.extractLane(m, 8));
+  equal(0, SIMD.Int8x16.extractLane(m, 9));
+  equal(0, SIMD.Int8x16.extractLane(m, 10));
+  equal(0, SIMD.Int8x16.extractLane(m, 11));
+  equal(0, SIMD.Int8x16.extractLane(m, 12));
+  equal(0, SIMD.Int8x16.extractLane(m, 13));
+  equal(0, SIMD.Int8x16.extractLane(m, 14));
+  equal(0, SIMD.Int8x16.extractLane(m, 15));
 
-  var n = SIMD.int8x16(0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff, -1, -1, -1, -1, 0x80, 0x00, 0x00, 0x00);
-  n = SIMD.int8x16.neg(n);
-  equal(0, SIMD.int8x16.extractLane(n, 0));
-  equal(0, SIMD.int8x16.extractLane(n, 1));
-  equal(0, SIMD.int8x16.extractLane(n, 2));
-  equal(0, SIMD.int8x16.extractLane(n, 3));
-  equal(-127, SIMD.int8x16.extractLane(n, 4));
-  equal(1, SIMD.int8x16.extractLane(n, 5));
-  equal(1, SIMD.int8x16.extractLane(n, 6));
-  equal(1, SIMD.int8x16.extractLane(n, 7));
-  equal(1, SIMD.int8x16.extractLane(n, 8));
-  equal(1, SIMD.int8x16.extractLane(n, 9));
-  equal(1, SIMD.int8x16.extractLane(n, 10));
-  equal(1, SIMD.int8x16.extractLane(n, 11));
-  equal(-128, SIMD.int8x16.extractLane(n, 12));
-  equal(0, SIMD.int8x16.extractLane(n, 13));
-  equal(0, SIMD.int8x16.extractLane(n, 14));
-  equal(0, SIMD.int8x16.extractLane(n, 15));
+  var n = SIMD.Int8x16(0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff, -1, -1, -1, -1, 0x80, 0x00, 0x00, 0x00);
+  n = SIMD.Int8x16.neg(n);
+  equal(0, SIMD.Int8x16.extractLane(n, 0));
+  equal(0, SIMD.Int8x16.extractLane(n, 1));
+  equal(0, SIMD.Int8x16.extractLane(n, 2));
+  equal(0, SIMD.Int8x16.extractLane(n, 3));
+  equal(-127, SIMD.Int8x16.extractLane(n, 4));
+  equal(1, SIMD.Int8x16.extractLane(n, 5));
+  equal(1, SIMD.Int8x16.extractLane(n, 6));
+  equal(1, SIMD.Int8x16.extractLane(n, 7));
+  equal(1, SIMD.Int8x16.extractLane(n, 8));
+  equal(1, SIMD.Int8x16.extractLane(n, 9));
+  equal(1, SIMD.Int8x16.extractLane(n, 10));
+  equal(1, SIMD.Int8x16.extractLane(n, 11));
+  equal(-128, SIMD.Int8x16.extractLane(n, 12));
+  equal(0, SIMD.Int8x16.extractLane(n, 13));
+  equal(0, SIMD.Int8x16.extractLane(n, 14));
+  equal(0, SIMD.Int8x16.extractLane(n, 15));
 });
 
-test('int8x16 allTrue', function () {
-  var v0000 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0001 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v0010 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0100 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v1000 = SIMD.int8x16(0x80, 0x80, 0x80, 0x80, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0011 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v0111 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v1111 = SIMD.int8x16(0x80, 0x80, 0x80, 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  equal(SIMD.int8x16.allTrue(v0000), false);
-  equal(SIMD.int8x16.allTrue(v0001), false);
-  equal(SIMD.int8x16.allTrue(v0010), false);
-  equal(SIMD.int8x16.allTrue(v0100), false);
-  equal(SIMD.int8x16.allTrue(v1000), false);
-  equal(SIMD.int8x16.allTrue(v0011), false);
-  equal(SIMD.int8x16.allTrue(v0111), false);
-  equal(SIMD.int8x16.allTrue(v1111), true);
+test('Int8x16 allTrue', function () {
+  var v0000 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0001 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v0010 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0100 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v1000 = SIMD.Int8x16(0x80, 0x80, 0x80, 0x80, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0011 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v0111 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v1111 = SIMD.Int8x16(0x80, 0x80, 0x80, 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  equal(SIMD.Int8x16.allTrue(v0000), false);
+  equal(SIMD.Int8x16.allTrue(v0001), false);
+  equal(SIMD.Int8x16.allTrue(v0010), false);
+  equal(SIMD.Int8x16.allTrue(v0100), false);
+  equal(SIMD.Int8x16.allTrue(v1000), false);
+  equal(SIMD.Int8x16.allTrue(v0011), false);
+  equal(SIMD.Int8x16.allTrue(v0111), false);
+  equal(SIMD.Int8x16.allTrue(v1111), true);
 });
 
-test('int8x16 anyTrue', function () {
-  var v0000 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0001 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v0010 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0100 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v1000 = SIMD.int8x16(0x80, 0x80, 0x80, 0x80, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
-  var v0011 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v0111 = SIMD.int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  var v1111 = SIMD.int8x16(0x80, 0x80, 0x80, 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
-  equal(SIMD.int8x16.anyTrue(v0000), false);
-  equal(SIMD.int8x16.anyTrue(v0001), true);
-  equal(SIMD.int8x16.anyTrue(v0010), true);
-  equal(SIMD.int8x16.anyTrue(v0100), true);
-  equal(SIMD.int8x16.anyTrue(v1000), true);
-  equal(SIMD.int8x16.anyTrue(v0011), true);
-  equal(SIMD.int8x16.anyTrue(v0111), true);
-  equal(SIMD.int8x16.anyTrue(v1111), true);
+test('Int8x16 anyTrue', function () {
+  var v0000 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0001 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v0010 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0100 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v1000 = SIMD.Int8x16(0x80, 0x80, 0x80, 0x80, 0x7F, 0x7F, 0x7F, 0x7F, 0x01, 0x01, 0x01, 0x01, 0x5A, 0x5A, 0x5A, 0x5A);
+  var v0011 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v0111 = SIMD.Int8x16(0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  var v1111 = SIMD.Int8x16(0x80, 0x80, 0x80, 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0x81, 0x81, 0x81, 0x81, 0xA5, 0xA5, 0xA5, 0xA5);
+  equal(SIMD.Int8x16.anyTrue(v0000), false);
+  equal(SIMD.Int8x16.anyTrue(v0001), true);
+  equal(SIMD.Int8x16.anyTrue(v0010), true);
+  equal(SIMD.Int8x16.anyTrue(v0100), true);
+  equal(SIMD.Int8x16.anyTrue(v1000), true);
+  equal(SIMD.Int8x16.anyTrue(v0011), true);
+  equal(SIMD.Int8x16.anyTrue(v0111), true);
+  equal(SIMD.Int8x16.anyTrue(v1111), true);
 });
 
-test('int8x16 add', function () {
-  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.int8x16.add(a, b);
-  equal(-1, SIMD.int8x16.extractLane(c, 0));
-  equal(-1, SIMD.int8x16.extractLane(c, 1));
-  equal(-1, SIMD.int8x16.extractLane(c, 2));
-  equal(0x0, SIMD.int8x16.extractLane(c, 3));
-  equal(-2, SIMD.int8x16.extractLane(c, 4));
-  equal(-2, SIMD.int8x16.extractLane(c, 5));
-  equal(-2, SIMD.int8x16.extractLane(c, 6));
-  equal(-2, SIMD.int8x16.extractLane(c, 7));
-  equal(0x7f, SIMD.int8x16.extractLane(c, 8));
-  equal(-1, SIMD.int8x16.extractLane(c, 9));
-  equal(-1, SIMD.int8x16.extractLane(c, 10));
-  equal(0x0, SIMD.int8x16.extractLane(c, 11));
-  equal(-1, SIMD.int8x16.extractLane(c, 12));
-  equal(-1, SIMD.int8x16.extractLane(c, 13));
-  equal(-1, SIMD.int8x16.extractLane(c, 14));
-  equal(-1, SIMD.int8x16.extractLane(c, 15));
+test('Int8x16 add', function () {
+  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.Int8x16.add(a, b);
+  equal(-1, SIMD.Int8x16.extractLane(c, 0));
+  equal(-1, SIMD.Int8x16.extractLane(c, 1));
+  equal(-1, SIMD.Int8x16.extractLane(c, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(c, 3));
+  equal(-2, SIMD.Int8x16.extractLane(c, 4));
+  equal(-2, SIMD.Int8x16.extractLane(c, 5));
+  equal(-2, SIMD.Int8x16.extractLane(c, 6));
+  equal(-2, SIMD.Int8x16.extractLane(c, 7));
+  equal(0x7f, SIMD.Int8x16.extractLane(c, 8));
+  equal(-1, SIMD.Int8x16.extractLane(c, 9));
+  equal(-1, SIMD.Int8x16.extractLane(c, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(c, 11));
+  equal(-1, SIMD.Int8x16.extractLane(c, 12));
+  equal(-1, SIMD.Int8x16.extractLane(c, 13));
+  equal(-1, SIMD.Int8x16.extractLane(c, 14));
+  equal(-1, SIMD.Int8x16.extractLane(c, 15));
 });
 
-test('int8x16 sub', function() {
-  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.int8x16.sub(a, b);
-  equal(-1, SIMD.int8x16.extractLane(c, 0));
-  equal(-1, SIMD.int8x16.extractLane(c, 1));
-  equal(-1, SIMD.int8x16.extractLane(c, 2));
-  equal(-2, SIMD.int8x16.extractLane(c, 3));
-  equal(0, SIMD.int8x16.extractLane(c, 4));
-  equal(0, SIMD.int8x16.extractLane(c, 5));
-  equal(0, SIMD.int8x16.extractLane(c, 6));
-  equal(0, SIMD.int8x16.extractLane(c, 7));
-  equal(0x7f, SIMD.int8x16.extractLane(c, 8));
-  equal(-1, SIMD.int8x16.extractLane(c, 9));
-  equal(-1, SIMD.int8x16.extractLane(c, 10));
-  equal(-2, SIMD.int8x16.extractLane(c, 11));
-  equal(1, SIMD.int8x16.extractLane(c, 12));
-  equal(1, SIMD.int8x16.extractLane(c, 13));
-  equal(1, SIMD.int8x16.extractLane(c, 14));
-  equal(1, SIMD.int8x16.extractLane(c, 15));
+test('Int8x16 sub', function() {
+  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.Int8x16.sub(a, b);
+  equal(-1, SIMD.Int8x16.extractLane(c, 0));
+  equal(-1, SIMD.Int8x16.extractLane(c, 1));
+  equal(-1, SIMD.Int8x16.extractLane(c, 2));
+  equal(-2, SIMD.Int8x16.extractLane(c, 3));
+  equal(0, SIMD.Int8x16.extractLane(c, 4));
+  equal(0, SIMD.Int8x16.extractLane(c, 5));
+  equal(0, SIMD.Int8x16.extractLane(c, 6));
+  equal(0, SIMD.Int8x16.extractLane(c, 7));
+  equal(0x7f, SIMD.Int8x16.extractLane(c, 8));
+  equal(-1, SIMD.Int8x16.extractLane(c, 9));
+  equal(-1, SIMD.Int8x16.extractLane(c, 10));
+  equal(-2, SIMD.Int8x16.extractLane(c, 11));
+  equal(1, SIMD.Int8x16.extractLane(c, 12));
+  equal(1, SIMD.Int8x16.extractLane(c, 13));
+  equal(1, SIMD.Int8x16.extractLane(c, 14));
+  equal(1, SIMD.Int8x16.extractLane(c, 15));
 });
 
-test('int8x16 mul', function() {
-  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.int8x16.mul(a, b);
-  equal(0x0, SIMD.int8x16.extractLane(c, 0));
-  equal(0x0, SIMD.int8x16.extractLane(c, 1));
-  equal(0x0, SIMD.int8x16.extractLane(c, 2));
-  equal(-1, SIMD.int8x16.extractLane(c, 3));
-  equal(1, SIMD.int8x16.extractLane(c, 4));
-  equal(1, SIMD.int8x16.extractLane(c, 5));
-  equal(1, SIMD.int8x16.extractLane(c, 6));
-  equal(1, SIMD.int8x16.extractLane(c, 7));
-  equal(0, SIMD.int8x16.extractLane(c, 8));
-  equal(0, SIMD.int8x16.extractLane(c, 9));
-  equal(0, SIMD.int8x16.extractLane(c, 10));
-  equal(-1, SIMD.int8x16.extractLane(c, 11));
-  equal(0, SIMD.int8x16.extractLane(c, 12));
-  equal(0, SIMD.int8x16.extractLane(c, 13));
-  equal(0, SIMD.int8x16.extractLane(c, 14));
-  equal(0, SIMD.int8x16.extractLane(c, 15));
+test('Int8x16 mul', function() {
+  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.Int8x16.mul(a, b);
+  equal(0x0, SIMD.Int8x16.extractLane(c, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(c, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(c, 2));
+  equal(-1, SIMD.Int8x16.extractLane(c, 3));
+  equal(1, SIMD.Int8x16.extractLane(c, 4));
+  equal(1, SIMD.Int8x16.extractLane(c, 5));
+  equal(1, SIMD.Int8x16.extractLane(c, 6));
+  equal(1, SIMD.Int8x16.extractLane(c, 7));
+  equal(0, SIMD.Int8x16.extractLane(c, 8));
+  equal(0, SIMD.Int8x16.extractLane(c, 9));
+  equal(0, SIMD.Int8x16.extractLane(c, 10));
+  equal(-1, SIMD.Int8x16.extractLane(c, 11));
+  equal(0, SIMD.Int8x16.extractLane(c, 12));
+  equal(0, SIMD.Int8x16.extractLane(c, 13));
+  equal(0, SIMD.Int8x16.extractLane(c, 14));
+  equal(0, SIMD.Int8x16.extractLane(c, 15));
 });
 
-test('int8x16 addSaturate', function() {
-  var a = SIMD.int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
-  var b = SIMD.int8x16.splat(1);
-  var c = SIMD.int8x16.splat(-1);
-  var d = SIMD.int8x16.addSaturate(a, b);
-  var e = SIMD.int8x16.addSaturate(a, c);
-  equal(1, SIMD.int8x16.extractLane(d, 0));
-  equal(2, SIMD.int8x16.extractLane(d, 1));
-  equal(0x7f, SIMD.int8x16.extractLane(d, 2));
-  equal(-0x7f, SIMD.int8x16.extractLane(d, 3));
-  equal(0, SIMD.int8x16.extractLane(d, 4));
-  equal(0x7f, SIMD.int8x16.extractLane(d, 5));
-  equal(-0x7e, SIMD.int8x16.extractLane(d, 6));
-  equal(11, SIMD.int8x16.extractLane(d, 7));
-  equal(12, SIMD.int8x16.extractLane(d, 8));
-  equal(13, SIMD.int8x16.extractLane(d, 9));
-  equal(14, SIMD.int8x16.extractLane(d, 10));
-  equal(15, SIMD.int8x16.extractLane(d, 11));
-  equal(16, SIMD.int8x16.extractLane(d, 12));
-  equal(17, SIMD.int8x16.extractLane(d, 13));
-  equal(18, SIMD.int8x16.extractLane(d, 14));
-  equal(19, SIMD.int8x16.extractLane(d, 15));
-  equal(-1, SIMD.int8x16.extractLane(e, 0));
-  equal(0, SIMD.int8x16.extractLane(e, 1));
-  equal(0x7e, SIMD.int8x16.extractLane(e, 2));
-  equal(-0x80, SIMD.int8x16.extractLane(e, 3));
-  equal(-2, SIMD.int8x16.extractLane(e, 4));
-  equal(0x7d, SIMD.int8x16.extractLane(e, 5));
-  equal(-0x80, SIMD.int8x16.extractLane(e, 6));
-  equal(9, SIMD.int8x16.extractLane(e, 7));
-  equal(10, SIMD.int8x16.extractLane(e, 8));
-  equal(11, SIMD.int8x16.extractLane(e, 9));
-  equal(12, SIMD.int8x16.extractLane(e, 10));
-  equal(13, SIMD.int8x16.extractLane(e, 11));
-  equal(14, SIMD.int8x16.extractLane(e, 12));
-  equal(15, SIMD.int8x16.extractLane(e, 13));
-  equal(16, SIMD.int8x16.extractLane(e, 14));
-  equal(17, SIMD.int8x16.extractLane(e, 15));
+test('Int8x16 addSaturate', function() {
+  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
+  var b = SIMD.Int8x16.splat(1);
+  var c = SIMD.Int8x16.splat(-1);
+  var d = SIMD.Int8x16.addSaturate(a, b);
+  var e = SIMD.Int8x16.addSaturate(a, c);
+  equal(1, SIMD.Int8x16.extractLane(d, 0));
+  equal(2, SIMD.Int8x16.extractLane(d, 1));
+  equal(0x7f, SIMD.Int8x16.extractLane(d, 2));
+  equal(-0x7f, SIMD.Int8x16.extractLane(d, 3));
+  equal(0, SIMD.Int8x16.extractLane(d, 4));
+  equal(0x7f, SIMD.Int8x16.extractLane(d, 5));
+  equal(-0x7e, SIMD.Int8x16.extractLane(d, 6));
+  equal(11, SIMD.Int8x16.extractLane(d, 7));
+  equal(12, SIMD.Int8x16.extractLane(d, 8));
+  equal(13, SIMD.Int8x16.extractLane(d, 9));
+  equal(14, SIMD.Int8x16.extractLane(d, 10));
+  equal(15, SIMD.Int8x16.extractLane(d, 11));
+  equal(16, SIMD.Int8x16.extractLane(d, 12));
+  equal(17, SIMD.Int8x16.extractLane(d, 13));
+  equal(18, SIMD.Int8x16.extractLane(d, 14));
+  equal(19, SIMD.Int8x16.extractLane(d, 15));
+  equal(-1, SIMD.Int8x16.extractLane(e, 0));
+  equal(0, SIMD.Int8x16.extractLane(e, 1));
+  equal(0x7e, SIMD.Int8x16.extractLane(e, 2));
+  equal(-0x80, SIMD.Int8x16.extractLane(e, 3));
+  equal(-2, SIMD.Int8x16.extractLane(e, 4));
+  equal(0x7d, SIMD.Int8x16.extractLane(e, 5));
+  equal(-0x80, SIMD.Int8x16.extractLane(e, 6));
+  equal(9, SIMD.Int8x16.extractLane(e, 7));
+  equal(10, SIMD.Int8x16.extractLane(e, 8));
+  equal(11, SIMD.Int8x16.extractLane(e, 9));
+  equal(12, SIMD.Int8x16.extractLane(e, 10));
+  equal(13, SIMD.Int8x16.extractLane(e, 11));
+  equal(14, SIMD.Int8x16.extractLane(e, 12));
+  equal(15, SIMD.Int8x16.extractLane(e, 13));
+  equal(16, SIMD.Int8x16.extractLane(e, 14));
+  equal(17, SIMD.Int8x16.extractLane(e, 15));
 });
 
-test('int8x16 subSaturate', function() {
-  var a = SIMD.int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
-  var b = SIMD.int8x16.splat(1);
-  var c = SIMD.int8x16.splat(-1);
-  var d = SIMD.int8x16.subSaturate(a, b);
-  var e = SIMD.int8x16.subSaturate(a, c);
-  equal(-1, SIMD.int8x16.extractLane(d, 0));
-  equal(0, SIMD.int8x16.extractLane(d, 1));
-  equal(0x7e, SIMD.int8x16.extractLane(d, 2));
-  equal(-0x80, SIMD.int8x16.extractLane(d, 3));
-  equal(-2, SIMD.int8x16.extractLane(d, 4));
-  equal(0x7d, SIMD.int8x16.extractLane(d, 5));
-  equal(-0x80, SIMD.int8x16.extractLane(d, 6));
-  equal(9, SIMD.int8x16.extractLane(d, 7));
-  equal(10, SIMD.int8x16.extractLane(d, 8));
-  equal(11, SIMD.int8x16.extractLane(d, 9));
-  equal(12, SIMD.int8x16.extractLane(d, 10));
-  equal(13, SIMD.int8x16.extractLane(d, 11));
-  equal(14, SIMD.int8x16.extractLane(d, 12));
-  equal(15, SIMD.int8x16.extractLane(d, 13));
-  equal(16, SIMD.int8x16.extractLane(d, 14));
-  equal(17, SIMD.int8x16.extractLane(d, 15));
-  equal(1, SIMD.int8x16.extractLane(e, 0));
-  equal(2, SIMD.int8x16.extractLane(e, 1));
-  equal(0x7f, SIMD.int8x16.extractLane(e, 2));
-  equal(-0x7f, SIMD.int8x16.extractLane(e, 3));
-  equal(0, SIMD.int8x16.extractLane(e, 4));
-  equal(0x7f, SIMD.int8x16.extractLane(e, 5));
-  equal(-0x7e, SIMD.int8x16.extractLane(e, 6));
-  equal(11, SIMD.int8x16.extractLane(e, 7));
-  equal(12, SIMD.int8x16.extractLane(e, 8));
-  equal(13, SIMD.int8x16.extractLane(e, 9));
-  equal(14, SIMD.int8x16.extractLane(e, 10));
-  equal(15, SIMD.int8x16.extractLane(e, 11));
-  equal(16, SIMD.int8x16.extractLane(e, 12));
-  equal(17, SIMD.int8x16.extractLane(e, 13));
-  equal(18, SIMD.int8x16.extractLane(e, 14));
-  equal(19, SIMD.int8x16.extractLane(e, 15));
+test('Int8x16 subSaturate', function() {
+  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
+  var b = SIMD.Int8x16.splat(1);
+  var c = SIMD.Int8x16.splat(-1);
+  var d = SIMD.Int8x16.subSaturate(a, b);
+  var e = SIMD.Int8x16.subSaturate(a, c);
+  equal(-1, SIMD.Int8x16.extractLane(d, 0));
+  equal(0, SIMD.Int8x16.extractLane(d, 1));
+  equal(0x7e, SIMD.Int8x16.extractLane(d, 2));
+  equal(-0x80, SIMD.Int8x16.extractLane(d, 3));
+  equal(-2, SIMD.Int8x16.extractLane(d, 4));
+  equal(0x7d, SIMD.Int8x16.extractLane(d, 5));
+  equal(-0x80, SIMD.Int8x16.extractLane(d, 6));
+  equal(9, SIMD.Int8x16.extractLane(d, 7));
+  equal(10, SIMD.Int8x16.extractLane(d, 8));
+  equal(11, SIMD.Int8x16.extractLane(d, 9));
+  equal(12, SIMD.Int8x16.extractLane(d, 10));
+  equal(13, SIMD.Int8x16.extractLane(d, 11));
+  equal(14, SIMD.Int8x16.extractLane(d, 12));
+  equal(15, SIMD.Int8x16.extractLane(d, 13));
+  equal(16, SIMD.Int8x16.extractLane(d, 14));
+  equal(17, SIMD.Int8x16.extractLane(d, 15));
+  equal(1, SIMD.Int8x16.extractLane(e, 0));
+  equal(2, SIMD.Int8x16.extractLane(e, 1));
+  equal(0x7f, SIMD.Int8x16.extractLane(e, 2));
+  equal(-0x7f, SIMD.Int8x16.extractLane(e, 3));
+  equal(0, SIMD.Int8x16.extractLane(e, 4));
+  equal(0x7f, SIMD.Int8x16.extractLane(e, 5));
+  equal(-0x7e, SIMD.Int8x16.extractLane(e, 6));
+  equal(11, SIMD.Int8x16.extractLane(e, 7));
+  equal(12, SIMD.Int8x16.extractLane(e, 8));
+  equal(13, SIMD.Int8x16.extractLane(e, 9));
+  equal(14, SIMD.Int8x16.extractLane(e, 10));
+  equal(15, SIMD.Int8x16.extractLane(e, 11));
+  equal(16, SIMD.Int8x16.extractLane(e, 12));
+  equal(17, SIMD.Int8x16.extractLane(e, 13));
+  equal(18, SIMD.Int8x16.extractLane(e, 14));
+  equal(19, SIMD.Int8x16.extractLane(e, 15));
 });
 
-test('int8x16 sumOfAbsoluteDifferences', function() {
-  var a = SIMD.int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.int8x16.sumOfAbsoluteDifferences(a, b);
+test('Int8x16 sumOfAbsoluteDifferences', function() {
+  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
+  var c = SIMD.Int8x16.sumOfAbsoluteDifferences(a, b);
   equal(c, 140);
 });
 
-test('int8x16 comparisons', function() {
-  var m = SIMD.int8x16(1000, 2000, 100, 1, -1000, -2000, -100, 1, 0, 0, 0, 0, -1, 1, -2, 2);
-  var n = SIMD.int8x16(-2000, 2000, 1, 100, 2000, -2000, -1, -100, -1, 1, -2, 2, 0, 0, 0, 0);
+test('Int8x16 comparisons', function() {
+  var m = SIMD.Int8x16(1000, 2000, 100, 1, -1000, -2000, -100, 1, 0, 0, 0, 0, -1, 1, -2, 2);
+  var n = SIMD.Int8x16(-2000, 2000, 1, 100, 2000, -2000, -1, -100, -1, 1, -2, 2, 0, 0, 0, 0);
   var cmp;
-  cmp = SIMD.int8x16.lessThan(m, n);
-  equal(-1, SIMD.int8x16.extractLane(cmp, 0));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 1));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 2));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 3));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 4));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 5));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 6));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 7));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 8));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 9));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 10));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 11));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 12));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 13));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 14));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.lessThan(m, n);
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 15));
 
-  cmp = SIMD.int8x16.lessThanOrEqual(m, n);
-  equal(-1, SIMD.int8x16.extractLane(cmp, 0));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 1));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 2));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 3));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 4));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 5));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 6));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 7));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 8));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 9));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 10));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 11));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 12));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 13));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 14));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.lessThanOrEqual(m, n);
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 15));
 
-  cmp = SIMD.int8x16.equal(m, n);
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 0));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 1));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 2));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 3));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 4));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 5));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 6));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 7));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 8));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 9));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 10));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 11));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 12));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 13));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 14));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.equal(m, n);
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 15));
 
-  cmp = SIMD.int8x16.notEqual(m, n);
-  equal(-1, SIMD.int8x16.extractLane(cmp, 0));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 1));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 2));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 3));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 4));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 5));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 6));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 7));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 8));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 9));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 10));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 11));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 12));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 13));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 14));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.notEqual(m, n);
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 15));
 
-  cmp = SIMD.int8x16.greaterThan(m, n);
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 0));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 1));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 2));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 3));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 4));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 5));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 6));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 7));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 8));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 9));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 10));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 11));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 12));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 13));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 14));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.greaterThan(m, n);
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 15));
 
-  cmp = SIMD.int8x16.greaterThanOrEqual(m, n);
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 0));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 1));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 2));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 3));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 4));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 5));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 6));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 7));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 8));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 9));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 10));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 11));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 12));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 13));
-  equal(0x0, SIMD.int8x16.extractLane(cmp, 14));
-  equal(-1, SIMD.int8x16.extractLane(cmp, 15));
+  cmp = SIMD.Int8x16.greaterThanOrEqual(m, n);
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 0));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 1));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 3));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 4));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 5));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 6));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 7));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 8));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 9));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 10));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 11));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 12));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 13));
+  equal(0x0, SIMD.Int8x16.extractLane(cmp, 14));
+  equal(-1, SIMD.Int8x16.extractLane(cmp, 15));
 });
 
-test('int8x16 shiftLeftByScalar', function() {
-  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+test('Int8x16 shiftLeftByScalar', function() {
+  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
   var b;
 
-  b = SIMD.int8x16.shiftLeftByScalar(a, 1);
-  equal(SIMD.int8x16.extractLane(b, 0), -2);
-  equal(SIMD.int8x16.extractLane(b, 1), -2);
-  equal(SIMD.int8x16.extractLane(b, 2), -2);
-  equal(SIMD.int8x16.extractLane(b, 3), -2);
-  equal(SIMD.int8x16.extractLane(b, 4), -2);
-  equal(SIMD.int8x16.extractLane(b, 5), -2);
-  equal(SIMD.int8x16.extractLane(b, 6), -2);
-  equal(SIMD.int8x16.extractLane(b, 7), -2);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x02);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftLeftByScalar(a, 2);
-  equal(SIMD.int8x16.extractLane(b, 0), -4);
-  equal(SIMD.int8x16.extractLane(b, 1), -4);
-  equal(SIMD.int8x16.extractLane(b, 2), -4);
-  equal(SIMD.int8x16.extractLane(b, 3), -4);
-  equal(SIMD.int8x16.extractLane(b, 4), -4);
-  equal(SIMD.int8x16.extractLane(b, 5), -4);
-  equal(SIMD.int8x16.extractLane(b, 6), -4);
-  equal(SIMD.int8x16.extractLane(b, 7), -4);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x04);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftLeftByScalar(a, 6);
-  equal(SIMD.int8x16.extractLane(b, 0), -64);
-  equal(SIMD.int8x16.extractLane(b, 1), -64);
-  equal(SIMD.int8x16.extractLane(b, 2), -64);
-  equal(SIMD.int8x16.extractLane(b, 3), -64);
-  equal(SIMD.int8x16.extractLane(b, 4), -64);
-  equal(SIMD.int8x16.extractLane(b, 5), -64);
-  equal(SIMD.int8x16.extractLane(b, 6), -64);
-  equal(SIMD.int8x16.extractLane(b, 7), -64);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x40);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftLeftByScalar(a, 7);
-  equal(SIMD.int8x16.extractLane(b, 0), -128);
-  equal(SIMD.int8x16.extractLane(b, 1), -128);
-  equal(SIMD.int8x16.extractLane(b, 2), -128);
-  equal(SIMD.int8x16.extractLane(b, 3), -128);
-  equal(SIMD.int8x16.extractLane(b, 4), -128);
-  equal(SIMD.int8x16.extractLane(b, 5), -128);
-  equal(SIMD.int8x16.extractLane(b, 6), -128);
-  equal(SIMD.int8x16.extractLane(b, 7), -128);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), -128);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftLeftByScalar(a, 16);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.int8x16.shiftLeftByScalar(a, -1);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, 1);
+  equal(SIMD.Int8x16.extractLane(b, 0), -2);
+  equal(SIMD.Int8x16.extractLane(b, 1), -2);
+  equal(SIMD.Int8x16.extractLane(b, 2), -2);
+  equal(SIMD.Int8x16.extractLane(b, 3), -2);
+  equal(SIMD.Int8x16.extractLane(b, 4), -2);
+  equal(SIMD.Int8x16.extractLane(b, 5), -2);
+  equal(SIMD.Int8x16.extractLane(b, 6), -2);
+  equal(SIMD.Int8x16.extractLane(b, 7), -2);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x02);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, 2);
+  equal(SIMD.Int8x16.extractLane(b, 0), -4);
+  equal(SIMD.Int8x16.extractLane(b, 1), -4);
+  equal(SIMD.Int8x16.extractLane(b, 2), -4);
+  equal(SIMD.Int8x16.extractLane(b, 3), -4);
+  equal(SIMD.Int8x16.extractLane(b, 4), -4);
+  equal(SIMD.Int8x16.extractLane(b, 5), -4);
+  equal(SIMD.Int8x16.extractLane(b, 6), -4);
+  equal(SIMD.Int8x16.extractLane(b, 7), -4);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x04);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, 6);
+  equal(SIMD.Int8x16.extractLane(b, 0), -64);
+  equal(SIMD.Int8x16.extractLane(b, 1), -64);
+  equal(SIMD.Int8x16.extractLane(b, 2), -64);
+  equal(SIMD.Int8x16.extractLane(b, 3), -64);
+  equal(SIMD.Int8x16.extractLane(b, 4), -64);
+  equal(SIMD.Int8x16.extractLane(b, 5), -64);
+  equal(SIMD.Int8x16.extractLane(b, 6), -64);
+  equal(SIMD.Int8x16.extractLane(b, 7), -64);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x40);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, 7);
+  equal(SIMD.Int8x16.extractLane(b, 0), -128);
+  equal(SIMD.Int8x16.extractLane(b, 1), -128);
+  equal(SIMD.Int8x16.extractLane(b, 2), -128);
+  equal(SIMD.Int8x16.extractLane(b, 3), -128);
+  equal(SIMD.Int8x16.extractLane(b, 4), -128);
+  equal(SIMD.Int8x16.extractLane(b, 5), -128);
+  equal(SIMD.Int8x16.extractLane(b, 6), -128);
+  equal(SIMD.Int8x16.extractLane(b, 7), -128);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), -128);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, 16);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftLeftByScalar(a, -1);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
 });
 
-test('int8x16 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+test('Int8x16 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
   var b;
 
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 1);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 2);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x1f);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 6);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 7);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, 8);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.int8x16.shiftRightArithmeticByScalar(a, -1);
-  equal(SIMD.int8x16.extractLane(b, 0), -1);
-  equal(SIMD.int8x16.extractLane(b, 1), -1);
-  equal(SIMD.int8x16.extractLane(b, 2), -1);
-  equal(SIMD.int8x16.extractLane(b, 3), -1);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), -1);
-  equal(SIMD.int8x16.extractLane(b, 6), -1);
-  equal(SIMD.int8x16.extractLane(b, 7), -1);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 1);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 2);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x1f);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 6);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 7);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, 8);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftRightArithmeticByScalar(a, -1);
+  equal(SIMD.Int8x16.extractLane(b, 0), -1);
+  equal(SIMD.Int8x16.extractLane(b, 1), -1);
+  equal(SIMD.Int8x16.extractLane(b, 2), -1);
+  equal(SIMD.Int8x16.extractLane(b, 3), -1);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), -1);
+  equal(SIMD.Int8x16.extractLane(b, 6), -1);
+  equal(SIMD.Int8x16.extractLane(b, 7), -1);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
 });
 
-test('int8x16 shiftRightLogicalByScalar', function() {
-  var a = SIMD.int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
+test('Int8x16 shiftRightLogicalByScalar', function() {
+  var a = SIMD.Int8x16(0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0);
   var b;
 
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 1);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x7f);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 2);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x1f);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x3f);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 6);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x03);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 7);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x01);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x00);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x00);
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, 8);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
-  b = SIMD.int8x16.shiftRightLogicalByScalar(a, -1);
-  equal(SIMD.int8x16.extractLane(b, 0), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 1), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 2), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 3), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 4), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 5), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 6), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 7), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 8), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 9), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 10), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 11), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 12), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 13), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 14), 0x0);
-  equal(SIMD.int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 1);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x7f);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 2);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x1f);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x3f);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 6);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x03);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 7);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x01);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x00);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x00);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, 8);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
+  b = SIMD.Int8x16.shiftRightLogicalByScalar(a, -1);
+  equal(SIMD.Int8x16.extractLane(b, 0), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 1), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 2), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 3), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 4), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 5), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 6), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 7), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 8), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 9), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 10), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 11), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 12), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 13), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 14), 0x0);
+  equal(SIMD.Int8x16.extractLane(b, 15), 0x0);
 });
 
-test('int8x16 select', function() {
-  var m = SIMD.int8x16.bool(true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false);
-  var t = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var f = SIMD.int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-  var s = SIMD.int8x16.select(m, t, f);
-  equal(1, SIMD.int8x16.extractLane(s, 0));
-  equal(2, SIMD.int8x16.extractLane(s, 1));
-  equal(3, SIMD.int8x16.extractLane(s, 2));
-  equal(4, SIMD.int8x16.extractLane(s, 3));
-  equal(5, SIMD.int8x16.extractLane(s, 4));
-  equal(6, SIMD.int8x16.extractLane(s, 5));
-  equal(7, SIMD.int8x16.extractLane(s, 6));
-  equal(8, SIMD.int8x16.extractLane(s, 7));
-  equal(25, SIMD.int8x16.extractLane(s, 8));
-  equal(26, SIMD.int8x16.extractLane(s, 9));
-  equal(27, SIMD.int8x16.extractLane(s, 10));
-  equal(28, SIMD.int8x16.extractLane(s, 11));
-  equal(29, SIMD.int8x16.extractLane(s, 12));
-  equal(30, SIMD.int8x16.extractLane(s, 13));
-  equal(31, SIMD.int8x16.extractLane(s, 14));
-  equal(32, SIMD.int8x16.extractLane(s, 15));
+test('Int8x16 select', function() {
+  var m = SIMD.Int8x16.bool(true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false);
+  var t = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var f = SIMD.Int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+  var s = SIMD.Int8x16.select(m, t, f);
+  equal(1, SIMD.Int8x16.extractLane(s, 0));
+  equal(2, SIMD.Int8x16.extractLane(s, 1));
+  equal(3, SIMD.Int8x16.extractLane(s, 2));
+  equal(4, SIMD.Int8x16.extractLane(s, 3));
+  equal(5, SIMD.Int8x16.extractLane(s, 4));
+  equal(6, SIMD.Int8x16.extractLane(s, 5));
+  equal(7, SIMD.Int8x16.extractLane(s, 6));
+  equal(8, SIMD.Int8x16.extractLane(s, 7));
+  equal(25, SIMD.Int8x16.extractLane(s, 8));
+  equal(26, SIMD.Int8x16.extractLane(s, 9));
+  equal(27, SIMD.Int8x16.extractLane(s, 10));
+  equal(28, SIMD.Int8x16.extractLane(s, 11));
+  equal(29, SIMD.Int8x16.extractLane(s, 12));
+  equal(30, SIMD.Int8x16.extractLane(s, 13));
+  equal(31, SIMD.Int8x16.extractLane(s, 14));
+  equal(32, SIMD.Int8x16.extractLane(s, 15));
 });
 
-test('int8x16 selectBits', function() {
-  var m = SIMD.int8x16(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x11111111,
+test('Int8x16 selectBits', function() {
+  var m = SIMD.Int8x16(0xaaaaaaaa, 0xbbbbbbbb, 0xcccccccc, 0xdddddddd, 0xeeeeeeee, 0xffffffff, 0x00000000, 0x11111111,
                        0x22222222, 0x33333333, 0x44444444, 0x55555555, 0x66666666, 0x77777777, 0x88888888, 0x99999999);
-  var t = SIMD.int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-  var f = SIMD.int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
-  var s = SIMD.int8x16.selectBits(m, t, f);
-  equal(17, SIMD.int8x16.extractLane(s, 0));
-  equal(2, SIMD.int8x16.extractLane(s, 1));
-  equal(19, SIMD.int8x16.extractLane(s, 2));
-  equal(4, SIMD.int8x16.extractLane(s, 3));
-  equal(21, SIMD.int8x16.extractLane(s, 4));
-  equal(6, SIMD.int8x16.extractLane(s, 5));
-  equal(23, SIMD.int8x16.extractLane(s, 6));
-  equal(8, SIMD.int8x16.extractLane(s, 7));
-  equal(25, SIMD.int8x16.extractLane(s, 8));
-  equal(10, SIMD.int8x16.extractLane(s, 9));
-  equal(27, SIMD.int8x16.extractLane(s, 10));
-  equal(12, SIMD.int8x16.extractLane(s, 11));
-  equal(29, SIMD.int8x16.extractLane(s, 12));
-  equal(14, SIMD.int8x16.extractLane(s, 13));
-  equal(31, SIMD.int8x16.extractLane(s, 14));
-  equal(48, SIMD.int8x16.extractLane(s, 15));
+  var t = SIMD.Int8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  var f = SIMD.Int8x16(17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+  var s = SIMD.Int8x16.selectBits(m, t, f);
+  equal(17, SIMD.Int8x16.extractLane(s, 0));
+  equal(2, SIMD.Int8x16.extractLane(s, 1));
+  equal(19, SIMD.Int8x16.extractLane(s, 2));
+  equal(4, SIMD.Int8x16.extractLane(s, 3));
+  equal(21, SIMD.Int8x16.extractLane(s, 4));
+  equal(6, SIMD.Int8x16.extractLane(s, 5));
+  equal(23, SIMD.Int8x16.extractLane(s, 6));
+  equal(8, SIMD.Int8x16.extractLane(s, 7));
+  equal(25, SIMD.Int8x16.extractLane(s, 8));
+  equal(10, SIMD.Int8x16.extractLane(s, 9));
+  equal(27, SIMD.Int8x16.extractLane(s, 10));
+  equal(12, SIMD.Int8x16.extractLane(s, 11));
+  equal(29, SIMD.Int8x16.extractLane(s, 12));
+  equal(14, SIMD.Int8x16.extractLane(s, 13));
+  equal(31, SIMD.Int8x16.extractLane(s, 14));
+  equal(48, SIMD.Int8x16.extractLane(s, 15));
 });
 
-test('int8x16 fromFloat32x4Bits constructor', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var n = SIMD.int8x16.fromFloat32x4Bits(m);
-  equal(0x00, SIMD.int8x16.extractLane(n, 0));
-  equal(0x00, SIMD.int8x16.extractLane(n, 1));
-  equal(-128, SIMD.int8x16.extractLane(n, 2));
-  equal(0x3f, SIMD.int8x16.extractLane(n, 3));
-  equal(0x00, SIMD.int8x16.extractLane(n, 4));
-  equal(0x00, SIMD.int8x16.extractLane(n, 5));
-  equal(0x00, SIMD.int8x16.extractLane(n, 6));
-  equal(0x40, SIMD.int8x16.extractLane(n, 7));
-  equal(0x00, SIMD.int8x16.extractLane(n, 8));
-  equal(0x00, SIMD.int8x16.extractLane(n, 9));
-  equal(0x40, SIMD.int8x16.extractLane(n, 10));
-  equal(0x40, SIMD.int8x16.extractLane(n, 11));
-  equal(0x00, SIMD.int8x16.extractLane(n, 12));
-  equal(0x00, SIMD.int8x16.extractLane(n, 13));
-  equal(-128, SIMD.int8x16.extractLane(n, 14));
-  equal(0x40, SIMD.int8x16.extractLane(n, 15));
+test('Int8x16 fromFloat32x4Bits constructor', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var n = SIMD.Int8x16.fromFloat32x4Bits(m);
+  equal(0x00, SIMD.Int8x16.extractLane(n, 0));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 1));
+  equal(-128, SIMD.Int8x16.extractLane(n, 2));
+  equal(0x3f, SIMD.Int8x16.extractLane(n, 3));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 4));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 5));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 6));
+  equal(0x40, SIMD.Int8x16.extractLane(n, 7));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 8));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 9));
+  equal(0x40, SIMD.Int8x16.extractLane(n, 10));
+  equal(0x40, SIMD.Int8x16.extractLane(n, 11));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 12));
+  equal(0x00, SIMD.Int8x16.extractLane(n, 13));
+  equal(-128, SIMD.Int8x16.extractLane(n, 14));
+  equal(0x40, SIMD.Int8x16.extractLane(n, 15));
 });


### PR DESCRIPTION
This is done to match the spec, which attempts to match existing types
such as Number. Benchmarks and tests are also updated to match the
new casing.

Also add transform.js to run.js, to match the browser benchmark code.