### PR TITLE
Unsigned absolute diff

### DIFF
--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -262,7 +262,7 @@ function restoreInt8x16() {
 
 if (typeof SIMD.Bool64x2 === "undefined") {
   /**
-    * Construct a new instance of bool64x2 number.
+    * Construct a new instance of Bool64x2 number.
     * @constructor
     */
   SIMD.Bool64x2 = function(x, y) {
@@ -277,13 +277,13 @@ if (typeof SIMD.Bool64x2 === "undefined") {
 
 if (typeof SIMD.Bool64x2.check === "undefined") {
   /**
-    * Check whether the argument is a bool64x2.
-    * @param {bool64x2} v An instance of bool64x2.
-    * @return {bool64x2} The bool64x2 instance.
+    * Check whether the argument is a Bool64x2.
+    * @param {Bool64x2} v An instance of Bool64x2.
+    * @return {Bool64x2} The Bool64x2 instance.
     */
   SIMD.Bool64x2.check = function(v) {
     if (!(v instanceof SIMD.Bool64x2)) {
-      throw new TypeError("argument is not a bool64x2.");
+      throw new TypeError("argument is not a Bool64x2.");
     }
     return v;
   }
@@ -291,7 +291,7 @@ if (typeof SIMD.Bool64x2.check === "undefined") {
 
 if (typeof SIMD.Bool64x2.splat === "undefined") {
   /**
-    * Construct a new instance of bool64x2 with the same value
+    * Construct a new instance of Bool64x2 with the same value
     * in all lanes.
     * @param {double} value used for all lanes.
     * @constructor
@@ -303,7 +303,7 @@ if (typeof SIMD.Bool64x2.splat === "undefined") {
 
 if (typeof SIMD.Bool64x2.extractLane === "undefined") {
   /**
-    * @param {bool64x2} v An instance of bool64x2.
+    * @param {Bool64x2} v An instance of Bool64x2.
     * @param {integer} i Index in concatenation of v for lane i
     * @return {Boolean} The value in lane i of v.
     */
@@ -319,17 +319,17 @@ if (typeof SIMD.Bool64x2.extractLane === "undefined") {
 
 if (typeof SIMD.Bool64x2.replaceLane === "undefined") {
   /**
-    * @param {bool64x2} v An instance of bool64x2.
+    * @param {Bool64x2} v An instance of Bool64x2.
     * @param {integer} i Index in concatenation of v for lane i
     * @param {double} value used for lane i.
-    * @return {bool64x2} New instance of bool64x2 with the values in v and
+    * @return {Bool64x2} New instance of Bool64x2 with the values in v and
     * lane i replaced with {s}.
     */
   SIMD.Bool64x2.replaceLane = function(v, i, s) {
     v = SIMD.Bool64x2.check(v);
     check2(i);
     // Other replaceLane implementations do the replacement in memory, but
-    // this is awkward for bool64x2 without something like Int64Array.
+    // this is awkward for Bool64x2 without something like Int64Array.
     return i == 0 ?
            SIMD.Bool64x2(s, SIMD.Bool64x2.extractLane(v, 1)) :
            SIMD.Bool64x2(SIMD.Bool64x2.extractLane(v, 0), s);
@@ -339,7 +339,7 @@ if (typeof SIMD.Bool64x2.replaceLane === "undefined") {
 if (typeof SIMD.Bool64x2.allTrue === "undefined") {
   /**
     * Check if all 2 lanes hold a true value
-    * @param {bool64x2} v An instance of bool64x2.
+    * @param {Bool64x2} v An instance of Bool64x2.
     * @return {Boolean} All 2 lanes hold a true value
     */
   SIMD.Bool64x2.allTrue = function(v) {
@@ -352,7 +352,7 @@ if (typeof SIMD.Bool64x2.allTrue === "undefined") {
 if (typeof SIMD.Bool64x2.anyTrue === "undefined") {
   /**
     * Check if any of the 2 lanes hold a true value
-    * @param {bool64x2} v An instance of bool64x2.
+    * @param {Bool64x2} v An instance of Bool64x2.
     * @return {Boolean} Any of the 2 lanes holds a true value
     */
   SIMD.Bool64x2.anyTrue = function(v) {
@@ -364,9 +364,9 @@ if (typeof SIMD.Bool64x2.anyTrue === "undefined") {
 
 if (typeof SIMD.Bool64x2.and === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @param {bool64x2} b An instance of bool64x2.
-    * @return {bool64x2} New instance of bool64x2 with values of a & b.
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @param {Bool64x2} b An instance of Bool64x2.
+    * @return {Bool64x2} New instance of Bool64x2 with values of a & b.
     */
   SIMD.Bool64x2.and = function(a, b) {
     a = SIMD.Bool64x2.check(a);
@@ -378,9 +378,9 @@ if (typeof SIMD.Bool64x2.and === "undefined") {
 
 if (typeof SIMD.Bool64x2.or === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @param {bool64x2} b An instance of bool64x2.
-    * @return {bool64x2} New instance of bool64x2 with values of a | b.
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @param {Bool64x2} b An instance of Bool64x2.
+    * @return {Bool64x2} New instance of Bool64x2 with values of a | b.
     */
   SIMD.Bool64x2.or = function(a, b) {
     a = SIMD.Bool64x2.check(a);
@@ -392,9 +392,9 @@ if (typeof SIMD.Bool64x2.or === "undefined") {
 
 if (typeof SIMD.Bool64x2.xor === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @param {bool64x2} b An instance of bool64x2.
-    * @return {bool64x2} New instance of bool64x2 with values of a ^ b.
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @param {Bool64x2} b An instance of Bool64x2.
+    * @return {Bool64x2} New instance of Bool64x2 with values of a ^ b.
     */
   SIMD.Bool64x2.xor = function(a, b) {
     a = SIMD.Bool64x2.check(a);
@@ -406,8 +406,8 @@ if (typeof SIMD.Bool64x2.xor === "undefined") {
 
 if (typeof SIMD.Bool64x2.not === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @return {bool64x2} New instance of bool64x2 with values of !a
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @return {Bool64x2} New instance of Bool64x2 with values of !a
     */
   SIMD.Bool64x2.not = function(a) {
     a = SIMD.Bool64x2.check(a);
@@ -418,9 +418,9 @@ if (typeof SIMD.Bool64x2.not === "undefined") {
 
 if (typeof SIMD.Bool64x2.equal === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @param {bool64x2} b An instance of bool64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @param {Bool64x2} b An instance of Bool64x2.
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of a == b.
     */
   SIMD.Bool64x2.equal = function(a, b) {
@@ -433,9 +433,9 @@ if (typeof SIMD.Bool64x2.equal === "undefined") {
 
 if (typeof SIMD.Bool64x2.notEqual === "undefined") {
   /**
-    * @param {bool64x2} a An instance of bool64x2.
-    * @param {bool64x2} b An instance of bool64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @param {Bool64x2} a An instance of Bool64x2.
+    * @param {Bool64x2} b An instance of Bool64x2.
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of a != b.
     */
   SIMD.Bool64x2.notEqual = function(a, b) {
@@ -448,12 +448,12 @@ if (typeof SIMD.Bool64x2.notEqual === "undefined") {
 
 if (typeof SIMD.Bool64x2.select === "undefined") {
   /**
-    * @param {bool64x2} mask Selector mask. An instance of bool64x2
-    * @param {bool64x2} trueValue Pick lane from here if corresponding
+    * @param {Bool64x2} mask Selector mask. An instance of Bool64x2
+    * @param {Bool64x2} trueValue Pick lane from here if corresponding
     * selector lane is 1
-    * @param {bool64x2} falseValue Pick lane from here if corresponding
+    * @param {Bool64x2} falseValue Pick lane from here if corresponding
     * selector lane is 0
-    * @return {bool64x2} Mix of lanes from trueValue or falseValue as
+    * @return {Bool64x2} Mix of lanes from trueValue or falseValue as
     * indicated
     */
   SIMD.Bool64x2.select = function(mask, trueValue, falseValue) {
@@ -3166,7 +3166,7 @@ if (typeof SIMD.Float64x2.lessThan === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t < other.
     */
   SIMD.Float64x2.lessThan = function(t, other) {
@@ -3184,7 +3184,7 @@ if (typeof SIMD.Float64x2.lessThanOrEqual === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t <= other.
     */
   SIMD.Float64x2.lessThanOrEqual = function(t, other) {
@@ -3202,7 +3202,7 @@ if (typeof SIMD.Float64x2.equal === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t == other.
     */
   SIMD.Float64x2.equal = function(t, other) {
@@ -3220,7 +3220,7 @@ if (typeof SIMD.Float64x2.notEqual === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t != other.
     */
   SIMD.Float64x2.notEqual = function(t, other) {
@@ -3238,7 +3238,7 @@ if (typeof SIMD.Float64x2.greaterThanOrEqual === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t >= other.
     */
   SIMD.Float64x2.greaterThanOrEqual = function(t, other) {
@@ -3256,7 +3256,7 @@ if (typeof SIMD.Float64x2.greaterThan === "undefined") {
   /**
     * @param {Float64x2} t An instance of Float64x2.
     * @param {Float64x2} other An instance of Float64x2.
-    * @return {bool64x2} true or false in each lane depending on
+    * @return {Bool64x2} true or false in each lane depending on
     * the result of t > other.
     */
   SIMD.Float64x2.greaterThan = function(t, other) {
@@ -3272,7 +3272,7 @@ if (typeof SIMD.Float64x2.greaterThan === "undefined") {
 
 if (typeof SIMD.Float64x2.select === "undefined") {
   /**
-    * @param {bool64x2} t Selector mask. An instance of bool64x2
+    * @param {Bool64x2} t Selector mask. An instance of Bool64x2
     * @param {Float64x2} trueValue Pick lane from here if corresponding
     * selector lane is true
     * @param {Float64x2} falseValue Pick lane from here if corresponding

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -1896,6 +1896,28 @@ if (typeof SIMD.Int16x8.extractLane === "undefined") {
   }
 }
 
+if (typeof SIMD.Int16x8.unsignedExtractLane === "undefined") {
+  /**
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {integer} The value in lane i of t extracted as an unsigned value.
+    */
+  SIMD.Int16x8.unsignedExtractLane = function(t, i) {
+    t = SIMD.Int16x8.check(t);
+    check8(i);
+    switch(i) {
+      case 0: return t.s0_ & 0xffff;
+      case 1: return t.s1_ & 0xffff;
+      case 2: return t.s2_ & 0xffff;
+      case 3: return t.s3_ & 0xffff;
+      case 4: return t.s4_ & 0xffff;
+      case 5: return t.s5_ & 0xffff;
+      case 6: return t.s6_ & 0xffff;
+      case 7: return t.s7_ & 0xffff;
+    }
+  }
+}
+
 if (typeof SIMD.Int16x8.replaceLane === "undefined") {
   /**
     * @param {Int16x8} t An instance of Int16x8.
@@ -2096,6 +2118,36 @@ if (typeof SIMD.Int8x16.extractLane === "undefined") {
       case 13: return t.s13_;
       case 14: return t.s14_;
       case 15: return t.s15_;
+    }
+  }
+}
+
+if (typeof SIMD.Int8x16.unsignedExtractLane === "undefined") {
+  /**
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {integer} i Index in concatenation of t for lane i
+    * @return {integer} The value in lane i of t extracted as an unsigned value.
+    */
+  SIMD.Int8x16.unsignedExtractLane = function(t, i) {
+    t = SIMD.Int8x16.check(t);
+    check16(i);
+    switch(i) {
+      case 0: return t.s0_ & 0xff;
+      case 1: return t.s1_ & 0xff;
+      case 2: return t.s2_ & 0xff;
+      case 3: return t.s3_ & 0xff;
+      case 4: return t.s4_ & 0xff;
+      case 5: return t.s5_ & 0xff;
+      case 6: return t.s6_ & 0xff;
+      case 7: return t.s7_ & 0xff;
+      case 8: return t.s8_ & 0xff;
+      case 9: return t.s9_ & 0xff;
+      case 10: return t.s10_ & 0xff;
+      case 11: return t.s11_ & 0xff;
+      case 12: return t.s12_ & 0xff;
+      case 13: return t.s13_ & 0xff;
+      case 14: return t.s14_ & 0xff;
+      case 15: return t.s15_ & 0xff;
     }
   }
 }
@@ -4343,6 +4395,27 @@ if (typeof SIMD.Int16x8.addSaturate === "undefined") {
   }
 }
 
+if (typeof SIMD.Int16x8.unsignedAddSaturate === "undefined") {
+  /**
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a + b with
+    * unsigned saturating behavior on overflow.
+    */
+  SIMD.Int16x8.unsignedAddSaturate = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    var c = SIMD.Int16x8.add(a, b);
+    var max = SIMD.Int16x8.splat(0xffff);
+    var min = SIMD.Int16x8.splat(0x0000);
+    var mask = SIMD.Int16x8.unsignedLessThan(c, a);
+    var bneg = SIMD.Int16x8.unsignedLessThan(b, SIMD.Int16x8.splat(0));
+    return SIMD.Int16x8.select(SIMD.Bool16x8.and(mask, SIMD.Bool16x8.not(bneg)), max,
+             SIMD.Int16x8.select(SIMD.Bool16x8.and(SIMD.Bool16x8.not(mask), bneg), min,
+               c));
+  }
+}
+
 if (typeof SIMD.Int16x8.subSaturate === "undefined") {
   /**
     * @param {Int16x8} a An instance of Int16x8.
@@ -4358,6 +4431,27 @@ if (typeof SIMD.Int16x8.subSaturate === "undefined") {
     var min = SIMD.Int16x8.splat(0x8000);
     var mask = SIMD.Int16x8.greaterThan(c, a);
     var bneg = SIMD.Int16x8.lessThan(b, SIMD.Int16x8.splat(0));
+    return SIMD.Int16x8.select(SIMD.Bool16x8.and(mask, SIMD.Bool16x8.not(bneg)), min,
+             SIMD.Int16x8.select(SIMD.Bool16x8.and(SIMD.Bool16x8.not(mask), bneg), max,
+               c));
+  }
+}
+
+if (typeof SIMD.Int16x8.unsignedSubSaturate === "undefined") {
+  /**
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int16x8} New instance of Int16x8 with values of a - b with
+    * unsigned saturating behavior on overflow.
+    */
+  SIMD.Int16x8.unsignedSubSaturate = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    var c = SIMD.Int16x8.sub(a, b);
+    var max = SIMD.Int16x8.splat(0xffff);
+    var min = SIMD.Int16x8.splat(0x0000);
+    var mask = SIMD.Int16x8.unsignedGreaterThan(c, a);
+    var bneg = SIMD.Int16x8.unsignedLessThan(b, SIMD.Int16x8.splat(0));
     return SIMD.Int16x8.select(SIMD.Bool16x8.and(mask, SIMD.Bool16x8.not(bneg)), min,
              SIMD.Int16x8.select(SIMD.Bool16x8.and(SIMD.Bool16x8.not(mask), bneg), max,
                c));
@@ -4516,6 +4610,36 @@ if (typeof SIMD.Int16x8.greaterThan === "undefined") {
   }
 }
 
+if (typeof SIMD.Int16x8.unsignedGreaterThan === "undefined") {
+  /**
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Bool16x8} true or false in each lane depending on
+    * the result of t > other as unsigned values.
+    */
+  SIMD.Int16x8.unsignedGreaterThan = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
+    var cs0 =
+        SIMD.Int16x8.unsignedExtractLane(t, 0) > SIMD.Int16x8.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int16x8.unsignedExtractLane(t, 1) > SIMD.Int16x8.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int16x8.unsignedExtractLane(t, 2) > SIMD.Int16x8.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int16x8.unsignedExtractLane(t, 3) > SIMD.Int16x8.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int16x8.unsignedExtractLane(t, 4) > SIMD.Int16x8.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int16x8.unsignedExtractLane(t, 5) > SIMD.Int16x8.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int16x8.unsignedExtractLane(t, 6) > SIMD.Int16x8.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int16x8.unsignedExtractLane(t, 7) > SIMD.Int16x8.unsignedExtractLane(other, 7);
+    return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+  }
+}
+
 if (typeof SIMD.Int16x8.greaterThanOrEqual === "undefined") {
   /**
     * @param {Int16x8} t An instance of Int16x8.
@@ -4542,6 +4666,36 @@ if (typeof SIMD.Int16x8.greaterThanOrEqual === "undefined") {
         SIMD.Int16x8.extractLane(t, 6) >= SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
         SIMD.Int16x8.extractLane(t, 7) >= SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+  }
+}
+
+if (typeof SIMD.Int16x8.unsignedGreaterThanOrEqual === "undefined") {
+  /**
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Bool16x8} true or false in each lane depending on
+    * the result of t >= other as unsigned values.
+    */
+  SIMD.Int16x8.unsignedGreaterThanOrEqual = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
+    var cs0 =
+        SIMD.Int16x8.unsignedExtractLane(t, 0) >= SIMD.Int16x8.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int16x8.unsignedExtractLane(t, 1) >= SIMD.Int16x8.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int16x8.unsignedExtractLane(t, 2) >= SIMD.Int16x8.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int16x8.unsignedExtractLane(t, 3) >= SIMD.Int16x8.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int16x8.unsignedExtractLane(t, 4) >= SIMD.Int16x8.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int16x8.unsignedExtractLane(t, 5) >= SIMD.Int16x8.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int16x8.unsignedExtractLane(t, 6) >= SIMD.Int16x8.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int16x8.unsignedExtractLane(t, 7) >= SIMD.Int16x8.unsignedExtractLane(other, 7);
     return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
@@ -4576,6 +4730,36 @@ if (typeof SIMD.Int16x8.lessThan === "undefined") {
   }
 }
 
+if (typeof SIMD.Int16x8.unsignedLessThan === "undefined") {
+  /**
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Bool16x8} true or false in each lane depending on
+    * the result of t < other as unsigned values.
+    */
+  SIMD.Int16x8.unsignedLessThan = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
+    var cs0 =
+        SIMD.Int16x8.unsignedExtractLane(t, 0) < SIMD.Int16x8.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int16x8.unsignedExtractLane(t, 1) < SIMD.Int16x8.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int16x8.unsignedExtractLane(t, 2) < SIMD.Int16x8.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int16x8.unsignedExtractLane(t, 3) < SIMD.Int16x8.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int16x8.unsignedExtractLane(t, 4) < SIMD.Int16x8.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int16x8.unsignedExtractLane(t, 5) < SIMD.Int16x8.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int16x8.unsignedExtractLane(t, 6) < SIMD.Int16x8.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int16x8.unsignedExtractLane(t, 7) < SIMD.Int16x8.unsignedExtractLane(other, 7);
+    return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+  }
+}
+
 if (typeof SIMD.Int16x8.lessThanOrEqual === "undefined") {
   /**
     * @param {Int16x8} t An instance of Int16x8.
@@ -4602,6 +4786,36 @@ if (typeof SIMD.Int16x8.lessThanOrEqual === "undefined") {
         SIMD.Int16x8.extractLane(t, 6) <= SIMD.Int16x8.extractLane(other, 6);
     var cs7 =
         SIMD.Int16x8.extractLane(t, 7) <= SIMD.Int16x8.extractLane(other, 7);
+    return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
+  }
+}
+
+if (typeof SIMD.Int16x8.unsignedLessThanOrEqual === "undefined") {
+  /**
+    * @param {Int16x8} t An instance of Int16x8.
+    * @param {Int16x8} other An instance of Int16x8.
+    * @return {Bool16x8} true or false in each lane depending on
+    * the result of t <= other as unsigned values.
+    */
+  SIMD.Int16x8.unsignedLessThanOrEqual = function(t, other) {
+    t = SIMD.Int16x8.check(t);
+    other = SIMD.Int16x8.check(other);
+    var cs0 =
+        SIMD.Int16x8.unsignedExtractLane(t, 0) <= SIMD.Int16x8.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int16x8.unsignedExtractLane(t, 1) <= SIMD.Int16x8.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int16x8.unsignedExtractLane(t, 2) <= SIMD.Int16x8.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int16x8.unsignedExtractLane(t, 3) <= SIMD.Int16x8.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int16x8.unsignedExtractLane(t, 4) <= SIMD.Int16x8.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int16x8.unsignedExtractLane(t, 5) <= SIMD.Int16x8.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int16x8.unsignedExtractLane(t, 6) <= SIMD.Int16x8.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int16x8.unsignedExtractLane(t, 7) <= SIMD.Int16x8.unsignedExtractLane(other, 7);
     return SIMD.Bool16x8(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7);
   }
 }
@@ -5145,6 +5359,27 @@ if (typeof SIMD.Int8x16.addSaturate === "undefined") {
   }
 }
 
+if (typeof SIMD.Int8x16.unsignedAddSaturate === "undefined") {
+  /**
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a + b with
+    * unsigned saturating behavior on overflow.
+    */
+  SIMD.Int8x16.unsignedAddSaturate = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    var c = SIMD.Int8x16.add(a, b);
+    var max = SIMD.Int8x16.splat(0xff);
+    var min = SIMD.Int8x16.splat(0x00);
+    var mask = SIMD.Int8x16.unsignedLessThan(c, a);
+    var bneg = SIMD.Int8x16.unsignedLessThan(b, SIMD.Int8x16.splat(0));
+    return SIMD.Int8x16.select(SIMD.Bool8x16.and(mask, SIMD.Bool8x16.not(bneg)), max,
+             SIMD.Int8x16.select(SIMD.Bool8x16.and(SIMD.Bool8x16.not(mask), bneg), min,
+               c));
+  }
+}
+
 if (typeof SIMD.Int8x16.subSaturate === "undefined") {
   /**
     * @param {Int8x16} a An instance of Int8x16.
@@ -5160,6 +5395,27 @@ if (typeof SIMD.Int8x16.subSaturate === "undefined") {
     var min = SIMD.Int8x16.splat(0x80);
     var mask = SIMD.Int8x16.greaterThan(c, a);
     var bneg = SIMD.Int8x16.lessThan(b, SIMD.Int8x16.splat(0));
+    return SIMD.Int8x16.select(SIMD.Bool8x16.and(mask, SIMD.Bool8x16.not(bneg)), min,
+             SIMD.Int8x16.select(SIMD.Bool8x16.and(SIMD.Bool8x16.not(mask), bneg), max,
+               c));
+  }
+}
+
+if (typeof SIMD.Int8x16.unsignedSubSaturate === "undefined") {
+  /**
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int8x16} New instance of Int8x16 with values of a - b with
+    * unsigned saturating behavior on overflow.
+    */
+  SIMD.Int8x16.unsignedSubSaturate = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    var c = SIMD.Int8x16.sub(a, b);
+    var max = SIMD.Int8x16.splat(0xff);
+    var min = SIMD.Int8x16.splat(0x00);
+    var mask = SIMD.Int8x16.unsignedGreaterThan(c, a);
+    var bneg = SIMD.Int8x16.unsignedLessThan(b, SIMD.Int8x16.splat(0));
     return SIMD.Int8x16.select(SIMD.Bool8x16.and(mask, SIMD.Bool8x16.not(bneg)), min,
              SIMD.Int8x16.select(SIMD.Bool8x16.and(SIMD.Bool8x16.not(mask), bneg), max,
                c));
@@ -5438,6 +5694,53 @@ if (typeof SIMD.Int8x16.greaterThan === "undefined") {
   }
 }
 
+if (typeof SIMD.Int8x16.unsignedGreaterThan === "undefined") {
+  /**
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Bool8x16} true or false in each lane depending on
+    * the result of t > other as unsigned values.
+    */
+  SIMD.Int8x16.unsignedGreaterThan = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
+    var cs0 =
+        SIMD.Int8x16.unsignedExtractLane(t, 0) > SIMD.Int8x16.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int8x16.unsignedExtractLane(t, 1) > SIMD.Int8x16.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int8x16.unsignedExtractLane(t, 2) > SIMD.Int8x16.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int8x16.unsignedExtractLane(t, 3) > SIMD.Int8x16.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int8x16.unsignedExtractLane(t, 4) > SIMD.Int8x16.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int8x16.unsignedExtractLane(t, 5) > SIMD.Int8x16.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int8x16.unsignedExtractLane(t, 6) > SIMD.Int8x16.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int8x16.unsignedExtractLane(t, 7) > SIMD.Int8x16.unsignedExtractLane(other, 7);
+    var cs8 =
+        SIMD.Int8x16.unsignedExtractLane(t, 8) > SIMD.Int8x16.unsignedExtractLane(other, 8);
+    var cs9 =
+        SIMD.Int8x16.unsignedExtractLane(t, 9) > SIMD.Int8x16.unsignedExtractLane(other, 9);
+    var cs10 =
+        SIMD.Int8x16.unsignedExtractLane(t, 10) > SIMD.Int8x16.unsignedExtractLane(other, 10);
+    var cs11 =
+        SIMD.Int8x16.unsignedExtractLane(t, 11) > SIMD.Int8x16.unsignedExtractLane(other, 11);
+    var cs12 =
+        SIMD.Int8x16.unsignedExtractLane(t, 12) > SIMD.Int8x16.unsignedExtractLane(other, 12);
+    var cs13 =
+        SIMD.Int8x16.unsignedExtractLane(t, 13) > SIMD.Int8x16.unsignedExtractLane(other, 13);
+    var cs14 =
+        SIMD.Int8x16.unsignedExtractLane(t, 14) > SIMD.Int8x16.unsignedExtractLane(other, 14);
+    var cs15 =
+        SIMD.Int8x16.unsignedExtractLane(t, 15) > SIMD.Int8x16.unsignedExtractLane(other, 15);
+    return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                         cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+  }
+}
+
 if (typeof SIMD.Int8x16.greaterThanOrEqual === "undefined") {
   /**
     * @param {Int8x16} t An instance of Int8x16.
@@ -5480,6 +5783,53 @@ if (typeof SIMD.Int8x16.greaterThanOrEqual === "undefined") {
         SIMD.Int8x16.extractLane(t, 14) >= SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
         SIMD.Int8x16.extractLane(t, 15) >= SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                         cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+  }
+}
+
+if (typeof SIMD.Int8x16.unsignedGreaterThanOrEqual === "undefined") {
+  /**
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Bool8x16} true or false in each lane depending on
+    * the result of t >= other as unsigned values.
+    */
+  SIMD.Int8x16.unsignedGreaterThanOrEqual = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
+    var cs0 =
+        SIMD.Int8x16.unsignedExtractLane(t, 0) >= SIMD.Int8x16.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int8x16.unsignedExtractLane(t, 1) >= SIMD.Int8x16.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int8x16.unsignedExtractLane(t, 2) >= SIMD.Int8x16.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int8x16.unsignedExtractLane(t, 3) >= SIMD.Int8x16.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int8x16.unsignedExtractLane(t, 4) >= SIMD.Int8x16.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int8x16.unsignedExtractLane(t, 5) >= SIMD.Int8x16.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int8x16.unsignedExtractLane(t, 6) >= SIMD.Int8x16.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int8x16.unsignedExtractLane(t, 7) >= SIMD.Int8x16.unsignedExtractLane(other, 7);
+    var cs8 =
+        SIMD.Int8x16.unsignedExtractLane(t, 8) >= SIMD.Int8x16.unsignedExtractLane(other, 8);
+    var cs9 =
+        SIMD.Int8x16.unsignedExtractLane(t, 9) >= SIMD.Int8x16.unsignedExtractLane(other, 9);
+    var cs10 =
+        SIMD.Int8x16.unsignedExtractLane(t, 10) >= SIMD.Int8x16.unsignedExtractLane(other, 10);
+    var cs11 =
+        SIMD.Int8x16.unsignedExtractLane(t, 11) >= SIMD.Int8x16.unsignedExtractLane(other, 11);
+    var cs12 =
+        SIMD.Int8x16.unsignedExtractLane(t, 12) >= SIMD.Int8x16.unsignedExtractLane(other, 12);
+    var cs13 =
+        SIMD.Int8x16.unsignedExtractLane(t, 13) >= SIMD.Int8x16.unsignedExtractLane(other, 13);
+    var cs14 =
+        SIMD.Int8x16.unsignedExtractLane(t, 14) >= SIMD.Int8x16.unsignedExtractLane(other, 14);
+    var cs15 =
+        SIMD.Int8x16.unsignedExtractLane(t, 15) >= SIMD.Int8x16.unsignedExtractLane(other, 15);
     return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                          cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }
@@ -5532,6 +5882,53 @@ if (typeof SIMD.Int8x16.lessThan === "undefined") {
   }
 }
 
+if (typeof SIMD.Int8x16.unsignedLessThan === "undefined") {
+  /**
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Bool8x16} true or false in each lane depending on
+    * the result of t < other as unsigned values.
+    */
+  SIMD.Int8x16.unsignedLessThan = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
+    var cs0 =
+        SIMD.Int8x16.unsignedExtractLane(t, 0) < SIMD.Int8x16.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int8x16.unsignedExtractLane(t, 1) < SIMD.Int8x16.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int8x16.unsignedExtractLane(t, 2) < SIMD.Int8x16.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int8x16.unsignedExtractLane(t, 3) < SIMD.Int8x16.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int8x16.unsignedExtractLane(t, 4) < SIMD.Int8x16.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int8x16.unsignedExtractLane(t, 5) < SIMD.Int8x16.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int8x16.unsignedExtractLane(t, 6) < SIMD.Int8x16.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int8x16.unsignedExtractLane(t, 7) < SIMD.Int8x16.unsignedExtractLane(other, 7);
+    var cs8 =
+        SIMD.Int8x16.unsignedExtractLane(t, 8) < SIMD.Int8x16.unsignedExtractLane(other, 8);
+    var cs9 =
+        SIMD.Int8x16.unsignedExtractLane(t, 9) < SIMD.Int8x16.unsignedExtractLane(other, 9);
+    var cs10 =
+        SIMD.Int8x16.unsignedExtractLane(t, 10) < SIMD.Int8x16.unsignedExtractLane(other, 10);
+    var cs11 =
+        SIMD.Int8x16.unsignedExtractLane(t, 11) < SIMD.Int8x16.unsignedExtractLane(other, 11);
+    var cs12 =
+        SIMD.Int8x16.unsignedExtractLane(t, 12) < SIMD.Int8x16.unsignedExtractLane(other, 12);
+    var cs13 =
+        SIMD.Int8x16.unsignedExtractLane(t, 13) < SIMD.Int8x16.unsignedExtractLane(other, 13);
+    var cs14 =
+        SIMD.Int8x16.unsignedExtractLane(t, 14) < SIMD.Int8x16.unsignedExtractLane(other, 14);
+    var cs15 =
+        SIMD.Int8x16.unsignedExtractLane(t, 15) < SIMD.Int8x16.unsignedExtractLane(other, 15);
+    return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                         cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+  }
+}
+
 if (typeof SIMD.Int8x16.lessThanOrEqual === "undefined") {
   /**
     * @param {Int8x16} t An instance of Int8x16.
@@ -5574,6 +5971,53 @@ if (typeof SIMD.Int8x16.lessThanOrEqual === "undefined") {
         SIMD.Int8x16.extractLane(t, 14) <= SIMD.Int8x16.extractLane(other, 14);
     var cs15 =
         SIMD.Int8x16.extractLane(t, 15) <= SIMD.Int8x16.extractLane(other, 15);
+    return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+                         cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
+  }
+}
+
+if (typeof SIMD.Int8x16.unsignedLessThanOrEqual === "undefined") {
+  /**
+    * @param {Int8x16} t An instance of Int8x16.
+    * @param {Int8x16} other An instance of Int8x16.
+    * @return {Bool8x16} true or false in each lane depending on
+    * the result of t <= other as unsigned values.
+    */
+  SIMD.Int8x16.unsignedLessThanOrEqual = function(t, other) {
+    t = SIMD.Int8x16.check(t);
+    other = SIMD.Int8x16.check(other);
+    var cs0 =
+        SIMD.Int8x16.unsignedExtractLane(t, 0) <= SIMD.Int8x16.unsignedExtractLane(other, 0);
+    var cs1 =
+        SIMD.Int8x16.unsignedExtractLane(t, 1) <= SIMD.Int8x16.unsignedExtractLane(other, 1);
+    var cs2 =
+        SIMD.Int8x16.unsignedExtractLane(t, 2) <= SIMD.Int8x16.unsignedExtractLane(other, 2);
+    var cs3 =
+        SIMD.Int8x16.unsignedExtractLane(t, 3) <= SIMD.Int8x16.unsignedExtractLane(other, 3);
+    var cs4 =
+        SIMD.Int8x16.unsignedExtractLane(t, 4) <= SIMD.Int8x16.unsignedExtractLane(other, 4);
+    var cs5 =
+        SIMD.Int8x16.unsignedExtractLane(t, 5) <= SIMD.Int8x16.unsignedExtractLane(other, 5);
+    var cs6 =
+        SIMD.Int8x16.unsignedExtractLane(t, 6) <= SIMD.Int8x16.unsignedExtractLane(other, 6);
+    var cs7 =
+        SIMD.Int8x16.unsignedExtractLane(t, 7) <= SIMD.Int8x16.unsignedExtractLane(other, 7);
+    var cs8 =
+        SIMD.Int8x16.unsignedExtractLane(t, 8) <= SIMD.Int8x16.unsignedExtractLane(other, 8);
+    var cs9 =
+        SIMD.Int8x16.unsignedExtractLane(t, 9) <= SIMD.Int8x16.unsignedExtractLane(other, 9);
+    var cs10 =
+        SIMD.Int8x16.unsignedExtractLane(t, 10) <= SIMD.Int8x16.unsignedExtractLane(other, 10);
+    var cs11 =
+        SIMD.Int8x16.unsignedExtractLane(t, 11) <= SIMD.Int8x16.unsignedExtractLane(other, 11);
+    var cs12 =
+        SIMD.Int8x16.unsignedExtractLane(t, 12) <= SIMD.Int8x16.unsignedExtractLane(other, 12);
+    var cs13 =
+        SIMD.Int8x16.unsignedExtractLane(t, 13) <= SIMD.Int8x16.unsignedExtractLane(other, 13);
+    var cs14 =
+        SIMD.Int8x16.unsignedExtractLane(t, 14) <= SIMD.Int8x16.unsignedExtractLane(other, 14);
+    var cs15 =
+        SIMD.Int8x16.unsignedExtractLane(t, 15) <= SIMD.Int8x16.unsignedExtractLane(other, 15);
     return SIMD.Bool8x16(cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
                          cs8, cs9, cs10, cs11, cs12, cs13, cs14, cs15);
   }

--- a/src/ecmascript_simd.js
+++ b/src/ecmascript_simd.js
@@ -3646,6 +3646,20 @@ if (typeof SIMD.Int32x4.shuffle === "undefined") {
   }
 }
 
+if (typeof SIMD.Int32x4.unsignedHorizontalSum === "undefined") {
+  /**
+    * @param {Int32x4} a An instance of 32x4.
+    * @return {Number} The sum of all the lanes in a, extracted as unsigned values.
+    */
+  SIMD.Int32x4.unsignedHorizontalSum = function(a) {
+    a = SIMD.Int32x4.check(a);
+    return (SIMD.Int32x4.extractLane(a, 0)>>>0) +
+           (SIMD.Int32x4.extractLane(a, 1)>>>0) +
+           (SIMD.Int32x4.extractLane(a, 2)>>>0) +
+           (SIMD.Int32x4.extractLane(a, 3)>>>0);
+  }
+}
+
 if (typeof SIMD.Int32x4.select === "undefined") {
   /**
     * @param {Bool32x4} t Selector mask. An instance of Bool32x4
@@ -4455,6 +4469,79 @@ if (typeof SIMD.Int16x8.unsignedSubSaturate === "undefined") {
     return SIMD.Int16x8.select(SIMD.Bool16x8.and(mask, SIMD.Bool16x8.not(bneg)), min,
              SIMD.Int16x8.select(SIMD.Bool16x8.and(SIMD.Bool16x8.not(mask), bneg), max,
                c));
+  }
+}
+
+if (typeof SIMD.Int16x8.unsignedAbsoluteDifference === "undefined") {
+  /**
+    * @param {Int16x8} a An instance of Int8x16.
+    * @param {Int16x8} b An instance of Int8x16.
+    * @return {Int16x8} The absolute differences (abs(x - y)) of the
+    * corresponding elements of a and b. x and y are interpreted as unsigned
+    * integers.
+    */
+  SIMD.Int16x8.unsignedAbsoluteDifference = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    var x = SIMD.Int16x8(
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 0) - SIMD.Int16x8.unsignedExtractLane(b, 0)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 1) - SIMD.Int16x8.unsignedExtractLane(b, 1)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 2) - SIMD.Int16x8.unsignedExtractLane(b, 2)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 3) - SIMD.Int16x8.unsignedExtractLane(b, 3)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 4) - SIMD.Int16x8.unsignedExtractLane(b, 4)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 5) - SIMD.Int16x8.unsignedExtractLane(b, 5)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 6) - SIMD.Int16x8.unsignedExtractLane(b, 6)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 7) - SIMD.Int16x8.unsignedExtractLane(b, 7)));
+    return x;
+  }
+}
+
+if (typeof SIMD.Int16x8.widenedUnsignedAbsoluteDifference === "undefined") {
+  /**
+    * @param {Int16x8} a An instance of Int16x8.
+    * @param {Int16x8} b An instance of Int16x8.
+    * @return {Int32x4} The absolute differences (abs(x - y)) of the
+    * first 4 corresponding elements of a and b, returning 32-bit results.
+    * x and y are interpreted as unsigned integers.
+    */
+  SIMD.Int16x8.widenedUnsignedAbsoluteDifference = function(a, b) {
+    a = SIMD.Int16x8.check(a);
+    b = SIMD.Int16x8.check(b);
+    return SIMD.Int32x4(
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 0) - SIMD.Int16x8.unsignedExtractLane(b, 0)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 1) - SIMD.Int16x8.unsignedExtractLane(b, 1)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 2) - SIMD.Int16x8.unsignedExtractLane(b, 2)),
+        Math.abs(
+            SIMD.Int16x8.unsignedExtractLane(a, 3) - SIMD.Int16x8.unsignedExtractLane(b, 3)));
+  }
+}
+
+if (typeof SIMD.Int16x8.unsignedHorizontalSum === "undefined") {
+  /**
+    * @param {Int16x8} a An instance of Int16x8.
+    * @return {Number} The sum of all the lanes in a, extracted as unsigned values.
+    */
+  SIMD.Int16x8.unsignedHorizontalSum = function(a) {
+    a = SIMD.Int16x8.check(a);
+    return SIMD.Int16x8.unsignedExtractLane(a, 0) +
+           SIMD.Int16x8.unsignedExtractLane(a, 1) +
+           SIMD.Int16x8.unsignedExtractLane(a, 2) +
+           SIMD.Int16x8.unsignedExtractLane(a, 3) +
+           SIMD.Int16x8.unsignedExtractLane(a, 4) +
+           SIMD.Int16x8.unsignedExtractLane(a, 5) +
+           SIMD.Int16x8.unsignedExtractLane(a, 6) +
+           SIMD.Int16x8.unsignedExtractLane(a, 7);
   }
 }
 
@@ -5422,48 +5509,108 @@ if (typeof SIMD.Int8x16.unsignedSubSaturate === "undefined") {
   }
 }
 
-if (typeof SIMD.Int8x16.sumOfAbsoluteDifferences === "undefined") {
+if (typeof SIMD.Int8x16.unsignedAbsoluteDifference === "undefined") {
   /**
     * @param {Int8x16} a An instance of Int8x16.
     * @param {Int8x16} b An instance of Int8x16.
-    * @return {Number} The sum of the absolute differences (SAD) of the
-    * corresponding elements of a and b.
+    * @return {Int8x16} The absolute differences (abs(x - y)) of the
+    * corresponding elements of a and b. x and y are interpreted as unsigned
+    * integers.
     */
-  SIMD.Int8x16.sumOfAbsoluteDifferences = function(a, b) {
+  SIMD.Int8x16.unsignedAbsoluteDifference = function(a, b) {
     a = SIMD.Int8x16.check(a);
     b = SIMD.Int8x16.check(b);
-    return Math.abs(
-        SIMD.Int8x16.extractLane(a, 0) - SIMD.Int8x16.extractLane(b, 0)) +
+    var x = SIMD.Int8x16(
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 1) - SIMD.Int8x16.extractLane(b, 1)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 0) - SIMD.Int8x16.unsignedExtractLane(b, 0)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 2) - SIMD.Int8x16.extractLane(b, 2)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 1) - SIMD.Int8x16.unsignedExtractLane(b, 1)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 3) - SIMD.Int8x16.extractLane(b, 3)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 2) - SIMD.Int8x16.unsignedExtractLane(b, 2)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 4) - SIMD.Int8x16.extractLane(b, 4)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 3) - SIMD.Int8x16.unsignedExtractLane(b, 3)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 5) - SIMD.Int8x16.extractLane(b, 5)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 4) - SIMD.Int8x16.unsignedExtractLane(b, 4)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 6) - SIMD.Int8x16.extractLane(b, 6)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 5) - SIMD.Int8x16.unsignedExtractLane(b, 5)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 7) - SIMD.Int8x16.extractLane(b, 7)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 6) - SIMD.Int8x16.unsignedExtractLane(b, 6)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 8) - SIMD.Int8x16.extractLane(b, 8)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 7) - SIMD.Int8x16.unsignedExtractLane(b, 7)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 9) - SIMD.Int8x16.extractLane(b, 9)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 8) - SIMD.Int8x16.unsignedExtractLane(b, 8)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 10) - SIMD.Int8x16.extractLane(b, 10)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 9) - SIMD.Int8x16.unsignedExtractLane(b, 9)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 11) - SIMD.Int8x16.extractLane(b, 11)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 10) - SIMD.Int8x16.unsignedExtractLane(b, 10)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 12) - SIMD.Int8x16.extractLane(b, 12)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 11) - SIMD.Int8x16.unsignedExtractLane(b, 11)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 13) - SIMD.Int8x16.extractLane(b, 13)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 12) - SIMD.Int8x16.unsignedExtractLane(b, 12)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 14) - SIMD.Int8x16.extractLane(b, 14)) +
+            SIMD.Int8x16.unsignedExtractLane(a, 13) - SIMD.Int8x16.unsignedExtractLane(b, 13)),
         Math.abs(
-            SIMD.Int8x16.extractLane(a, 15) - SIMD.Int8x16.extractLane(b, 15));
+            SIMD.Int8x16.unsignedExtractLane(a, 14) - SIMD.Int8x16.unsignedExtractLane(b, 14)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 15) - SIMD.Int8x16.unsignedExtractLane(b, 15)));
+    return x;
+  }
+}
+
+if (typeof SIMD.Int8x16.widenedUnsignedAbsoluteDifference === "undefined") {
+  /**
+    * @param {Int8x16} a An instance of Int8x16.
+    * @param {Int8x16} b An instance of Int8x16.
+    * @return {Int16x8} The absolute differences (abs(x - y)) of the
+    * first 8 corresponding elements of a and b, returning 16-bit results.
+    * x and y are interpreted as unsigned integers.
+    */
+  SIMD.Int8x16.widenedUnsignedAbsoluteDifference = function(a, b) {
+    a = SIMD.Int8x16.check(a);
+    b = SIMD.Int8x16.check(b);
+    return SIMD.Int16x8(
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 0) - SIMD.Int8x16.unsignedExtractLane(b, 0)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 1) - SIMD.Int8x16.unsignedExtractLane(b, 1)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 2) - SIMD.Int8x16.unsignedExtractLane(b, 2)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 3) - SIMD.Int8x16.unsignedExtractLane(b, 3)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 4) - SIMD.Int8x16.unsignedExtractLane(b, 4)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 5) - SIMD.Int8x16.unsignedExtractLane(b, 5)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 6) - SIMD.Int8x16.unsignedExtractLane(b, 6)),
+        Math.abs(
+            SIMD.Int8x16.unsignedExtractLane(a, 7) - SIMD.Int8x16.unsignedExtractLane(b, 7)));
+  }
+}
+
+if (typeof SIMD.Int8x16.unsignedHorizontalSum === "undefined") {
+  /**
+    * @param {Int8x16} a An instance of Int8x16.
+    * @return {Number} The sum of all the lanes in a, extracted as unsigned values.
+    */
+  SIMD.Int8x16.unsignedHorizontalSum = function(a) {
+    a = SIMD.Int8x16.check(a);
+    return SIMD.Int8x16.unsignedExtractLane(a, 0) +
+           SIMD.Int8x16.unsignedExtractLane(a, 1) +
+           SIMD.Int8x16.unsignedExtractLane(a, 2) +
+           SIMD.Int8x16.unsignedExtractLane(a, 3) +
+           SIMD.Int8x16.unsignedExtractLane(a, 4) +
+           SIMD.Int8x16.unsignedExtractLane(a, 5) +
+           SIMD.Int8x16.unsignedExtractLane(a, 6) +
+           SIMD.Int8x16.unsignedExtractLane(a, 7) +
+           SIMD.Int8x16.unsignedExtractLane(a, 8) +
+           SIMD.Int8x16.unsignedExtractLane(a, 9) +
+           SIMD.Int8x16.unsignedExtractLane(a, 10) +
+           SIMD.Int8x16.unsignedExtractLane(a, 11) +
+           SIMD.Int8x16.unsignedExtractLane(a, 12) +
+           SIMD.Int8x16.unsignedExtractLane(a, 13) +
+           SIMD.Int8x16.unsignedExtractLane(a, 14) +
+           SIMD.Int8x16.unsignedExtractLane(a, 15);
   }
 }
 

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -204,7 +204,7 @@ test('Int16x8 operators', function() {
     equal(SIMD.Int16x8(0, 1, 2, 3, 4, 5, 6, 7) ? 1 : 2, 1);
 });
 
-test('bool64x2 constructor', function() {
+test('Bool64x2 constructor', function() {
   equal('function', typeof SIMD.Bool64x2);
   var m = SIMD.Bool64x2(false, true);
   equal(false, SIMD.Bool64x2.extractLane(m, 0));
@@ -215,7 +215,7 @@ test('bool64x2 constructor', function() {
   throws(function() { SIMD.Bool8x16.check(m); });
 });
 
-test('bool64x2 splat constructor', function() {
+test('Bool64x2 splat constructor', function() {
   equal('function', typeof SIMD.Bool64x2.splat);
   var m = SIMD.Bool64x2.splat(true);
   equal(true, SIMD.Bool64x2.extractLane(m, 0));
@@ -225,13 +225,13 @@ test('bool64x2 splat constructor', function() {
   equal(false, SIMD.Bool64x2.extractLane(m, 1));
 });
 
-test('bool64x2 scalar getters', function() {
+test('Bool64x2 scalar getters', function() {
   var m = SIMD.Bool64x2(true, false);
   equal(true, SIMD.Bool64x2.extractLane(m, 0));
   equal(false, SIMD.Bool64x2.extractLane(m, 1));
 });
 
-test('bool64x2 replaceLane', function() {
+test('Bool64x2 replaceLane', function() {
   var a = SIMD.Bool64x2(false, false);
   var c = SIMD.Bool64x2.replaceLane(a, 0, true);
   equal(true, SIMD.Bool64x2.extractLane(c, 0));
@@ -256,7 +256,7 @@ test('bool64x2 replaceLane', function() {
   testIndexCheck(2);
 });
 
-test('bool64x2 allTrue', function () {
+test('Bool64x2 allTrue', function () {
   var v00 = SIMD.Bool64x2(false, false);
   var v01 = SIMD.Bool64x2(false, true);
   var v10 = SIMD.Bool64x2(true, false);
@@ -267,7 +267,7 @@ test('bool64x2 allTrue', function () {
   equal(SIMD.Bool64x2.allTrue(v11), true);
 });
 
-test('bool64x2 anyTrue', function () {
+test('Bool64x2 anyTrue', function () {
   var v00 = SIMD.Bool64x2(false, false);
   var v01 = SIMD.Bool64x2(false, true);
   var v10 = SIMD.Bool64x2(true, false);
@@ -278,7 +278,7 @@ test('bool64x2 anyTrue', function () {
   equal(SIMD.Bool64x2.anyTrue(v11), true);
 });
 
-test('bool64x2 and', function() {
+test('Bool64x2 and', function() {
   var m = SIMD.Bool64x2(true, true);
   var n = SIMD.Bool64x2(true, false);
   var o = SIMD.Bool64x2.and(m,n);
@@ -291,7 +291,7 @@ test('bool64x2 and', function() {
   equal(false, SIMD.Bool64x2.extractLane(o, 1));
 });
 
-test('bool64x2 or', function() {
+test('Bool64x2 or', function() {
   var m = SIMD.Bool64x2(true, true);
   var n = SIMD.Bool64x2(true, false);
   var o = SIMD.Bool64x2.or(m,n);
@@ -304,7 +304,7 @@ test('bool64x2 or', function() {
   equal(false, SIMD.Bool64x2.extractLane(o, 1));
 });
 
-test('bool64x2 xor', function() {
+test('Bool64x2 xor', function() {
   var m = SIMD.Bool64x2(true, true);
   var n = SIMD.Bool64x2(true, false);
   var o = SIMD.Bool64x2.xor(m,n);
@@ -317,14 +317,14 @@ test('bool64x2 xor', function() {
   equal(false, SIMD.Bool64x2.extractLane(o, 1));
 });
 
-test('bool64x2 not', function() {
+test('Bool64x2 not', function() {
   var m = SIMD.Bool64x2(true, false);
   var o = SIMD.Bool64x2.not(m);
   equal(false, SIMD.Bool64x2.extractLane(o, 0));
   equal(true, SIMD.Bool64x2.extractLane(o, 1));
 });
 
-test('bool64x2 comparisons', function() {
+test('Bool64x2 comparisons', function() {
   var m = SIMD.Bool64x2(true, true);
   var n = SIMD.Bool64x2(false, true);
   var cmp;
@@ -338,7 +338,7 @@ test('bool64x2 comparisons', function() {
   equal(false, SIMD.Bool64x2.extractLane(cmp, 1));
 });
 
-test('bool64x2 select', function() {
+test('Bool64x2 select', function() {
   var m = SIMD.Bool64x2(true, false);
   var t = SIMD.Bool64x2(true, true);
   var f = SIMD.Bool64x2(false, false);

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -3489,6 +3489,20 @@ test('Int32x4 mul', function() {
   equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
+test('Int32x4 unsignedHorizontalSum', function() {
+  var a = SIMD.Int32x4.splat(0);
+  var b = SIMD.Int32x4.unsignedHorizontalSum(a);
+  equal(0, b);
+
+  var a = SIMD.Int32x4.splat(-1);
+  var b = SIMD.Int32x4.unsignedHorizontalSum(a);
+  equal(17179869180, b);
+
+  a = SIMD.Int32x4(0xFF, 0, 0xFF, 1);
+  b = SIMD.Int32x4.unsignedHorizontalSum(a);
+  equal(511, b);
+});
+
 test('Int32x4 comparisons', function() {
   var m = SIMD.Int32x4(1000, 2000, 100, 1);
   var n = SIMD.Int32x4(-2000, 2000, 1, 100);
@@ -4537,6 +4551,44 @@ test('Int16x8 unsignedSubSaturate', function() {
   equal(9, SIMD.Int16x8.unsignedExtractLane(d, 7));
 });
 
+test('Int16x8 unsignedAbsoluteDifference', function() {
+  var a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
+  var b = SIMD.Int16x8(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1);
+  var c = SIMD.Int16x8.unsignedAbsoluteDifference(a, b);
+  equal(0xff, SIMD.Int16x8.unsignedExtractLane(c, 0));
+  equal(0xff, SIMD.Int16x8.unsignedExtractLane(c, 1));
+  equal(0xfe, SIMD.Int16x8.unsignedExtractLane(c, 2));
+  equal(0xfe, SIMD.Int16x8.unsignedExtractLane(c, 3));
+  equal(1, SIMD.Int16x8.unsignedExtractLane(c, 4));
+  equal(1, SIMD.Int16x8.unsignedExtractLane(c, 5));
+  equal(0xfffc, SIMD.Int16x8.unsignedExtractLane(c, 6));
+  equal(0xfffc, SIMD.Int16x8.unsignedExtractLane(c, 7));
+});
+
+test('Int16x8 widenedUnsignedAbsoluteDifference', function() {
+  var a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
+  var b = SIMD.Int16x8(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1);
+  var c = SIMD.Int16x8.widenedUnsignedAbsoluteDifference(a, b);
+  equal(255, SIMD.Int32x4.extractLane(c, 0));
+  equal(255, SIMD.Int32x4.extractLane(c, 1));
+  equal(254, SIMD.Int32x4.extractLane(c, 2));
+  equal(254, SIMD.Int32x4.extractLane(c, 3));
+});
+
+test('Int16x8 unsignedHorizontalSum', function() {
+  var a = SIMD.Int16x8.splat(0);
+  var b = SIMD.Int16x8.unsignedHorizontalSum(a);
+  equal(0, b);
+
+  var a = SIMD.Int16x8.splat(-1);
+  var b = SIMD.Int16x8.unsignedHorizontalSum(a);
+  equal(524280, b);
+
+  a = SIMD.Int16x8(0xFF, 0, 0xFF, 1, 2, 1, -1, 3);
+  b = SIMD.Int16x8.unsignedHorizontalSum(a);
+  equal(66052, b);
+});
+
 test('Int16x8 comparisons', function() {
   var m = SIMD.Int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
   var n = SIMD.Int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
@@ -5370,11 +5422,54 @@ test('Int8x16 unsignedSubSaturate', function() {
   equal(17, SIMD.Int8x16.unsignedExtractLane(d, 15));
 });
 
-test('Int8x16 sumOfAbsoluteDifferences', function() {
-  var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
-  var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
-  var c = SIMD.Int8x16.sumOfAbsoluteDifferences(a, b);
-  equal(c, 140);
+test('Int8x16 unsignedAbsoluteDifference', function() {
+  var a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
+  var b = SIMD.Int8x16(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1, 0, 0x7f, 0xe0, 0xf0, 9, 10, 9, -10);
+  var c = SIMD.Int8x16.unsignedAbsoluteDifference(a, b);
+  equal(255, SIMD.Int8x16.unsignedExtractLane(c, 0));
+  equal(255, SIMD.Int8x16.unsignedExtractLane(c, 1));
+  equal(254, SIMD.Int8x16.unsignedExtractLane(c, 2));
+  equal(254, SIMD.Int8x16.unsignedExtractLane(c, 3));
+  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 4));
+  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 5));
+  equal(252, SIMD.Int8x16.unsignedExtractLane(c, 6));
+  equal(252, SIMD.Int8x16.unsignedExtractLane(c, 7));
+  equal(127, SIMD.Int8x16.unsignedExtractLane(c, 8));
+  equal(127, SIMD.Int8x16.unsignedExtractLane(c, 9));
+  equal(16, SIMD.Int8x16.unsignedExtractLane(c, 10));
+  equal(16, SIMD.Int8x16.unsignedExtractLane(c, 11));
+  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 12));
+  equal(1, SIMD.Int8x16.unsignedExtractLane(c, 13));
+  equal(237, SIMD.Int8x16.unsignedExtractLane(c, 14));
+  equal(237, SIMD.Int8x16.unsignedExtractLane(c, 15));
+});
+
+test('Int8x16 widenedUnsignedAbsoluteDifference', function() {
+  var a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
+  var b = SIMD.Int8x16(0x0, 0xFF, 1, 0xFF, 1, 2, 3, -1, 0, 0x7f, 0xe0, 0xf0, 9, 10, 9, -10);
+  var c = SIMD.Int8x16.widenedUnsignedAbsoluteDifference(a, b);
+  equal(255, SIMD.Int16x8.extractLane(c, 0));
+  equal(255, SIMD.Int16x8.extractLane(c, 1));
+  equal(254, SIMD.Int16x8.extractLane(c, 2));
+  equal(254, SIMD.Int16x8.extractLane(c, 3));
+  equal(1, SIMD.Int16x8.extractLane(c, 4));
+  equal(1, SIMD.Int16x8.extractLane(c, 5));
+  equal(252, SIMD.Int16x8.extractLane(c, 6));
+  equal(252, SIMD.Int16x8.extractLane(c, 7));
+});
+
+test('Int8x16 unsignedHorizontalSum', function() {
+  var a = SIMD.Int8x16.splat(0);
+  var b = SIMD.Int8x16.unsignedHorizontalSum(a);
+  equal(0, b);
+
+  var a = SIMD.Int8x16.splat(-1);
+  var b = SIMD.Int8x16.unsignedHorizontalSum(a);
+  equal(4080, b);
+
+  a = SIMD.Int8x16(0xFF, 0, 0xFF, 1, 2, 1, -1, 3, 0x7f, 0, 0xf0, 0xe0, 10, 9, -10, 9);
+  b = SIMD.Int8x16.unsignedHorizontalSum(a);
+  equal(1637, b);
 });
 
 test('Int8x16 comparisons', function() {

--- a/src/ecmascript_simd_tests.js
+++ b/src/ecmascript_simd_tests.js
@@ -4399,6 +4399,27 @@ test('Int16x8 neg', function() {
   equal(0, SIMD.Int16x8.extractLane(n, 7));
 });
 
+test('Int16x8 scalar getters', function () {
+  var a = SIMD.Int16x8(0, 1, -1, -2, 65535, 255, 65536, -500);
+  equal(0, SIMD.Int16x8.extractLane(a, 0));
+  equal(1, SIMD.Int16x8.extractLane(a, 1));
+  equal(-1, SIMD.Int16x8.extractLane(a, 2));
+  equal(-2, SIMD.Int16x8.extractLane(a, 3));
+  equal(-1, SIMD.Int16x8.extractLane(a, 4));
+  equal(255, SIMD.Int16x8.extractLane(a, 5));
+  equal(0, SIMD.Int16x8.extractLane(a, 6));
+  equal(-500, SIMD.Int16x8.extractLane(a, 7));
+
+  equal(0, SIMD.Int16x8.unsignedExtractLane(a, 0));
+  equal(1, SIMD.Int16x8.unsignedExtractLane(a, 1));
+  equal(65535, SIMD.Int16x8.unsignedExtractLane(a, 2));
+  equal(65534, SIMD.Int16x8.unsignedExtractLane(a, 3));
+  equal(65535, SIMD.Int16x8.unsignedExtractLane(a, 4));
+  equal(255, SIMD.Int16x8.unsignedExtractLane(a, 5));
+  equal(0, SIMD.Int16x8.unsignedExtractLane(a, 6));
+  equal(65036, SIMD.Int16x8.unsignedExtractLane(a, 7));
+});
+
 test('Int16x8 add', function() {
   var a = SIMD.Int16x8(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x7fff, 0xffff, 0x0, 0x0);
   var b = SIMD.Int16x8(0x0, 0x1, 0xFFFF, 0xFFFF, 0x0, 0x1, 0xFFFF, 0xFFFF);
@@ -4465,6 +4486,19 @@ test('Int16x8 addSaturate', function() {
   equal(9, SIMD.Int16x8.extractLane(e, 7));
 });
 
+test('Int16x8 unsignedAddSaturate', function() {
+  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
+  var b = SIMD.Int16x8.splat(1);
+  var d = SIMD.Int16x8.unsignedAddSaturate(a, b);
+  equal(1, SIMD.Int16x8.unsignedExtractLane(d, 0));
+  equal(2, SIMD.Int16x8.unsignedExtractLane(d, 1));
+  equal(0x8000, SIMD.Int16x8.unsignedExtractLane(d, 2));
+  equal(0x8001, SIMD.Int16x8.unsignedExtractLane(d, 3));
+  equal(0xffff, SIMD.Int16x8.unsignedExtractLane(d, 4));
+  equal(0x7fff, SIMD.Int16x8.unsignedExtractLane(d, 5));
+  equal(0x8002, SIMD.Int16x8.unsignedExtractLane(d, 6));
+});
+
 test('Int16x8 subSaturate', function() {
   var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
   var b = SIMD.Int16x8.splat(1);
@@ -4489,6 +4523,20 @@ test('Int16x8 subSaturate', function() {
   equal(11, SIMD.Int16x8.extractLane(e, 7));
 });
 
+test('Int16x8 unsignedSubSaturate', function() {
+  var a = SIMD.Int16x8(0, 1, 0x7fff, 0x8000, -1, 0x7ffe, 0x8001, 10);
+  var b = SIMD.Int16x8.splat(1);
+  var d = SIMD.Int16x8.unsignedSubSaturate(a, b);
+  equal(0, SIMD.Int16x8.unsignedExtractLane(d, 0));
+  equal(0, SIMD.Int16x8.unsignedExtractLane(d, 1));
+  equal(0x7ffe, SIMD.Int16x8.unsignedExtractLane(d, 2));
+  equal(0x7fff, SIMD.Int16x8.unsignedExtractLane(d, 3));
+  equal(0xfffe, SIMD.Int16x8.unsignedExtractLane(d, 4));
+  equal(0x7ffd, SIMD.Int16x8.unsignedExtractLane(d, 5));
+  equal(0x8000, SIMD.Int16x8.unsignedExtractLane(d, 6));
+  equal(9, SIMD.Int16x8.unsignedExtractLane(d, 7));
+});
+
 test('Int16x8 comparisons', function() {
   var m = SIMD.Int16x8(1000, 2000, 100, 1, -1000, -2000, -100, 1);
   var n = SIMD.Int16x8(-2000, 2000, 1, 100, 2000, -2000, -1, -100);
@@ -4503,6 +4551,16 @@ test('Int16x8 comparisons', function() {
   equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
   equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
 
+  cmp = SIMD.Int16x8.unsignedLessThan(m, n);
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
+
   cmp = SIMD.Int16x8.lessThanOrEqual(m, n);
   equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
   equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
@@ -4512,6 +4570,16 @@ test('Int16x8 comparisons', function() {
   equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
   equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
   equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
+
+  cmp = SIMD.Int16x8.unsignedLessThanOrEqual(m, n);
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 2));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 3));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 4));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 6));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
 
   cmp = SIMD.Int16x8.equal(m, n);
   equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
@@ -4543,6 +4611,16 @@ test('Int16x8 comparisons', function() {
   equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
   equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
 
+  cmp = SIMD.Int16x8.unsignedGreaterThan(m, n);
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 1));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 5));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
+
   cmp = SIMD.Int16x8.greaterThanOrEqual(m, n);
   equal(true, SIMD.Bool16x8.extractLane(cmp, 0));
   equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
@@ -4552,6 +4630,16 @@ test('Int16x8 comparisons', function() {
   equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
   equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
   equal(true, SIMD.Bool16x8.extractLane(cmp, 7));
+
+  cmp = SIMD.Int16x8.unsignedGreaterThanOrEqual(m, n);
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 0));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 1));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 2));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 3));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 4));
+  equal(true, SIMD.Bool16x8.extractLane(cmp, 5));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 6));
+  equal(false, SIMD.Bool16x8.extractLane(cmp, 7));
 });
 
 test('Int16x8 shiftLeftByScalar', function() {
@@ -5054,6 +5142,44 @@ test('Int8x16 neg', function() {
   equal(0, SIMD.Int8x16.extractLane(n, 15));
 });
 
+test('Int8x16 scalar getters', function () {
+  var a = SIMD.Int8x16(0, 1, -1, -2, 65535, 255, 65536, -500,
+                       2, -3, 4, -5, 6, -7, 8, -9);
+  equal(0, SIMD.Int8x16.extractLane(a, 0));
+  equal(1, SIMD.Int8x16.extractLane(a, 1));
+  equal(-1, SIMD.Int8x16.extractLane(a, 2));
+  equal(-2, SIMD.Int8x16.extractLane(a, 3));
+  equal(-1, SIMD.Int8x16.extractLane(a, 4));
+  equal(-1, SIMD.Int8x16.extractLane(a, 5));
+  equal(0, SIMD.Int8x16.extractLane(a, 6));
+  equal(12, SIMD.Int8x16.extractLane(a, 7));
+  equal(2, SIMD.Int8x16.extractLane(a, 8));
+  equal(-3, SIMD.Int8x16.extractLane(a, 9));
+  equal(4, SIMD.Int8x16.extractLane(a, 10));
+  equal(-5, SIMD.Int8x16.extractLane(a, 11));
+  equal(6, SIMD.Int8x16.extractLane(a, 12));
+  equal(-7, SIMD.Int8x16.extractLane(a, 13));
+  equal(8, SIMD.Int8x16.extractLane(a, 14));
+  equal(-9, SIMD.Int8x16.extractLane(a, 15));
+
+  equal(0, SIMD.Int8x16.unsignedExtractLane(a, 0));
+  equal(1, SIMD.Int8x16.unsignedExtractLane(a, 1));
+  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 2));
+  equal(254, SIMD.Int8x16.unsignedExtractLane(a, 3));
+  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 4));
+  equal(255, SIMD.Int8x16.unsignedExtractLane(a, 5));
+  equal(0, SIMD.Int8x16.unsignedExtractLane(a, 6));
+  equal(12, SIMD.Int8x16.unsignedExtractLane(a, 7));
+  equal(2, SIMD.Int8x16.unsignedExtractLane(a, 8));
+  equal(253, SIMD.Int8x16.unsignedExtractLane(a, 9));
+  equal(4, SIMD.Int8x16.unsignedExtractLane(a, 10));
+  equal(251, SIMD.Int8x16.unsignedExtractLane(a, 11));
+  equal(6, SIMD.Int8x16.unsignedExtractLane(a, 12));
+  equal(249, SIMD.Int8x16.unsignedExtractLane(a, 13));
+  equal(8, SIMD.Int8x16.unsignedExtractLane(a, 14));
+  equal(247, SIMD.Int8x16.unsignedExtractLane(a, 15));
+});
+
 test('Int8x16 add', function () {
   var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
   var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
@@ -5160,6 +5286,28 @@ test('Int8x16 addSaturate', function() {
   equal(17, SIMD.Int8x16.extractLane(e, 15));
 });
 
+test('Int8x16 unsignedAddSaturate', function() {
+  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
+  var b = SIMD.Int8x16.splat(1);
+  var d = SIMD.Int8x16.unsignedAddSaturate(a, b);
+  equal(1, SIMD.Int8x16.unsignedExtractLane(d, 0));
+  equal(2, SIMD.Int8x16.unsignedExtractLane(d, 1));
+  equal(0x80, SIMD.Int8x16.unsignedExtractLane(d, 2));
+  equal(0x81, SIMD.Int8x16.unsignedExtractLane(d, 3));
+  equal(0xff, SIMD.Int8x16.unsignedExtractLane(d, 4));
+  equal(0x7f, SIMD.Int8x16.unsignedExtractLane(d, 5));
+  equal(0x82, SIMD.Int8x16.unsignedExtractLane(d, 6));
+  equal(11, SIMD.Int8x16.unsignedExtractLane(d, 7));
+  equal(12, SIMD.Int8x16.unsignedExtractLane(d, 8));
+  equal(13, SIMD.Int8x16.unsignedExtractLane(d, 9));
+  equal(14, SIMD.Int8x16.unsignedExtractLane(d, 10));
+  equal(15, SIMD.Int8x16.unsignedExtractLane(d, 11));
+  equal(16, SIMD.Int8x16.unsignedExtractLane(d, 12));
+  equal(17, SIMD.Int8x16.unsignedExtractLane(d, 13));
+  equal(18, SIMD.Int8x16.unsignedExtractLane(d, 14));
+  equal(19, SIMD.Int8x16.unsignedExtractLane(d, 15));
+});
+
 test('Int8x16 subSaturate', function() {
   var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
   var b = SIMD.Int8x16.splat(1);
@@ -5200,6 +5348,28 @@ test('Int8x16 subSaturate', function() {
   equal(19, SIMD.Int8x16.extractLane(e, 15));
 });
 
+test('Int8x16 unsignedSubSaturate', function() {
+  var a = SIMD.Int8x16(0, 1, 0x7f, 0x80, -1, 0x7e, 0x81, 10, 11, 12, 13, 14, 15, 16, 17, 18);
+  var b = SIMD.Int8x16.splat(1);
+  var d = SIMD.Int8x16.unsignedSubSaturate(a, b);
+  equal(0, SIMD.Int8x16.unsignedExtractLane(d, 0));
+  equal(0, SIMD.Int8x16.unsignedExtractLane(d, 1));
+  equal(0x7e, SIMD.Int8x16.unsignedExtractLane(d, 2));
+  equal(0x7f, SIMD.Int8x16.unsignedExtractLane(d, 3));
+  equal(0xfe, SIMD.Int8x16.unsignedExtractLane(d, 4));
+  equal(0x7d, SIMD.Int8x16.unsignedExtractLane(d, 5));
+  equal(0x80, SIMD.Int8x16.unsignedExtractLane(d, 6));
+  equal(9, SIMD.Int8x16.unsignedExtractLane(d, 7));
+  equal(10, SIMD.Int8x16.unsignedExtractLane(d, 8));
+  equal(11, SIMD.Int8x16.unsignedExtractLane(d, 9));
+  equal(12, SIMD.Int8x16.unsignedExtractLane(d, 10));
+  equal(13, SIMD.Int8x16.unsignedExtractLane(d, 11));
+  equal(14, SIMD.Int8x16.unsignedExtractLane(d, 12));
+  equal(15, SIMD.Int8x16.unsignedExtractLane(d, 13));
+  equal(16, SIMD.Int8x16.unsignedExtractLane(d, 14));
+  equal(17, SIMD.Int8x16.unsignedExtractLane(d, 15));
+});
+
 test('Int8x16 sumOfAbsoluteDifferences', function() {
   var a = SIMD.Int8x16(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7f, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0);
   var b = SIMD.Int8x16(0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x1, 0xFF, 0xFF, 0xFF, 0xFF);
@@ -5229,6 +5399,24 @@ test('Int8x16 comparisons', function() {
   equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
   equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
 
+  cmp = SIMD.Int8x16.unsignedLessThan(m, n);
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
+
   cmp = SIMD.Int8x16.lessThanOrEqual(m, n);
   equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
@@ -5245,6 +5433,24 @@ test('Int8x16 comparisons', function() {
   equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
   equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
+
+  cmp = SIMD.Int8x16.unsignedLessThanOrEqual(m, n);
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 2));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 3));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 4));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 6));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 7));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 8));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 9));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 10));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 11));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 13));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
   equal(false, SIMD.Bool8x16.extractLane(cmp, 15));
 
   cmp = SIMD.Int8x16.equal(m, n);
@@ -5301,6 +5507,24 @@ test('Int8x16 comparisons', function() {
   equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
 
+  cmp = SIMD.Int8x16.unsignedGreaterThan(m, n);
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 1));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 5));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
+
   cmp = SIMD.Int8x16.greaterThanOrEqual(m, n);
   equal(false, SIMD.Bool8x16.extractLane(cmp, 0));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
@@ -5317,6 +5541,24 @@ test('Int8x16 comparisons', function() {
   equal(false, SIMD.Bool8x16.extractLane(cmp, 12));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
   equal(false, SIMD.Bool8x16.extractLane(cmp, 14));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
+
+  cmp = SIMD.Int8x16.unsignedGreaterThanOrEqual(m, n);
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 0));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 1));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 2));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 3));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 4));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 5));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 6));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 7));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 8));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 9));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 10));
+  equal(false, SIMD.Bool8x16.extractLane(cmp, 11));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 12));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 13));
+  equal(true, SIMD.Bool8x16.extractLane(cmp, 14));
   equal(true, SIMD.Bool8x16.extractLane(cmp, 15));
 });
 


### PR DESCRIPTION
This patch series:
 - fixes some capitalization inconsistency
 - adds unsigned comparisons for Int16x8 and Int8x16:
    * unsigned extract element
    * unsigned saturating add and sub
    * unsigned comparisons for Int16x8 and Int8x16
 - replaces subOfAbsoluteDifferences with three functions:
    * unsignedAbsoluteDifference (Int16x8 and Int8x16)
    * widenedUnsignedAbsoluteDifference (Int16x8 and Int8x16)
    * unsignedHorizontalSum (Int32x4, Int16x8, Int8x16)

There may still be some ironing out of these interfaces needed, but this is a good start.

SIMD.Int16x8.widenedUnsignedAbsoluteDifference on x86 might look something like this:
```
        pxor           %xmm2, %xmm2
        punpcklbw  %xmm2, %xmm0
        punpcklbw  %xmm2, %xmm1
        movdqa      %xmm0, %xmm2
        psubusw     %xmm1, %xmm0
        psubusw     %xmm2, %xmm1
        por             %xmm1, %xmm0
```
The Int8x16 version can do something similar. With SSE4.1 `pmovzxbw`, we could eliminate the `pxor`. With VEX encoding, we could eliminate the `movdqa`.
